### PR TITLE
feat(bot): Telegraf commands — /start /link /import /newbeers /route /filters /refresh (Tasks 19–23)

### DIFF
--- a/src/bot/commands/filters.ts
+++ b/src/bot/commands/filters.ts
@@ -1,0 +1,46 @@
+import { Composer } from 'telegraf';
+import type { BotContext } from '../index';
+import { filtersKeyboard } from '../keyboards';
+import { getFilters, setFilters } from '../../storage/user_filters';
+import { ensureProfile } from '../../storage/user_profiles';
+
+const emptyFilters = () => ({
+  styles: [] as string[],
+  min_rating: null as number | null,
+  abv_min: null as number | null,
+  abv_max: null as number | null,
+  default_route_n: null as number | null,
+});
+
+export const filtersCommand = new Composer<BotContext>();
+
+filtersCommand.command('filters', async (ctx) => {
+  ensureProfile(ctx.deps.db, ctx.from.id);
+  const f = getFilters(ctx.deps.db, ctx.from.id);
+  await ctx.reply(
+    `Поточні: styles=${(f?.styles ?? []).join(',') || '—'}, min_rating=${f?.min_rating ?? '—'}`,
+    filtersKeyboard(),
+  );
+});
+
+filtersCommand.action(/style:(.+)/, async (ctx) => {
+  const style = ctx.match[1];
+  const f = getFilters(ctx.deps.db, ctx.from!.id) ?? emptyFilters();
+  const styles = f.styles.includes(style)
+    ? f.styles.filter((s) => s !== style)
+    : [...f.styles, style];
+  setFilters(ctx.deps.db, ctx.from!.id, { ...f, styles });
+  await ctx.answerCbQuery(`styles=${styles.join(',') || '—'}`);
+});
+
+filtersCommand.action(/rating:(.+)/, async (ctx) => {
+  const r = parseFloat(ctx.match[1]);
+  const f = getFilters(ctx.deps.db, ctx.from!.id) ?? emptyFilters();
+  setFilters(ctx.deps.db, ctx.from!.id, { ...f, min_rating: r });
+  await ctx.answerCbQuery(`min_rating=${r}`);
+});
+
+filtersCommand.action('reset', async (ctx) => {
+  setFilters(ctx.deps.db, ctx.from!.id, emptyFilters());
+  await ctx.answerCbQuery('Скинуто');
+});

--- a/src/bot/commands/import.ts
+++ b/src/bot/commands/import.ts
@@ -1,0 +1,117 @@
+import { Composer } from 'telegraf';
+import { Readable } from 'node:stream';
+import type { BotContext } from '../index';
+import {
+  iterExport,
+  detectFormat,
+  type Checkin,
+  type ExportFormat,
+} from '../../sources/untappd/export';
+import { upsertBeer } from '../../storage/beers';
+import { mergeCheckin } from '../../storage/checkins';
+import { ensureProfile } from '../../storage/user_profiles';
+import { normalizeBrewery, normalizeName } from '../../domain/normalize';
+
+const BATCH_SIZE = 500;
+const PROGRESS_INTERVAL_MS = 2000;
+const TG_DOWNLOAD_LIMIT = 20 * 1024 * 1024;
+
+export const importCommand = new Composer<BotContext>();
+
+importCommand.command('import', async (ctx) => {
+  await ctx.reply(
+    'Надішли експорт з Untappd: CSV, JSON або ZIP (до 20 MB).\n' +
+      'Supporter → Account → Download History. Великий JSON краще запакувати в ZIP.',
+  );
+});
+
+importCommand.on('document', async (ctx) => {
+  const doc = ctx.message.document;
+  const name = doc.file_name ?? '';
+
+  let format: ExportFormat;
+  try {
+    format = detectFormat(name);
+  } catch {
+    await ctx.reply('Формат не підтримується. Очікую .csv, .json або .zip.');
+    return;
+  }
+
+  if (doc.file_size && doc.file_size > TG_DOWNLOAD_LIMIT) {
+    await ctx.reply(
+      'Файл > 20 MB — Telegram не дасть боту його скачати. ' +
+        'Запакуй JSON у ZIP (стискається ≈10×) і надішли ще раз.',
+    );
+    return;
+  }
+
+  ensureProfile(ctx.deps.db, ctx.from.id);
+
+  const link = await ctx.telegram.getFileLink(doc.file_id);
+  const res = await fetch(link.toString());
+  if (!res.ok || !res.body) {
+    await ctx.reply('Не вдалось отримати файл з Telegram.');
+    return;
+  }
+  const stream = Readable.fromWeb(res.body as never);
+
+  const progress = await ctx.reply('⏳ Починаю імпорт…');
+  const db = ctx.deps.db;
+  const telegramId = ctx.from.id;
+
+  const flushBatch = db.transaction((rows: Checkin[]) => {
+    for (const r of rows) {
+      const beerId = upsertBeer(db, {
+        untappd_id: r.bid ?? null,
+        name: r.beer_name,
+        brewery: r.brewery_name,
+        style: r.beer_type,
+        abv: r.beer_abv,
+        rating_global: null,
+        normalized_name: normalizeName(r.beer_name),
+        normalized_brewery: normalizeBrewery(r.brewery_name),
+      });
+      mergeCheckin(db, {
+        checkin_id: r.checkin_id,
+        telegram_id: telegramId,
+        beer_id: beerId,
+        user_rating: r.rating_score,
+        checkin_at: r.created_at,
+        venue: r.venue_name,
+      });
+    }
+  });
+
+  let total = 0;
+  let batch: Checkin[] = [];
+  let lastReport = Date.now();
+
+  const report = async (text: string) => {
+    await ctx.telegram
+      .editMessageText(ctx.chat.id, progress.message_id, undefined, text)
+      .catch(() => {});
+  };
+
+  try {
+    for await (const row of iterExport(stream, format)) {
+      batch.push(row);
+      if (batch.length >= BATCH_SIZE) {
+        flushBatch(batch);
+        total += batch.length;
+        batch = [];
+        if (Date.now() - lastReport > PROGRESS_INTERVAL_MS) {
+          lastReport = Date.now();
+          await report(`⏳ Імпортовано ${total}…`);
+        }
+      }
+    }
+    if (batch.length) {
+      flushBatch(batch);
+      total += batch.length;
+    }
+    await report(`✅ Імпортовано ${total} чекінів (${format.toUpperCase()}).`);
+  } catch (e) {
+    await report(`❌ Помилка після ${total} рядків: ${(e as Error).message}`);
+    throw e;
+  }
+});

--- a/src/bot/commands/link.test.ts
+++ b/src/bot/commands/link.test.ts
@@ -1,0 +1,23 @@
+import { parseLinkArgs } from './link';
+
+test('accepts a bare username', () => {
+  expect(parseLinkArgs('yuriy')).toEqual({ username: 'yuriy' });
+});
+
+test('accepts a full URL', () => {
+  expect(parseLinkArgs('https://untappd.com/user/yuriy')).toEqual({ username: 'yuriy' });
+});
+
+test('accepts a www URL', () => {
+  expect(parseLinkArgs('https://www.untappd.com/user/yuriy')).toEqual({ username: 'yuriy' });
+});
+
+test('tolerates trailing slash', () => {
+  expect(parseLinkArgs('yuriy/')).toEqual({ username: 'yuriy' });
+});
+
+test('rejects empty or junk', () => {
+  expect(parseLinkArgs('')).toBeNull();
+  expect(parseLinkArgs('not a username!')).toBeNull();
+  expect(parseLinkArgs('a')).toBeNull();
+});

--- a/src/bot/commands/link.ts
+++ b/src/bot/commands/link.ts
@@ -1,0 +1,24 @@
+import { Composer } from 'telegraf';
+import type { BotContext } from '../index';
+import { ensureProfile, setUntappdUsername } from '../../storage/user_profiles';
+
+export function parseLinkArgs(raw: string): { username: string } | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const m = trimmed.match(/^(?:https?:\/\/(?:www\.)?untappd\.com\/user\/)?([A-Za-z0-9_.-]{2,30})\/?$/);
+  return m ? { username: m[1] } : null;
+}
+
+export const linkCommand = new Composer<BotContext>();
+
+linkCommand.command('link', async (ctx) => {
+  const arg = ctx.message.text.split(' ').slice(1).join(' ');
+  const parsed = parseLinkArgs(arg);
+  if (!parsed) {
+    await ctx.reply('Використання: /link <username> (або повний URL untappd.com/user/<username>)');
+    return;
+  }
+  ensureProfile(ctx.deps.db, ctx.from.id);
+  setUntappdUsername(ctx.deps.db, ctx.from.id, parsed.username);
+  await ctx.reply(`✅ Прив'язано до untappd.com/user/${parsed.username}`);
+});

--- a/src/bot/commands/newbeers.ts
+++ b/src/bot/commands/newbeers.ts
@@ -1,0 +1,47 @@
+import { Composer } from 'telegraf';
+import type { BotContext } from '../index';
+import { latestSnapshotsPerPub, tapsForSnapshot } from '../../storage/snapshots';
+import { drunkBeerIds } from '../../storage/checkins';
+import { getMatch } from '../../storage/match_links';
+import { getFilters } from '../../storage/user_filters';
+import { filterInteresting, rankByRating } from '../../domain/filters';
+import { listPubs } from '../../storage/pubs';
+
+export const newbeersCommand = new Composer<BotContext>();
+
+newbeersCommand.command('newbeers', async (ctx) => {
+  const db = ctx.deps.db;
+  const drunk = drunkBeerIds(db, ctx.from.id);
+  const filters =
+    getFilters(db, ctx.from.id) ?? {
+      styles: [],
+      min_rating: null,
+      abv_min: null,
+      abv_max: null,
+      default_route_n: null,
+    };
+  const pubs = new Map(listPubs(db).map((p) => [p.id, p]));
+
+  const ranked: { pubName: string; beer: string; rating: number | null }[] = [];
+  for (const snap of latestSnapshotsPerPub(db)) {
+    const taps = tapsForSnapshot(db, snap.id).map((t) => ({
+      beer_id: getMatch(db, t.beer_ref)?.untappd_beer_id ?? null,
+      style: t.style,
+      abv: t.abv,
+      u_rating: t.u_rating,
+      beer_ref: t.beer_ref,
+    }));
+    const good = filterInteresting(taps, drunk, filters);
+    for (const t of rankByRating(good).slice(0, 3)) {
+      ranked.push({
+        pubName: pubs.get(snap.pub_id)!.name,
+        beer: t.beer_ref,
+        rating: t.u_rating,
+      });
+    }
+  }
+
+  ranked.sort((a, b) => (b.rating ?? 0) - (a.rating ?? 0));
+  const head = ranked.slice(0, 15).map((r) => `• ${r.beer} — ${r.pubName} (${r.rating ?? '—'})`);
+  await ctx.reply(head.length ? head.join('\n') : 'Нічого цікавого — спробуй /refresh.');
+});

--- a/src/bot/commands/refresh.ts
+++ b/src/bot/commands/refresh.ts
@@ -1,0 +1,26 @@
+import { Composer } from 'telegraf';
+import type { BotContext } from '../index';
+
+const COOLDOWN_MS = 5 * 60 * 1000;
+const lastCall = new Map<number, number>();
+
+export function createRefreshCommand(run: () => Promise<void>) {
+  const cmd = new Composer<BotContext>();
+  cmd.command('refresh', async (ctx) => {
+    const prev = lastCall.get(ctx.from.id) ?? 0;
+    if (Date.now() - prev < COOLDOWN_MS) {
+      await ctx.reply('⏱ Занадто часто — спробуй за кілька хвилин.');
+      return;
+    }
+    lastCall.set(ctx.from.id, Date.now());
+    await ctx.reply('Оновлюю…');
+    try {
+      await run();
+      await ctx.reply('✅ Готово.');
+    } catch (e) {
+      ctx.deps.log.error({ err: e }, 'refresh failed');
+      await ctx.reply('❌ Не вдалось — подивись логи.');
+    }
+  });
+  return cmd;
+}

--- a/src/bot/commands/route.ts
+++ b/src/bot/commands/route.ts
@@ -1,0 +1,96 @@
+import { Composer } from 'telegraf';
+import type { BotContext } from '../index';
+import { listPubs } from '../../storage/pubs';
+import { latestSnapshotsPerPub, tapsForSnapshot } from '../../storage/snapshots';
+import { drunkBeerIds } from '../../storage/checkins';
+import { getMatch } from '../../storage/match_links';
+import { getFilters } from '../../storage/user_filters';
+import { filterInteresting } from '../../domain/filters';
+import {
+  buildRoute,
+  haversineMeters,
+  createOsrmDistance,
+  type RoutePub,
+} from '../../domain/router';
+
+export const routeCommand = new Composer<BotContext>();
+
+routeCommand.command('route', async (ctx) => {
+  const db = ctx.deps.db;
+  const arg = ctx.message.text.split(' ')[1];
+  const N =
+    parseInt(arg ?? '', 10) ||
+    getFilters(db, ctx.from.id)?.default_route_n ||
+    ctx.deps.env.DEFAULT_ROUTE_N;
+
+  const drunk = drunkBeerIds(db, ctx.from.id);
+  const filters =
+    getFilters(db, ctx.from.id) ?? {
+      styles: [],
+      min_rating: null,
+      abv_min: null,
+      abv_max: null,
+      default_route_n: null,
+    };
+  const pubsById = new Map(listPubs(db).map((p) => [p.id, p]));
+
+  const routePubs: RoutePub[] = [];
+  for (const snap of latestSnapshotsPerPub(db)) {
+    const pub = pubsById.get(snap.pub_id);
+    if (!pub || pub.lat == null || pub.lon == null) continue;
+    const taps = tapsForSnapshot(db, snap.id).map((t) => ({
+      beer_id: getMatch(db, t.beer_ref)?.untappd_beer_id ?? null,
+      style: t.style,
+      abv: t.abv,
+      u_rating: t.u_rating,
+    }));
+    const interesting = filterInteresting(taps, drunk, filters).map((t) => t.beer_id!) as number[];
+    if (!interesting.length) continue;
+    routePubs.push({
+      id: pub.id,
+      lat: pub.lat,
+      lon: pub.lon,
+      interesting: new Set(interesting),
+    });
+  }
+
+  if (!routePubs.length) {
+    await ctx.reply('Немає цікавих непитих пив у поточному snapshot.');
+    return;
+  }
+
+  const osrm = createOsrmDistance(ctx.deps.env.OSRM_BASE_URL);
+  const n = routePubs.length;
+  const matrix: number[][] = Array.from({ length: n }, () => Array(n).fill(0));
+  const coordKey = (lat: number, lon: number) => `${lat},${lon}`;
+  const idxByCoord = new Map(routePubs.map((p, i) => [coordKey(p.lat, p.lon), i]));
+
+  for (let i = 0; i < n; i++) {
+    for (let j = i + 1; j < n; j++) {
+      const a: [number, number] = [routePubs[i].lat, routePubs[i].lon];
+      const b: [number, number] = [routePubs[j].lat, routePubs[j].lon];
+      let d: number;
+      try {
+        d = await osrm(a, b);
+      } catch (e) {
+        ctx.deps.log.warn({ err: e }, 'osrm failed, haversine');
+        d = haversineMeters(a, b);
+      }
+      matrix[i][j] = d;
+      matrix[j][i] = d;
+    }
+  }
+
+  const distance = (a: [number, number], b: [number, number]): number => {
+    const ia = idxByCoord.get(coordKey(a[0], a[1]));
+    const ib = idxByCoord.get(coordKey(b[0], b[1]));
+    if (ia === undefined || ib === undefined) return haversineMeters(a, b);
+    return matrix[ia][ib];
+  };
+
+  const result = buildRoute(routePubs, N, { distance });
+  const km = (result.distanceMeters / 1000).toFixed(1);
+  const header = `Маршрут: ≥${N} нових пив, покрито ${result.coveredCount}, ≈ ${km} км, ${result.pubIds.length} пабів`;
+  const lines = result.pubIds.map((id, i) => `${i + 1}. ${pubsById.get(id)!.name}`);
+  await ctx.reply([header, '', ...lines].join('\n'));
+});

--- a/src/bot/commands/start.ts
+++ b/src/bot/commands/start.ts
@@ -1,0 +1,19 @@
+import { Composer } from 'telegraf';
+import type { BotContext } from '../index';
+import { ensureProfile } from '../../storage/user_profiles';
+
+export const startCommand = new Composer<BotContext>();
+
+startCommand.command('start', async (ctx) => {
+  ensureProfile(ctx.deps.db, ctx.from.id);
+  await ctx.reply(
+    [
+      'Привіт! Я допоможу зібрати маршрут по варшавських пабах і випити щось нове.',
+      '',
+      '1) /link <untappd-username> — щоб підтягувати твої чекіни.',
+      '2) /import — завантаж CSV-експорт зі свого Untappd для повного бекфілу історії.',
+      '3) /newbeers — топ непитих пив на поточних кранах.',
+      '4) /route N — маршрут, що покриває ≥ N непитих пив із мінімальною пішою відстанню.',
+    ].join('\n'),
+  );
+});

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -1,0 +1,24 @@
+import { Telegraf, Context } from 'telegraf';
+import type pino from 'pino';
+import type { DB } from '../storage/db';
+import type { Env } from '../config/env';
+
+export interface AppDeps {
+  db: DB;
+  env: Env;
+  log: pino.Logger;
+}
+
+export interface BotContext extends Context {
+  deps: AppDeps;
+}
+
+export function createBot(deps: AppDeps): Telegraf<BotContext> {
+  const bot = new Telegraf<BotContext>(deps.env.TELEGRAM_BOT_TOKEN);
+  bot.use((ctx, next) => {
+    ctx.deps = deps;
+    return next();
+  });
+  bot.catch((err, ctx) => deps.log.error({ err, update: ctx.update }, 'bot error'));
+  return bot;
+}

--- a/src/bot/keyboards.ts
+++ b/src/bot/keyboards.ts
@@ -1,0 +1,9 @@
+import { Markup } from 'telegraf';
+
+export const filtersKeyboard = () =>
+  Markup.inlineKeyboard([
+    [Markup.button.callback('IPA', 'style:IPA'), Markup.button.callback('Pils', 'style:Pils')],
+    [Markup.button.callback('Stout', 'style:Stout'), Markup.button.callback('Sour', 'style:Sour')],
+    [Markup.button.callback('min 3.5', 'rating:3.5'), Markup.button.callback('min 3.8', 'rating:3.8')],
+    [Markup.button.callback('Скинути', 'reset')],
+  ]);


### PR DESCRIPTION
## Summary
- Telegraf bootstrap: `createBot(deps)` injects `{db, env, log}` into `BotContext` via middleware; centralised `bot.catch` logs errors.
- User commands: `/start` (intro + ensureProfile), `/link` (bare username or untappd URL; TDD on `parseLinkArgs`), `/import` (streaming CSV/JSON/ZIP with 500-row transactions and throttled progress updates; rejects > 20 MB with a ZIP hint).
- Discovery: `/newbeers` ranks top-3 interesting taps per pub, global top-15. `/route [N]` precomputes an N×N OSRM walking-distance matrix (haversine fallback per pair) and calls `buildRoute`.
- Config: `/filters` inline keyboard toggles styles, min-rating, or resets; `/refresh` is a factory over the injected job runner with a 5-min per-user in-memory cooldown.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm test` — 19 suites / 44 tests pass (incl. 5 new `parseLinkArgs` tests)
- [ ] Manual smoke against a live bot token is deferred to Task 25 (composition root) — the `import`/`newbeers`/`route` handlers need a wired DB+env to exercise end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)