### PR TITLE
docs(domain): explain and test Polish diacritic handling

### DIFF
--- a/src/domain/normalize.test.ts
+++ b/src/domain/normalize.test.ts
@@ -13,3 +13,12 @@ test('removes common style noise', () => {
 test('normalizes brewery the same way, no style stripping', () => {
   expect(normalizeBrewery('Browar Stu Mostów')).toBe('stu mostow');
 });
+
+test('strips every Polish diacritic', () => {
+  expect(normalizeBrewery('ąćęłńóśźż')).toBe('acelnoszz');
+  expect(normalizeBrewery('ĄĆĘŁŃÓŚŹŻ')).toBe('acelnoszz');
+  expect(normalizeBrewery('Żywiec')).toBe('zywiec');
+  expect(normalizeBrewery('Średnica')).toBe('srednica');
+  expect(normalizeBrewery('Księżyc')).toBe('ksiezyc');
+  expect(normalizeBrewery('Piąte')).toBe('piate');
+});

--- a/src/domain/normalize.ts
+++ b/src/domain/normalize.ts
@@ -6,6 +6,12 @@ const STYLE_WORDS = new Set([
 ]);
 const BREWERY_NOISE = new Set(['browar', 'brewery', 'brewing', 'co', 'company']);
 
+// NFD decomposes most Polish diacritics (ą ć ę ń ó ś ź ż and their
+// uppercase forms) into a base letter + a combining mark from the
+// U+0300–U+036F block, which the regex then strips. Ł/ł is the one
+// Polish letter that is NOT canonically decomposable — it's a base
+// letter with an inherent stroke (U+0141 / U+0142), so NFD leaves it
+// intact and we replace it explicitly.
 function stripDiacritics(s: string): string {
   return s.normalize('NFD')
     .replace(/[̀-ͯ]/g, '')


### PR DESCRIPTION
## Summary
Follow-up to #4 after review question: why is Ł the only Polish letter replaced explicitly?

Adds a code comment and a new test:

- **Comment** — documents that NFD + combining-mark stripping covers ąćęńóśźż (and uppercase), while Ł/ł is a non-decomposable base letter in Unicode (U+0141 / U+0142) and must be mapped manually.
- **Test** — `strips every Polish diacritic` asserts that `ąćęłńóśźż`, `ĄĆĘŁŃÓŚŹŻ`, plus realistic words (`Żywiec`, `Średnica`, `Księżyc`, `Piąte`) all normalize to their ASCII equivalents. Pins the behaviour so a future regression in `stripDiacritics` fails loudly.

No runtime change — the code was already correct; this PR documents why.

## Test Plan
- [x] `npm test` — 39/39 passing (one new test)
- [x] `npm run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)