### PR TITLE
feat/domain: normalize, matcher, filters, router (Tasks 15-18)

### DIFF
--- a/src/domain/filters.test.ts
+++ b/src/domain/filters.test.ts
@@ -1,0 +1,24 @@
+import { filterInteresting, rankByRating } from './filters';
+
+const taps = [
+  { beer_id: 1, style: 'IPA',   abv: 6.1, u_rating: 4.0 },
+  { beer_id: 2, style: 'Pils',  abv: 5.0, u_rating: 3.5 },
+  { beer_id: 3, style: 'IPA',   abv: 7.5, u_rating: 3.9 },
+  { beer_id: null, style: 'x',  abv: 4,   u_rating: 3.0 },
+];
+const drunk = new Set([1]);
+
+test('filterInteresting respects checkins + style + rating + abv', () => {
+  const out = filterInteresting(taps, drunk, {
+    styles: ['IPA'], min_rating: 3.8, abv_min: 4, abv_max: 8,
+  });
+  expect(out.map((t) => t.beer_id)).toEqual([3]);
+});
+
+test('rankByRating sorts desc and breaks ties by beer_id', () => {
+  const sorted = rankByRating([
+    { beer_id: 1, u_rating: 3.5 }, { beer_id: 2, u_rating: 4.0 },
+    { beer_id: 3, u_rating: 4.0 },
+  ]);
+  expect(sorted.map((t) => t.beer_id)).toEqual([2, 3, 1]);
+});

--- a/src/domain/filters.ts
+++ b/src/domain/filters.ts
@@ -1,0 +1,38 @@
+export interface TapView {
+  beer_id: number | null;
+  style: string | null;
+  abv: number | null;
+  u_rating: number | null;
+}
+
+export interface FilterOpts {
+  styles?: string[];
+  min_rating?: number | null;
+  abv_min?: number | null;
+  abv_max?: number | null;
+}
+
+export function filterInteresting<T extends TapView>(
+  taps: T[], drunk: Set<number>, opts: FilterOpts,
+): T[] {
+  return taps.filter((t) => {
+    if (t.beer_id == null) return false;
+    if (drunk.has(t.beer_id)) return false;
+    if (opts.min_rating != null && (t.u_rating ?? 0) < opts.min_rating) return false;
+    if (opts.abv_min != null && (t.abv ?? 0) < opts.abv_min) return false;
+    if (opts.abv_max != null && (t.abv ?? 0) > opts.abv_max) return false;
+    if (opts.styles && opts.styles.length) {
+      const s = (t.style ?? '').toLowerCase();
+      if (!opts.styles.some((x) => s.includes(x.toLowerCase()))) return false;
+    }
+    return true;
+  });
+}
+
+export function rankByRating<T extends { beer_id: number | null; u_rating: number | null }>(
+  taps: T[],
+): T[] {
+  return [...taps].sort(
+    (a, b) => (b.u_rating ?? 0) - (a.u_rating ?? 0) || (a.beer_id ?? 0) - (b.beer_id ?? 0),
+  );
+}

--- a/src/domain/matcher.test.ts
+++ b/src/domain/matcher.test.ts
@@ -1,0 +1,23 @@
+import { matchBeer } from './matcher';
+
+const catalog = [
+  { id: 1, brewery: 'Pinta', name: 'Atak Chmielu' },
+  { id: 2, brewery: 'Stu Mostów', name: 'Buty Skejta' },
+  { id: 3, brewery: 'Piwne Podziemie', name: 'Hopinka' },
+];
+
+test('exact normalized match is confidence 1', () => {
+  const m = matchBeer({ brewery: 'PINTA', name: 'Atak Chmielu IPA' }, catalog);
+  expect(m).toEqual({ id: 1, confidence: 1, source: 'exact' });
+});
+
+test('fuzzy match above threshold returns 0.85..1 confidence', () => {
+  const m = matchBeer({ brewery: 'Stu Mostow', name: 'Buty Skejty' }, catalog);
+  expect(m?.id).toBe(2);
+  expect(m!.confidence).toBeGreaterThanOrEqual(0.85);
+  expect(m!.confidence).toBeLessThan(1);
+});
+
+test('no match below threshold returns null', () => {
+  expect(matchBeer({ brewery: 'Random', name: 'Xyz' }, catalog)).toBeNull();
+});

--- a/src/domain/matcher.ts
+++ b/src/domain/matcher.ts
@@ -1,0 +1,32 @@
+import { Searcher } from 'fast-fuzzy';
+import { normalizeName, normalizeBrewery } from './normalize';
+
+export interface CatalogBeer { id: number; brewery: string; name: string; }
+export interface MatchResult { id: number; confidence: number; source: 'exact' | 'fuzzy'; }
+
+const FUZZY_THRESHOLD = 0.85;
+
+export function matchBeer(
+  input: { brewery: string; name: string },
+  catalog: CatalogBeer[],
+): MatchResult | null {
+  const nb = normalizeBrewery(input.brewery);
+  const nn = normalizeName(input.name);
+
+  const exact = catalog.find(
+    (c) => normalizeBrewery(c.brewery) === nb && normalizeName(c.name) === nn,
+  );
+  if (exact) return { id: exact.id, confidence: 1, source: 'exact' };
+
+  const pool = catalog.filter((c) => normalizeBrewery(c.brewery) === nb);
+  const candidates = pool.length ? pool : catalog;
+  const searcher = new Searcher(candidates, {
+    keySelector: (c) => `${normalizeBrewery(c.brewery)} ${normalizeName(c.name)}`,
+    threshold: FUZZY_THRESHOLD,
+    returnMatchData: true,
+  });
+  const results = searcher.search(`${nb} ${nn}`);
+  if (!results.length) return null;
+  const best = results[0];
+  return { id: best.item.id, confidence: best.score, source: 'fuzzy' };
+}

--- a/src/domain/normalize.test.ts
+++ b/src/domain/normalize.test.ts
@@ -1,0 +1,15 @@
+import { normalizeName, normalizeBrewery } from './normalize';
+
+test('lowercases and strips diacritics', () => {
+  expect(normalizeName('Atak Chmielu — Imperial')).toBe('atak chmielu');
+  expect(normalizeName('Łyso Pysk')).toBe('lyso pysk');
+});
+
+test('removes common style noise', () => {
+  expect(normalizeName('Piwo IPA (session)')).toBe('piwo');
+  expect(normalizeName('Double Dry Hopped NEIPA Hopinka')).toBe('hopinka');
+});
+
+test('normalizes brewery the same way, no style stripping', () => {
+  expect(normalizeBrewery('Browar Stu Mostów')).toBe('stu mostow');
+});

--- a/src/domain/normalize.ts
+++ b/src/domain/normalize.ts
@@ -1,0 +1,30 @@
+const STYLE_WORDS = new Set([
+  'ipa', 'apa', 'neipa', 'dipa', 'tipa', 'aipa', 'neneipa',
+  'imperial', 'double', 'triple', 'session', 'dry', 'hopped', 'dh', 'ddh',
+  'pils', 'pilsner', 'lager', 'stout', 'porter', 'weizen', 'wheat',
+  'saison', 'sour', 'gose', 'lambic', 'barleywine', 'bock',
+]);
+const BREWERY_NOISE = new Set(['browar', 'brewery', 'brewing', 'co', 'company']);
+
+function stripDiacritics(s: string): string {
+  return s.normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/ł/g, 'l').replace(/Ł/g, 'L');
+}
+
+function baseNormalize(s: string): string {
+  return stripDiacritics(s).toLowerCase()
+    .replace(/[^\p{L}\p{N}\s]/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function normalizeName(s: string): string {
+  const tokens = baseNormalize(s).split(' ').filter((t) => t && !STYLE_WORDS.has(t));
+  return tokens.join(' ');
+}
+
+export function normalizeBrewery(s: string): string {
+  const tokens = baseNormalize(s).split(' ').filter((t) => t && !BREWERY_NOISE.has(t));
+  return tokens.join(' ');
+}

--- a/src/domain/router.test.ts
+++ b/src/domain/router.test.ts
@@ -1,0 +1,19 @@
+import { buildRoute, haversineMeters } from './router';
+
+const pubs = [
+  { id: 1, lat: 0, lon: 0,    interesting: new Set([10, 11]) },
+  { id: 2, lat: 0, lon: 0.01, interesting: new Set([12]) },
+  { id: 3, lat: 0, lon: 0.02, interesting: new Set([13, 14]) },
+  { id: 4, lat: 1, lon: 1,    interesting: new Set([10, 11, 12, 13, 14]) },
+];
+
+test('prefers single far pub when it covers everything with smaller tour', () => {
+  const r = buildRoute(pubs, 5, { distance: haversineMeters });
+  expect(r.pubIds).toEqual([4]);
+  expect(r.coveredCount).toBeGreaterThanOrEqual(5);
+});
+
+test('handles partial coverage when N > union', () => {
+  const r = buildRoute(pubs.slice(0, 3), 10, { distance: haversineMeters });
+  expect(r.coveredCount).toBe(5);
+});

--- a/src/domain/router.ts
+++ b/src/domain/router.ts
@@ -1,0 +1,121 @@
+export interface RoutePub {
+  id: number;
+  lat: number;
+  lon: number;
+  interesting: Set<number>;
+}
+
+export interface RouteResult {
+  pubIds: number[];
+  coveredCount: number;
+  distanceMeters: number;
+}
+
+export interface RouteOpts {
+  distance: (a: [number, number], b: [number, number]) => number;
+}
+
+export function haversineMeters(a: [number, number], b: [number, number]): number {
+  const R = 6371000;
+  const toRad = (x: number) => (x * Math.PI) / 180;
+  const dLat = toRad(b[0] - a[0]);
+  const dLon = toRad(b[1] - a[1]);
+  const la1 = toRad(a[0]); const la2 = toRad(b[0]);
+  const h = Math.sin(dLat / 2) ** 2 + Math.cos(la1) * Math.cos(la2) * Math.sin(dLon / 2) ** 2;
+  return 2 * R * Math.asin(Math.sqrt(h));
+}
+
+export function buildRoute(pubs: RoutePub[], N: number, opts: RouteOpts): RouteResult {
+  const selected = greedySetCover(pubs, N);
+  const improved = localSwapForDistance(selected, pubs, N, opts);
+  const tour = openTsp(improved, opts);
+  return {
+    pubIds: tour.order.map((p) => p.id),
+    coveredCount: union(improved).size,
+    distanceMeters: tour.distance,
+  };
+}
+
+function union(pubs: RoutePub[]): Set<number> {
+  const s = new Set<number>();
+  for (const p of pubs) for (const x of p.interesting) s.add(x);
+  return s;
+}
+
+function greedySetCover(pubs: RoutePub[], N: number): RoutePub[] {
+  const picked: RoutePub[] = []; const covered = new Set<number>(); const remaining = [...pubs];
+  while (covered.size < N && remaining.length) {
+    let bestIdx = -1; let bestGain = -1;
+    for (let i = 0; i < remaining.length; i++) {
+      let gain = 0;
+      for (const x of remaining[i].interesting) if (!covered.has(x)) gain++;
+      if (gain > bestGain) { bestGain = gain; bestIdx = i; }
+    }
+    if (bestGain <= 0) break;
+    const chosen = remaining[bestIdx];
+    picked.push(chosen);
+    for (const x of chosen.interesting) covered.add(x);
+    remaining.splice(bestIdx, 1);
+  }
+  return picked;
+}
+
+function localSwapForDistance(
+  selected: RoutePub[], all: RoutePub[], N: number, opts: RouteOpts,
+): RoutePub[] {
+  let best = selected; let bestDist = openTsp(best, opts).distance;
+  let improved = true;
+  while (improved) {
+    improved = false;
+    for (let i = 0; i < best.length; i++) {
+      for (const cand of all) {
+        if (best.some((p) => p.id === cand.id)) continue;
+        const trial = [...best]; trial[i] = cand;
+        if (union(trial).size < N) continue;
+        const d = openTsp(trial, opts).distance;
+        if (d < bestDist) { best = trial; bestDist = d; improved = true; }
+      }
+    }
+  }
+  return best;
+}
+
+function openTsp(pubs: RoutePub[], opts: RouteOpts): { order: RoutePub[]; distance: number } {
+  if (pubs.length <= 1) return { order: pubs, distance: 0 };
+  const n = pubs.length;
+  const dist: number[][] = Array.from({ length: n }, () => Array(n).fill(0));
+  for (let i = 0; i < n; i++) for (let j = 0; j < n; j++) {
+    if (i !== j) dist[i][j] = opts.distance([pubs[i].lat, pubs[i].lon], [pubs[j].lat, pubs[j].lon]);
+  }
+  const SIZE = 1 << n;
+  const dp: number[][] = Array.from({ length: SIZE }, () => Array(n).fill(Infinity));
+  const parent: number[][] = Array.from({ length: SIZE }, () => Array(n).fill(-1));
+  for (let i = 0; i < n; i++) dp[1 << i][i] = 0;
+  for (let mask = 0; mask < SIZE; mask++) {
+    for (let u = 0; u < n; u++) {
+      if (!(mask & (1 << u)) || dp[mask][u] === Infinity) continue;
+      for (let v = 0; v < n; v++) {
+        if (mask & (1 << v)) continue;
+        const nm = mask | (1 << v);
+        const nd = dp[mask][u] + dist[u][v];
+        if (nd < dp[nm][v]) { dp[nm][v] = nd; parent[nm][v] = u; }
+      }
+    }
+  }
+  const full = SIZE - 1;
+  let best = Infinity; let bestEnd = 0;
+  for (let i = 0; i < n; i++) if (dp[full][i] < best) { best = dp[full][i]; bestEnd = i; }
+  const order: number[] = []; let cur = bestEnd; let mask = full;
+  while (cur !== -1) { order.unshift(cur); const p = parent[mask][cur]; mask ^= 1 << cur; cur = p; }
+  return { order: order.map((i) => pubs[i]), distance: best };
+}
+
+export function createOsrmDistance(base: string, fetchImpl: typeof fetch = fetch) {
+  return async (a: [number, number], b: [number, number]): Promise<number> => {
+    const url = `${base}/route/v1/foot/${a[1]},${a[0]};${b[1]},${b[0]}?overview=false`;
+    const res = await fetchImpl(url);
+    if (!res.ok) throw new Error(`OSRM HTTP ${res.status}`);
+    const body = (await res.json()) as { routes?: { distance: number }[] };
+    return body.routes?.[0]?.distance ?? haversineMeters(a, b);
+  };
+}


### PR DESCRIPTION
## Summary
Stage 4/6 — pure business logic, no I/O. Every function is deterministic and depends only on its arguments.

- **normalize** (`domain/normalize.ts`) — `normalizeName` and `normalizeBrewery`. Strips diacritics (NFD + combining-mark removal, plus manual Ł/ł → L/l), lowercases, drops non-letter/number chars, filters style words (ipa, neipa, stout…) for beer names and brewery noise (browar, brewery, co…) for brewery names.
- **matcher** (`domain/matcher.ts`) — `matchBeer({brewery, name}, catalog)` returns `{id, confidence, source}` or null. Exact normalized match → confidence 1. Otherwise `fast-fuzzy` Searcher over same-brewery candidates (falls back to full catalog if the brewery doesn't normalize to any), threshold 0.85.
- **filters** (`domain/filters.ts`) — `filterInteresting(taps, drunkSet, opts)` drops anything the user has drunk or that fails style/ABV/rating predicates. `rankByRating` sorts desc with deterministic tie-break on beer_id.
- **router** (`domain/router.ts`) — `buildRoute(pubs, N, opts)`:
  1. greedy set-cover until coverage ≥ N (or union exhausted);
  2. local-swap pass that replaces one selected pub with any alternative that keeps coverage ≥ N but shortens the tour;
  3. open-TSP via O(|S|² · 2^|S|) bitmask DP.

  Ships `haversineMeters` synchronous distance and `createOsrmDistance(base)` async helper (the caller materialises a distance matrix and passes a closure to `buildRoute`, keeping the core algorithm sync).

Next stage: `feat/bot` (Tasks 19-23 — Telegraf bootstrap + commands).

## Test Plan
- [x] `npm run typecheck` — clean
- [x] `npm test` — 38/38 passing across 18 suites (four new suites: normalize, matcher, filters, router)
- [ ] After merge, verify `feat/bot` starts from a clean baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)