### PR TITLE
feat(ops): refresh jobs + composition root + systemd deploy (Tasks 24–26)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,38 @@
+# Deploy
+
+## One-time host setup (as root)
+
+```bash
+useradd -r -s /usr/sbin/nologin warsaw-beer-bot
+install -d -o warsaw-beer-bot -g warsaw-beer-bot \
+  /etc/warsaw-beer-bot /var/lib/warsaw-beer-bot /opt/warsaw-beer-bot
+cp .env.example /etc/warsaw-beer-bot/.env
+chmod 600 /etc/warsaw-beer-bot/.env
+# edit /etc/warsaw-beer-bot/.env — set TELEGRAM_BOT_TOKEN and
+# DATABASE_PATH=/var/lib/warsaw-beer-bot/bot.db
+```
+
+Node 20+ must be installed system-wide (the unit calls `/usr/bin/node`).
+
+## Deploy
+
+From a dev checkout:
+
+```bash
+./deploy/deploy.sh
+```
+
+Subsequent deploys:
+
+```bash
+git pull
+./deploy/deploy.sh
+```
+
+## Operate
+
+```bash
+sudo systemctl status warsaw-beer-bot
+sudo journalctl -u warsaw-beer-bot -f
+sudo systemctl restart warsaw-beer-bot
+```

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP=/opt/warsaw-beer-bot
+DATA=/var/lib/warsaw-beer-bot
+ENVDIR=/etc/warsaw-beer-bot
+
+sudo install -d -o warsaw-beer-bot -g warsaw-beer-bot "$APP" "$DATA" "$ENVDIR"
+sudo rsync -a --delete \
+  --exclude node_modules \
+  --exclude tests \
+  --exclude docs \
+  --exclude .git \
+  --exclude .worktrees \
+  --exclude dist \
+  ./ "$APP"/
+sudo -u warsaw-beer-bot bash -lc "cd $APP && npm ci --omit=dev && npm run build"
+sudo install -m 0644 deploy/warsaw-beer-bot.service /etc/systemd/system/warsaw-beer-bot.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now warsaw-beer-bot
+sudo journalctl -u warsaw-beer-bot -n 30 --no-pager

--- a/deploy/warsaw-beer-bot.service
+++ b/deploy/warsaw-beer-bot.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Warsaw Beer Crawler Bot
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/warsaw-beer-bot
+EnvironmentFile=/etc/warsaw-beer-bot/.env
+ExecStart=/usr/bin/node /opt/warsaw-beer-bot/dist/index.js
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+User=warsaw-beer-bot
+Group=warsaw-beer-bot
+
+[Install]
+WantedBy=multi-user.target

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "better-sqlite3": "^12.9.0",
         "cheerio": "^1.2.0",
         "csv-parse": "^6.2.1",
+        "dotenv": "^17.4.2",
         "fast-fuzzy": "^1.12.0",
         "node-cron": "^4.2.1",
         "p-queue": "^6.6.2",
@@ -2964,6 +2965,18 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/eastasianwidth": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "better-sqlite3": "^12.9.0",
     "cheerio": "^1.2.0",
     "csv-parse": "^6.2.1",
+    "dotenv": "^17.4.2",
     "fast-fuzzy": "^1.12.0",
     "node-cron": "^4.2.1",
     "p-queue": "^6.6.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,63 @@
-console.log('warsaw-beer-bot: bootstrap OK');
+import 'dotenv/config';
+import cron from 'node-cron';
+import pino from 'pino';
+import { loadEnv } from './config/env';
+import { openDb } from './storage/db';
+import { migrate } from './storage/schema';
+import { createHttp } from './sources/http';
+import { createGeocoder } from './sources/geocoder';
+import { createBot } from './bot';
+import { startCommand } from './bot/commands/start';
+import { linkCommand } from './bot/commands/link';
+import { importCommand } from './bot/commands/import';
+import { newbeersCommand } from './bot/commands/newbeers';
+import { routeCommand } from './bot/commands/route';
+import { filtersCommand } from './bot/commands/filters';
+import { createRefreshCommand } from './bot/commands/refresh';
+import { refreshOntap } from './jobs/refresh-ontap';
+import { refreshAllUntappd } from './jobs/refresh-untappd';
+
+async function main(): Promise<void> {
+  const env = loadEnv(process.env);
+  const log = pino({ level: env.LOG_LEVEL });
+  const db = openDb(env.DATABASE_PATH);
+  migrate(db);
+
+  const http = createHttp({ userAgent: env.NOMINATIM_USER_AGENT });
+  const geocoder = createGeocoder({ userAgent: env.NOMINATIM_USER_AGENT });
+
+  const runOntap = () => refreshOntap({ db, log, http, geocoder });
+  const runUntappd = () => refreshAllUntappd({ db, log, http });
+
+  const bot = createBot({ db, env, log });
+  bot.use(
+    startCommand,
+    linkCommand,
+    importCommand,
+    newbeersCommand,
+    routeCommand,
+    filtersCommand,
+    createRefreshCommand(async () => {
+      await runOntap();
+      await runUntappd();
+    }),
+  );
+
+  cron.schedule('0 */12 * * *', () => {
+    runOntap().catch((e) => log.error({ err: e }, 'ontap cron'));
+  });
+  cron.schedule('0 3 * * *', () => {
+    runUntappd().catch((e) => log.error({ err: e }, 'untappd cron'));
+  });
+
+  bot.launch();
+  log.info('bot launched');
+
+  process.once('SIGINT', () => bot.stop('SIGINT'));
+  process.once('SIGTERM', () => bot.stop('SIGTERM'));
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/jobs/refresh-ontap.ts
+++ b/src/jobs/refresh-ontap.ts
@@ -1,0 +1,81 @@
+import type pino from 'pino';
+import type { DB } from '../storage/db';
+import type { Http } from '../sources/http';
+import type { Geocoder } from '../sources/geocoder';
+import { parseWarsawIndex } from '../sources/ontap/index';
+import { parsePubPage } from '../sources/ontap/pub';
+import { upsertPub } from '../storage/pubs';
+import { createSnapshot, insertTaps } from '../storage/snapshots';
+import { upsertMatch } from '../storage/match_links';
+import { upsertBeer } from '../storage/beers';
+import { matchBeer } from '../domain/matcher';
+import { normalizeBrewery, normalizeName } from '../domain/normalize';
+
+interface Deps {
+  db: DB;
+  log: pino.Logger;
+  http: Http;
+  geocoder: Geocoder;
+}
+
+export async function refreshOntap(deps: Deps): Promise<void> {
+  const { db, log, http, geocoder } = deps;
+  const indexHtml = await http.get('https://ontap.pl/warszawa');
+  const indexPubs = parseWarsawIndex(indexHtml);
+  log.info({ n: indexPubs.length }, 'ontap index parsed');
+
+  for (const ip of indexPubs) {
+    try {
+      const html = await http.get(`https://${ip.slug}.ontap.pl/`);
+      const { pub, taps } = parsePubPage(html);
+
+      let lat = pub.lat;
+      let lon = pub.lon;
+      if ((lat == null || lon == null) && pub.address) {
+        const g = await geocoder(pub.address);
+        if (g) {
+          lat = g.lat;
+          lon = g.lon;
+        }
+      }
+
+      const pubId = upsertPub(db, {
+        slug: ip.slug,
+        name: pub.name || ip.name,
+        address: pub.address,
+        lat,
+        lon,
+      });
+      const snapshotId = createSnapshot(db, pubId, new Date().toISOString());
+      insertTaps(db, snapshotId, taps);
+
+      const catalog = listBeerCatalog(db);
+      for (const t of taps) {
+        const brewery = t.brewery_ref ?? t.beer_ref.split(/[—-]\s|:\s/)[0] ?? '';
+        const m = matchBeer({ brewery, name: t.beer_ref }, catalog);
+        if (m) {
+          upsertMatch(db, t.beer_ref, m.id, m.confidence);
+        } else {
+          const beerId = upsertBeer(db, {
+            name: t.beer_ref,
+            brewery,
+            style: t.style,
+            abv: t.abv,
+            rating_global: t.u_rating,
+            normalized_name: normalizeName(t.beer_ref),
+            normalized_brewery: normalizeBrewery(brewery),
+          });
+          upsertMatch(db, t.beer_ref, beerId, 1.0);
+        }
+      }
+    } catch (e) {
+      log.warn({ err: e, slug: ip.slug }, 'ontap pub refresh failed');
+    }
+  }
+}
+
+function listBeerCatalog(db: DB): { id: number; brewery: string; name: string }[] {
+  return db
+    .prepare('SELECT id, brewery, name FROM beers')
+    .all() as { id: number; brewery: string; name: string }[];
+}

--- a/src/jobs/refresh-untappd.ts
+++ b/src/jobs/refresh-untappd.ts
@@ -1,0 +1,52 @@
+import type pino from 'pino';
+import type { DB } from '../storage/db';
+import type { Http } from '../sources/http';
+import { parseUserBeerPage } from '../sources/untappd/scraper';
+import { allProfiles } from '../storage/user_profiles';
+import { upsertBeer, findBeerByNormalized } from '../storage/beers';
+import { mergeCheckin } from '../storage/checkins';
+import { normalizeBrewery, normalizeName } from '../domain/normalize';
+
+interface Deps {
+  db: DB;
+  log: pino.Logger;
+  http: Http;
+}
+
+export async function refreshAllUntappd(deps: Deps): Promise<void> {
+  const { db, log, http } = deps;
+  for (const p of allProfiles(db)) {
+    if (!p.untappd_username) continue;
+    try {
+      const html = await http.get(`https://untappd.com/user/${p.untappd_username}/beer`);
+      const items = parseUserBeerPage(html);
+      for (const it of items) {
+        const nb = normalizeBrewery(it.brewery_name);
+        const nn = normalizeName(it.beer_name);
+        const existing = findBeerByNormalized(db, nb, nn);
+        const beerId =
+          existing?.id ??
+          upsertBeer(db, {
+            untappd_id: it.bid ?? null,
+            name: it.beer_name,
+            brewery: it.brewery_name,
+            style: null,
+            abv: null,
+            rating_global: it.rating_score,
+            normalized_name: nn,
+            normalized_brewery: nb,
+          });
+        mergeCheckin(db, {
+          checkin_id: it.checkin_id,
+          telegram_id: p.telegram_id,
+          beer_id: beerId,
+          user_rating: it.rating_score,
+          checkin_at: it.checkin_at || new Date().toISOString(),
+          venue: null,
+        });
+      }
+    } catch (e) {
+      log.warn({ err: e, user: p.untappd_username }, 'untappd scrape failed');
+    }
+  }
+}

--- a/src/sources/untappd/export.ts
+++ b/src/sources/untappd/export.ts
@@ -1,11 +1,12 @@
 import { Readable } from 'node:stream';
 import { parse as csvParse } from 'csv-parse';
-// stream-json v2 package.json exports: { "./*": "./src/*" }
-// ts (moduleResolution: node) doesn't honour that map, so we use require
-// to get the underlying module directly.
+// stream-json v2 exports: { "./*": "./src/*" } — Node applies the mapping
+// but does NOT append `.js` afterwards, so the require path must be explicit.
+// ts-jest resolves without the suffix, so tests passed while `node dist/...`
+// failed at module load.
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const streamArray: typeof import('stream-json/src/streamers/stream-array') =
-  require('stream-json/streamers/stream-array');
+  require('stream-json/streamers/stream-array.js');
 import yauzl from 'yauzl';
 
 export interface Checkin {


### PR DESCRIPTION
## Summary
- **Task 24** — `src/jobs/refresh-ontap.ts` (Warsaw index → per-pub page → snapshot+taps → matcher with new-beer fallback) and `refresh-untappd.ts` (per-profile public scrape → upsert beer → mergeCheckin). Per-pub `try/catch` so one bad page doesn't kill the run.
- **Task 25** — `src/index.ts` is now the composition root: loads env, opens+migrates DB, builds shared http+geocoder, wires all bot commands, schedules cron (`0 */12 * * *` ontap, `0 3 * * *` untappd), and registers SIGINT/SIGTERM. Adds `dotenv` dep. `/refresh` runs both jobs back-to-back.
- **Task 26** — `deploy/`: systemd unit (`warsaw-beer-bot.service`), `deploy.sh` (rsync → `npm ci --omit=dev` → `npm run build` → enable service), `README.md` with first-run host prep.

## Drive-by fix
- `fix(sources/untappd): require stream-json with .js suffix` — surfaced by the Task 25 smoke test. `stream-json@2` exports `{ "./*": "./src/*" }`, and Node does not append `.js` after the pattern substitution. Tests passed (ts-jest skips Node's exports resolution) but `node dist/index.js` failed at module load. Pre-existing bug from `feat/sources`; fixed here because it gates the smoke verification.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm test` — 19 suites / 44 tests pass
- [x] `npm run build` — clean
- [x] Local smoke: `node dist/index.js` with dummy token logs `bot launched` and then `TelegramError 401` — composition root reaches Telegraf network call.
- [ ] **Task 27 (host-side, manual)**: run `./deploy/deploy.sh` on the CX33, confirm `systemctl status warsaw-beer-bot` is `active (running)`, then exercise `/start /link /refresh /newbeers /route 5` in Telegram and tail `journalctl -u warsaw-beer-bot -f`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)