### PR TITLE
fix(ops): deploy.sh — chown after rsync + ensure home dir

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -3,16 +3,30 @@
 ## One-time host setup (as root)
 
 ```bash
-useradd -r -s /usr/sbin/nologin warsaw-beer-bot
+useradd -r -m -s /usr/sbin/nologin warsaw-beer-bot
 install -d -o warsaw-beer-bot -g warsaw-beer-bot \
   /etc/warsaw-beer-bot /var/lib/warsaw-beer-bot /opt/warsaw-beer-bot
 cp .env.example /etc/warsaw-beer-bot/.env
 chmod 600 /etc/warsaw-beer-bot/.env
+chown warsaw-beer-bot:warsaw-beer-bot /etc/warsaw-beer-bot/.env
 # edit /etc/warsaw-beer-bot/.env — set TELEGRAM_BOT_TOKEN and
 # DATABASE_PATH=/var/lib/warsaw-beer-bot/bot.db
 ```
 
-Node 20+ must be installed system-wide (the unit calls `/usr/bin/node`).
+The `-m` flag on `useradd` is important — npm needs a writable `$HOME`
+for its cache and logs. `deploy.sh` also creates the home dir defensively
+in case the user already exists without one.
+
+### Node 20
+
+Install system-wide (the systemd unit calls `/usr/bin/node`):
+
+```bash
+curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+apt-get install -y nodejs build-essential python3
+```
+
+`build-essential` + `python3` are needed for the `better-sqlite3` native build.
 
 ## Deploy
 

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -4,8 +4,11 @@ set -euo pipefail
 APP=/opt/warsaw-beer-bot
 DATA=/var/lib/warsaw-beer-bot
 ENVDIR=/etc/warsaw-beer-bot
+HOMEDIR=/home/warsaw-beer-bot
 
 sudo install -d -o warsaw-beer-bot -g warsaw-beer-bot "$APP" "$DATA" "$ENVDIR"
+sudo install -d -o warsaw-beer-bot -g warsaw-beer-bot -m 750 "$HOMEDIR"
+
 sudo rsync -a --delete \
   --exclude node_modules \
   --exclude tests \
@@ -14,6 +17,10 @@ sudo rsync -a --delete \
   --exclude .worktrees \
   --exclude dist \
   ./ "$APP"/
+
+# rsync -a preserves source ownership (root); reset before npm runs as warsaw-beer-bot.
+sudo chown -R warsaw-beer-bot:warsaw-beer-bot "$APP"
+
 sudo -u warsaw-beer-bot bash -lc "cd $APP && npm ci --omit=dev && npm run build"
 sudo install -m 0644 deploy/warsaw-beer-bot.service /etc/systemd/system/warsaw-beer-bot.service
 sudo systemctl daemon-reload


### PR DESCRIPTION
## Why
First CX33 smoke (Task 27) failed with `EACCES: permission denied, mkdir '/opt/warsaw-beer-bot/node_modules'`, plus a separate npm warning: *Log files were not written due to an error writing to the directory: /home/warsaw-beer-bot/.npm/_logs*.

## Root causes
1. `rsync -a ./ /opt/warsaw-beer-bot/` preserves source owner (root), so any directories rsync creates inside `$APP` end up root-owned. Even though `install -d -o warsaw-beer-bot` set the top dir, the subsequent rsync re-applied root ownership to the contents — and on existing dirs `install -d` does not re-chown. `npm ci` running as `warsaw-beer-bot` then can't `mkdir node_modules`.
2. `useradd -r -s /usr/sbin/nologin` (without `-m`) never created `/home/warsaw-beer-bot`, so npm couldn't write its cache or logs.

## Fix
- `deploy.sh`: idempotently `install -d` the home directory, and `chown -R warsaw-beer-bot:warsaw-beer-bot $APP` after the rsync, before running npm.
- `deploy/README.md`: `useradd -r -m` (so a home is created on fresh hosts), explicit Node 20 install instructions (NodeSource + `build-essential`+`python3` for the `better-sqlite3` native build), and a note explaining why home matters.

## Test plan
- [x] `bash -n deploy/deploy.sh` — syntax OK
- [ ] Re-run on the CX33: `git pull && ./deploy/deploy.sh` — expected to clear EACCES and to land at `systemctl status warsaw-beer-bot` = `active (running)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)