### PR TITLE
feat/storage: seven repository modules (Tasks 3-8)

### DIFF
--- a/src/storage/beers.test.ts
+++ b/src/storage/beers.test.ts
@@ -1,0 +1,30 @@
+import { openDb } from './db';
+import { migrate } from './schema';
+import { upsertBeer, findBeerByNormalized } from './beers';
+
+function fresh() {
+  const db = openDb(':memory:');
+  migrate(db);
+  return db;
+}
+
+test('upsertBeer inserts then updates by normalized key', () => {
+  const db = fresh();
+  const id1 = upsertBeer(db, {
+    name: 'Atak Chmielu', brewery: 'Pinta', style: 'IPA',
+    abv: 6.1, rating_global: 3.9,
+    normalized_name: 'atak chmielu', normalized_brewery: 'pinta',
+  });
+  const id2 = upsertBeer(db, {
+    name: 'Atak Chmielu', brewery: 'Pinta', style: 'IPA',
+    abv: 6.2, rating_global: 3.95,
+    normalized_name: 'atak chmielu', normalized_brewery: 'pinta',
+  });
+  expect(id1).toBe(id2);
+  const row = findBeerByNormalized(db, 'pinta', 'atak chmielu');
+  expect(row?.abv).toBeCloseTo(6.2);
+});
+
+test('findBeerByNormalized returns null when absent', () => {
+  expect(findBeerByNormalized(fresh(), 'x', 'y')).toBeNull();
+});

--- a/src/storage/beers.ts
+++ b/src/storage/beers.ts
@@ -1,0 +1,46 @@
+import type { DB } from './db';
+
+export interface BeerInput {
+  untappd_id?: number | null;
+  name: string;
+  brewery: string;
+  style?: string | null;
+  abv?: number | null;
+  rating_global?: number | null;
+  normalized_name: string;
+  normalized_brewery: string;
+}
+
+export interface BeerRow extends BeerInput { id: number; }
+
+export function upsertBeer(db: DB, b: BeerInput): number {
+  const existing = db
+    .prepare('SELECT id FROM beers WHERE normalized_brewery = ? AND normalized_name = ?')
+    .get(b.normalized_brewery, b.normalized_name) as { id: number } | undefined;
+
+  if (existing) {
+    db.prepare(
+      `UPDATE beers SET untappd_id = COALESCE(?, untappd_id), name = ?, brewery = ?,
+         style = ?, abv = ?, rating_global = ? WHERE id = ?`,
+    ).run(b.untappd_id ?? null, b.name, b.brewery, b.style ?? null,
+          b.abv ?? null, b.rating_global ?? null, existing.id);
+    return existing.id;
+  }
+
+  const res = db.prepare(
+    `INSERT INTO beers (untappd_id, name, brewery, style, abv, rating_global,
+       normalized_name, normalized_brewery)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(b.untappd_id ?? null, b.name, b.brewery, b.style ?? null, b.abv ?? null,
+        b.rating_global ?? null, b.normalized_name, b.normalized_brewery);
+  return Number(res.lastInsertRowid);
+}
+
+export function findBeerByNormalized(
+  db: DB, normBrewery: string, normName: string,
+): BeerRow | null {
+  const row = db
+    .prepare('SELECT * FROM beers WHERE normalized_brewery = ? AND normalized_name = ?')
+    .get(normBrewery, normName) as BeerRow | undefined;
+  return row ?? null;
+}

--- a/src/storage/checkins.test.ts
+++ b/src/storage/checkins.test.ts
@@ -1,0 +1,32 @@
+import { openDb } from './db';
+import { migrate } from './schema';
+import { mergeCheckin, checkinsForUser, hasBeenDrunk } from './checkins';
+import { upsertBeer } from './beers';
+
+function setup() {
+  const db = openDb(':memory:'); migrate(db);
+  const beerId = upsertBeer(db, {
+    name: 'Atak', brewery: 'Pinta', style: 'IPA', abv: 6, rating_global: 3.9,
+    normalized_name: 'atak', normalized_brewery: 'pinta',
+  });
+  return { db, beerId };
+}
+
+test('mergeCheckin is idempotent on (telegram_id, checkin_id)', () => {
+  const { db, beerId } = setup();
+  mergeCheckin(db, { checkin_id: 'c1', telegram_id: 10, beer_id: beerId,
+    user_rating: 4.0, checkin_at: '2026-04-22T10:00:00Z', venue: 'Home' });
+  mergeCheckin(db, { checkin_id: 'c1', telegram_id: 10, beer_id: beerId,
+    user_rating: 4.5, checkin_at: '2026-04-22T10:00:00Z', venue: 'Home' });
+  const all = checkinsForUser(db, 10);
+  expect(all).toHaveLength(1);
+  expect(all[0].user_rating).toBe(4.5);
+});
+
+test('hasBeenDrunk ignores other users', () => {
+  const { db, beerId } = setup();
+  mergeCheckin(db, { checkin_id: 'c', telegram_id: 10, beer_id: beerId,
+    user_rating: null, checkin_at: '2026-04-22T10:00:00Z', venue: null });
+  expect(hasBeenDrunk(db, 10, beerId)).toBe(true);
+  expect(hasBeenDrunk(db, 11, beerId)).toBe(false);
+});

--- a/src/storage/checkins.ts
+++ b/src/storage/checkins.ts
@@ -1,0 +1,43 @@
+import type { DB } from './db';
+
+export interface CheckinInput {
+  checkin_id: string;
+  telegram_id: number;
+  beer_id: number | null;
+  user_rating: number | null;
+  checkin_at: string;
+  venue: string | null;
+}
+
+export interface CheckinRow extends CheckinInput { id: number; }
+
+export function mergeCheckin(db: DB, c: CheckinInput): void {
+  db.prepare(
+    `INSERT INTO checkins (checkin_id, telegram_id, beer_id, user_rating, checkin_at, venue)
+       VALUES (?, ?, ?, ?, ?, ?)
+     ON CONFLICT(telegram_id, checkin_id) DO UPDATE SET
+       beer_id = excluded.beer_id,
+       user_rating = excluded.user_rating,
+       checkin_at = excluded.checkin_at,
+       venue = excluded.venue`,
+  ).run(c.checkin_id, c.telegram_id, c.beer_id, c.user_rating, c.checkin_at, c.venue);
+}
+
+export function checkinsForUser(db: DB, telegramId: number): CheckinRow[] {
+  return db.prepare('SELECT * FROM checkins WHERE telegram_id = ? ORDER BY checkin_at DESC')
+    .all(telegramId) as CheckinRow[];
+}
+
+export function hasBeenDrunk(db: DB, telegramId: number, beerId: number): boolean {
+  const row = db.prepare(
+    'SELECT 1 FROM checkins WHERE telegram_id = ? AND beer_id = ? LIMIT 1',
+  ).get(telegramId, beerId);
+  return !!row;
+}
+
+export function drunkBeerIds(db: DB, telegramId: number): Set<number> {
+  const rows = db.prepare(
+    'SELECT DISTINCT beer_id FROM checkins WHERE telegram_id = ? AND beer_id IS NOT NULL',
+  ).all(telegramId) as { beer_id: number }[];
+  return new Set(rows.map((r) => r.beer_id));
+}

--- a/src/storage/match_links.test.ts
+++ b/src/storage/match_links.test.ts
@@ -1,0 +1,28 @@
+import { openDb } from './db';
+import { migrate } from './schema';
+import { upsertBeer } from './beers';
+import { upsertMatch, getMatch, listUnreviewedBelow } from './match_links';
+
+function setup() {
+  const db = openDb(':memory:'); migrate(db);
+  const id = upsertBeer(db, {
+    name: 'X', brewery: 'B', style: null, abv: null, rating_global: null,
+    normalized_name: 'x', normalized_brewery: 'b',
+  });
+  return { db, beerId: id };
+}
+
+test('upsertMatch upserts by ontap_ref', () => {
+  const { db, beerId } = setup();
+  upsertMatch(db, 'PINTA|atak', beerId, 0.9);
+  upsertMatch(db, 'PINTA|atak', beerId, 1.0);
+  const m = getMatch(db, 'PINTA|atak');
+  expect(m?.confidence).toBe(1.0);
+});
+
+test('listUnreviewedBelow returns low-confidence, not yet reviewed', () => {
+  const { db, beerId } = setup();
+  upsertMatch(db, 'a', beerId, 0.7);
+  upsertMatch(db, 'b', beerId, 0.95);
+  expect(listUnreviewedBelow(db, 0.85).map((r) => r.ontap_ref)).toEqual(['a']);
+});

--- a/src/storage/match_links.ts
+++ b/src/storage/match_links.ts
@@ -1,0 +1,35 @@
+import type { DB } from './db';
+
+export interface MatchRow {
+  id: number;
+  ontap_ref: string;
+  untappd_beer_id: number | null;
+  confidence: number;
+  reviewed_by_user: number;
+}
+
+export function upsertMatch(db: DB, ontapRef: string, beerId: number | null, confidence: number): void {
+  db.prepare(
+    `INSERT INTO match_links (ontap_ref, untappd_beer_id, confidence, reviewed_by_user)
+       VALUES (?, ?, ?, 0)
+     ON CONFLICT(ontap_ref) DO UPDATE SET
+       untappd_beer_id = excluded.untappd_beer_id,
+       confidence = excluded.confidence`,
+  ).run(ontapRef, beerId, confidence);
+}
+
+export function getMatch(db: DB, ontapRef: string): MatchRow | null {
+  return (db.prepare('SELECT * FROM match_links WHERE ontap_ref = ?').get(ontapRef) as MatchRow | undefined) ?? null;
+}
+
+export function listUnreviewedBelow(db: DB, threshold: number): MatchRow[] {
+  return db.prepare(
+    'SELECT * FROM match_links WHERE confidence < ? AND reviewed_by_user = 0 ORDER BY confidence',
+  ).all(threshold) as MatchRow[];
+}
+
+export function markReviewed(db: DB, id: number, beerId: number | null): void {
+  db.prepare(
+    'UPDATE match_links SET untappd_beer_id = ?, confidence = 1.0, reviewed_by_user = 1 WHERE id = ?',
+  ).run(beerId, id);
+}

--- a/src/storage/pubs.test.ts
+++ b/src/storage/pubs.test.ts
@@ -1,0 +1,25 @@
+import { openDb } from './db';
+import { migrate } from './schema';
+import { upsertPub, listPubs, setPubCoords } from './pubs';
+
+function fresh() {
+  const db = openDb(':memory:'); migrate(db); return db;
+}
+
+test('upsertPub inserts a new pub and updates metadata in place', () => {
+  const db = fresh();
+  const id = upsertPub(db, { slug: 'beer-bones', name: 'Beer & Bones', address: 'Żurawia 32/34', lat: 52.228, lon: 21.013 });
+  expect(id).toBeGreaterThan(0);
+  const id2 = upsertPub(db, { slug: 'beer-bones', name: 'Beer & Bones CB&M', address: 'Żurawia 32/34', lat: null, lon: null });
+  expect(id2).toBe(id);
+  const pubs = listPubs(db);
+  expect(pubs[0].name).toBe('Beer & Bones CB&M');
+  expect(pubs[0].lat).toBeCloseTo(52.228);
+});
+
+test('setPubCoords fills missing coordinates', () => {
+  const db = fresh();
+  const id = upsertPub(db, { slug: 'x', name: 'X', address: 'A', lat: null, lon: null });
+  setPubCoords(db, id, 1.0, 2.0);
+  expect(listPubs(db)[0].lat).toBe(1.0);
+});

--- a/src/storage/pubs.ts
+++ b/src/storage/pubs.ts
@@ -1,0 +1,34 @@
+import type { DB } from './db';
+
+export interface PubInput {
+  slug: string;
+  name: string;
+  address: string | null;
+  lat: number | null;
+  lon: number | null;
+}
+
+export interface PubRow extends PubInput { id: number; }
+
+export function upsertPub(db: DB, p: PubInput): number {
+  const existing = db.prepare('SELECT id FROM pubs WHERE slug = ?').get(p.slug) as { id: number } | undefined;
+  if (existing) {
+    db.prepare(
+      `UPDATE pubs SET name = ?, address = COALESCE(?, address),
+         lat = COALESCE(?, lat), lon = COALESCE(?, lon) WHERE id = ?`,
+    ).run(p.name, p.address, p.lat, p.lon, existing.id);
+    return existing.id;
+  }
+  const res = db.prepare(
+    'INSERT INTO pubs (slug, name, address, lat, lon) VALUES (?, ?, ?, ?, ?)',
+  ).run(p.slug, p.name, p.address, p.lat, p.lon);
+  return Number(res.lastInsertRowid);
+}
+
+export function listPubs(db: DB): PubRow[] {
+  return db.prepare('SELECT * FROM pubs ORDER BY id').all() as PubRow[];
+}
+
+export function setPubCoords(db: DB, pubId: number, lat: number, lon: number): void {
+  db.prepare('UPDATE pubs SET lat = ?, lon = ? WHERE id = ?').run(lat, lon, pubId);
+}

--- a/src/storage/snapshots.test.ts
+++ b/src/storage/snapshots.test.ts
@@ -1,0 +1,29 @@
+import { openDb } from './db';
+import { migrate } from './schema';
+import { upsertPub } from './pubs';
+import { createSnapshot, latestSnapshot, insertTaps, tapsForSnapshot } from './snapshots';
+
+function setup() {
+  const db = openDb(':memory:'); migrate(db);
+  const pubId = upsertPub(db, { slug: 'p', name: 'P', address: null, lat: null, lon: null });
+  return { db, pubId };
+}
+
+test('createSnapshot + insertTaps roundtrip', () => {
+  const { db, pubId } = setup();
+  const snapId = createSnapshot(db, pubId, '2026-04-22T12:00:00Z');
+  insertTaps(db, snapId, [
+    { tap_number: 1, beer_ref: 'PINTA Atak Chmielu', brewery_ref: 'PINTA', abv: 6.1, ibu: 55, style: 'AIPA', u_rating: 3.9 },
+    { tap_number: 2, beer_ref: 'Stu Mostów Buty', brewery_ref: 'Stu Mostów', abv: 5.0, ibu: null, style: 'Pils', u_rating: 3.7 },
+  ]);
+  const rows = tapsForSnapshot(db, snapId);
+  expect(rows).toHaveLength(2);
+  expect(rows[0].beer_ref).toBe('PINTA Atak Chmielu');
+});
+
+test('latestSnapshot returns most recent per pub', () => {
+  const { db, pubId } = setup();
+  createSnapshot(db, pubId, '2026-04-22T10:00:00Z');
+  const s2 = createSnapshot(db, pubId, '2026-04-22T20:00:00Z');
+  expect(latestSnapshot(db, pubId)?.id).toBe(s2);
+});

--- a/src/storage/snapshots.ts
+++ b/src/storage/snapshots.ts
@@ -1,0 +1,54 @@
+import type { DB } from './db';
+
+export interface TapInput {
+  tap_number: number | null;
+  beer_ref: string;
+  brewery_ref: string | null;
+  abv: number | null;
+  ibu: number | null;
+  style: string | null;
+  u_rating: number | null;
+}
+
+export interface TapRow extends TapInput { id: number; snapshot_id: number; }
+export interface SnapshotRow { id: number; pub_id: number; snapshot_at: string; }
+
+export function createSnapshot(db: DB, pubId: number, at: string): number {
+  const res = db.prepare(
+    'INSERT INTO tap_snapshots (pub_id, snapshot_at) VALUES (?, ?)',
+  ).run(pubId, at);
+  return Number(res.lastInsertRowid);
+}
+
+export function insertTaps(db: DB, snapshotId: number, taps: TapInput[]): void {
+  const stmt = db.prepare(
+    `INSERT INTO taps (snapshot_id, tap_number, beer_ref, brewery_ref, abv, ibu, style, u_rating)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  );
+  const tx = db.transaction((items: TapInput[]) => {
+    for (const t of items) {
+      stmt.run(snapshotId, t.tap_number, t.beer_ref, t.brewery_ref,
+               t.abv, t.ibu, t.style, t.u_rating);
+    }
+  });
+  tx(taps);
+}
+
+export function tapsForSnapshot(db: DB, snapshotId: number): TapRow[] {
+  return db.prepare('SELECT * FROM taps WHERE snapshot_id = ? ORDER BY tap_number').all(snapshotId) as TapRow[];
+}
+
+export function latestSnapshot(db: DB, pubId: number): SnapshotRow | null {
+  return (db.prepare(
+    'SELECT * FROM tap_snapshots WHERE pub_id = ? ORDER BY snapshot_at DESC LIMIT 1',
+  ).get(pubId) as SnapshotRow | undefined) ?? null;
+}
+
+export function latestSnapshotsPerPub(db: DB): SnapshotRow[] {
+  return db.prepare(
+    `SELECT s.* FROM tap_snapshots s
+     INNER JOIN (
+       SELECT pub_id, MAX(snapshot_at) AS m FROM tap_snapshots GROUP BY pub_id
+     ) x ON x.pub_id = s.pub_id AND x.m = s.snapshot_at`,
+  ).all() as SnapshotRow[];
+}

--- a/src/storage/user.test.ts
+++ b/src/storage/user.test.ts
@@ -1,0 +1,23 @@
+import { openDb } from './db';
+import { migrate } from './schema';
+import { ensureProfile, setUntappdUsername, getProfile } from './user_profiles';
+import { getFilters, setFilters } from './user_filters';
+
+function fresh() { const db = openDb(':memory:'); migrate(db); return db; }
+
+test('ensureProfile is idempotent and setUntappdUsername sticks', () => {
+  const db = fresh();
+  ensureProfile(db, 42);
+  ensureProfile(db, 42);
+  setUntappdUsername(db, 42, 'yuriy');
+  expect(getProfile(db, 42)?.untappd_username).toBe('yuriy');
+});
+
+test('filters round-trip styles array', () => {
+  const db = fresh();
+  ensureProfile(db, 42);
+  setFilters(db, 42, { styles: ['IPA', 'Pils'], min_rating: 3.5, abv_min: 4, abv_max: 9, default_route_n: 7 });
+  const f = getFilters(db, 42);
+  expect(f?.styles).toEqual(['IPA', 'Pils']);
+  expect(f?.default_route_n).toBe(7);
+});

--- a/src/storage/user_filters.ts
+++ b/src/storage/user_filters.ts
@@ -1,0 +1,41 @@
+import type { DB } from './db';
+
+export interface Filters {
+  styles: string[];
+  min_rating: number | null;
+  abv_min: number | null;
+  abv_max: number | null;
+  default_route_n: number | null;
+}
+
+interface Row {
+  styles: string | null;
+  min_rating: number | null;
+  abv_min: number | null;
+  abv_max: number | null;
+  default_route_n: number | null;
+}
+
+export function getFilters(db: DB, telegramId: number): Filters | null {
+  const r = db.prepare('SELECT styles, min_rating, abv_min, abv_max, default_route_n FROM user_filters WHERE telegram_id = ?')
+    .get(telegramId) as Row | undefined;
+  if (!r) return null;
+  return {
+    styles: r.styles ? JSON.parse(r.styles) : [],
+    min_rating: r.min_rating,
+    abv_min: r.abv_min,
+    abv_max: r.abv_max,
+    default_route_n: r.default_route_n,
+  };
+}
+
+export function setFilters(db: DB, telegramId: number, f: Filters): void {
+  db.prepare(
+    `INSERT INTO user_filters (telegram_id, styles, min_rating, abv_min, abv_max, default_route_n)
+       VALUES (?, ?, ?, ?, ?, ?)
+     ON CONFLICT(telegram_id) DO UPDATE SET
+       styles = excluded.styles, min_rating = excluded.min_rating,
+       abv_min = excluded.abv_min, abv_max = excluded.abv_max,
+       default_route_n = excluded.default_route_n`,
+  ).run(telegramId, JSON.stringify(f.styles), f.min_rating, f.abv_min, f.abv_max, f.default_route_n);
+}

--- a/src/storage/user_profiles.ts
+++ b/src/storage/user_profiles.ts
@@ -1,0 +1,27 @@
+import type { DB } from './db';
+
+export interface ProfileRow {
+  telegram_id: number;
+  untappd_username: string | null;
+  created_at: string;
+}
+
+export function ensureProfile(db: DB, telegramId: number): void {
+  db.prepare(
+    'INSERT OR IGNORE INTO user_profiles (telegram_id) VALUES (?)',
+  ).run(telegramId);
+}
+
+export function setUntappdUsername(db: DB, telegramId: number, username: string): void {
+  db.prepare('UPDATE user_profiles SET untappd_username = ? WHERE telegram_id = ?')
+    .run(username, telegramId);
+}
+
+export function getProfile(db: DB, telegramId: number): ProfileRow | null {
+  return (db.prepare('SELECT * FROM user_profiles WHERE telegram_id = ?')
+    .get(telegramId) as ProfileRow | undefined) ?? null;
+}
+
+export function allProfiles(db: DB): ProfileRow[] {
+  return db.prepare('SELECT * FROM user_profiles').all() as ProfileRow[];
+}


### PR DESCRIPTION
## Summary
All repositories for the six entities declared in the schema, each a thin pure function layer over `better-sqlite3`:

- **beers** (`storage/beers.ts`) — upsert keyed on `(normalized_brewery, normalized_name)`; `untappd_id` preserved under `COALESCE` so a later lookup can fill it in.
- **pubs** (`storage/pubs.ts`) — upsert by `slug`; `address`/`lat`/`lon` guarded with `COALESCE` so a metadata-only refresh never overwrites geocoded coords.
- **tap_snapshots + taps** (`storage/snapshots.ts`) — snapshot-scoped inserts inside a single transaction; `latestSnapshot` per pub and `latestSnapshotsPerPub` for the whole catalogue.
- **checkins** (`storage/checkins.ts`) — idempotent merge on `(telegram_id, checkin_id)` via `ON CONFLICT DO UPDATE`; `hasBeenDrunk` / `drunkBeerIds` for matcher/filter queries.
- **match_links** (`storage/match_links.ts`) — upsert by `ontap_ref`; `listUnreviewedBelow(threshold)` and `markReviewed` queue up the manual-review flow.
- **user_profiles + user_filters** (`storage/user_profiles.ts`, `storage/user_filters.ts`) — `ensureProfile` is idempotent; filters serialise `styles[]` as JSON TEXT and round-trip cleanly.

Stage 2/6 of the MVP plan. Next: `feat/sources` (Tasks 9-14 — http queue, ontap parsers, untappd export/scraper, geocoder).

## Test Plan
- [x] `npm run typecheck` — clean
- [x] `npm test` — 16/16 passing (8 suites: env, schema, beers, pubs, snapshots, checkins, match_links, user)
- [ ] Verify `feat/sources` starts from a clean baseline after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)