### PR TITLE
fix(ops): install dev deps for build, then prune

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -21,7 +21,9 @@ sudo rsync -a --delete \
 # rsync -a preserves source ownership (root); reset before npm runs as warsaw-beer-bot.
 sudo chown -R warsaw-beer-bot:warsaw-beer-bot "$APP"
 
-sudo -u warsaw-beer-bot bash -lc "cd $APP && npm ci --omit=dev && npm run build"
+# typescript lives in devDependencies, so we need a full install for `tsc`,
+# then prune dev deps once dist/ is built.
+sudo -u warsaw-beer-bot bash -lc "cd $APP && npm ci && npm run build && npm prune --omit=dev"
 sudo install -m 0644 deploy/warsaw-beer-bot.service /etc/systemd/system/warsaw-beer-bot.service
 sudo systemctl daemon-reload
 sudo systemctl enable --now warsaw-beer-bot


### PR DESCRIPTION
## Why
Second CX33 smoke (Task 27, after #8 unblocked the EACCES path) fails on \`npm run build\`:

\`\`\`
> warsaw-beer-bot@1.0.0 build
> tsc
sh: 1: tsc: not found
\`\`\`

\`tsc\` is provided by the \`typescript\` package, which is a devDependency. \`npm ci --omit=dev\` skipped it.

## Fix
\`deploy.sh\` now does \`npm ci\` (full install) → \`npm run build\` → \`npm prune --omit=dev\`. The end state on disk is identical to before: \`dist/\` is built and \`node_modules\` only contains production deps. The intermediate dev install is required just for the build step.

## Test plan
- [x] \`bash -n deploy/deploy.sh\`
- [ ] On CX33: \`git pull && ./deploy/deploy.sh\` → expect to clear the \`tsc: not found\` error and reach \`systemctl status warsaw-beer-bot\` = \`active (running)\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)