### PR TITLE
feat(bot): live progress for /refresh

### DIFF
--- a/src/bot/commands/refresh.test.ts
+++ b/src/bot/commands/refresh.test.ts
@@ -1,0 +1,52 @@
+import { makeThrottledProgress } from './refresh';
+
+describe('makeThrottledProgress', () => {
+  test('drops non-forced calls within interval', async () => {
+    let now = 1000;
+    const calls: string[] = [];
+    const send = async (t: string) => {
+      calls.push(t);
+    };
+    const notify = makeThrottledProgress(send, 100, () => now);
+
+    await notify('a');
+    await notify('b');
+    expect(calls).toEqual(['a']);
+
+    now += 50;
+    await notify('c');
+    expect(calls).toEqual(['a']);
+
+    now += 60;
+    await notify('d');
+    expect(calls).toEqual(['a', 'd']);
+  });
+
+  test('forced calls bypass throttle', async () => {
+    let now = 1000;
+    const calls: string[] = [];
+    const send = async (t: string) => {
+      calls.push(t);
+    };
+    const notify = makeThrottledProgress(send, 100000, () => now);
+
+    await notify('start', { force: true });
+    await notify('mid');
+    await notify('end', { force: true });
+    expect(calls).toEqual(['start', 'end']);
+  });
+
+  test('dedupes consecutive identical messages', async () => {
+    let now = 1000;
+    const calls: string[] = [];
+    const send = async (t: string) => {
+      calls.push(t);
+    };
+    const notify = makeThrottledProgress(send, 0, () => now);
+
+    await notify('a');
+    await notify('a');
+    await notify('a', { force: true });
+    expect(calls).toEqual(['a']);
+  });
+});

--- a/src/bot/commands/refresh.ts
+++ b/src/bot/commands/refresh.ts
@@ -1,10 +1,28 @@
 import { Composer } from 'telegraf';
 import type { BotContext } from '../index';
+import type { ProgressFn } from '../../jobs/progress';
 
 const COOLDOWN_MS = 5 * 60 * 1000;
+const PROGRESS_MIN_INTERVAL_MS = 2000;
 const lastCall = new Map<number, number>();
 
-export function createRefreshCommand(run: () => Promise<void>) {
+export function makeThrottledProgress(
+  send: (text: string) => Promise<void>,
+  intervalMs: number,
+  now: () => number = Date.now,
+): ProgressFn {
+  let lastAt = 0;
+  let lastText = '';
+  return async (text, opts) => {
+    if (text === lastText) return;
+    if (!opts?.force && now() - lastAt < intervalMs) return;
+    lastAt = now();
+    lastText = text;
+    await send(text);
+  };
+}
+
+export function createRefreshCommand(run: (notify: ProgressFn) => Promise<void>) {
   const cmd = new Composer<BotContext>();
   cmd.command('refresh', async (ctx) => {
     const prev = lastCall.get(ctx.from.id) ?? 0;
@@ -13,13 +31,23 @@ export function createRefreshCommand(run: () => Promise<void>) {
       return;
     }
     lastCall.set(ctx.from.id, Date.now());
-    await ctx.reply('Оновлюю…');
+
+    const status = await ctx.reply('⏳ Оновлюю…');
+    const notify = makeThrottledProgress(
+      async (text) => {
+        await ctx.telegram
+          .editMessageText(ctx.chat.id, status.message_id, undefined, text)
+          .catch(() => {});
+      },
+      PROGRESS_MIN_INTERVAL_MS,
+    );
+
     try {
-      await run();
-      await ctx.reply('✅ Готово.');
+      await run(notify);
+      await notify('✅ Готово.', { force: true });
     } catch (e) {
       ctx.deps.log.error({ err: e }, 'refresh failed');
-      await ctx.reply('❌ Не вдалось — подивись логи.');
+      await notify('❌ Не вдалось — подивись логи.', { force: true });
     }
   });
   return cmd;

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,9 +26,6 @@ async function main(): Promise<void> {
   const http = createHttp({ userAgent: env.NOMINATIM_USER_AGENT });
   const geocoder = createGeocoder({ userAgent: env.NOMINATIM_USER_AGENT });
 
-  const runOntap = () => refreshOntap({ db, log, http, geocoder });
-  const runUntappd = () => refreshAllUntappd({ db, log, http });
-
   const bot = createBot({ db, env, log });
   bot.use(
     startCommand,
@@ -37,17 +34,17 @@ async function main(): Promise<void> {
     newbeersCommand,
     routeCommand,
     filtersCommand,
-    createRefreshCommand(async () => {
-      await runOntap();
-      await runUntappd();
+    createRefreshCommand(async (notify) => {
+      await refreshOntap({ db, log, http, geocoder, onProgress: notify });
+      await refreshAllUntappd({ db, log, http, onProgress: notify });
     }),
   );
 
   cron.schedule('0 */12 * * *', () => {
-    runOntap().catch((e) => log.error({ err: e }, 'ontap cron'));
+    refreshOntap({ db, log, http, geocoder }).catch((e) => log.error({ err: e }, 'ontap cron'));
   });
   cron.schedule('0 3 * * *', () => {
-    runUntappd().catch((e) => log.error({ err: e }, 'untappd cron'));
+    refreshAllUntappd({ db, log, http }).catch((e) => log.error({ err: e }, 'untappd cron'));
   });
 
   bot.launch();

--- a/src/jobs/progress.ts
+++ b/src/jobs/progress.ts
@@ -1,0 +1,3 @@
+export type ProgressFn = (text: string, opts?: { force?: boolean }) => Promise<void>;
+
+export const noopProgress: ProgressFn = async () => {};

--- a/src/jobs/refresh-ontap.ts
+++ b/src/jobs/refresh-ontap.ts
@@ -10,21 +10,28 @@ import { upsertMatch } from '../storage/match_links';
 import { upsertBeer } from '../storage/beers';
 import { matchBeer } from '../domain/matcher';
 import { normalizeBrewery, normalizeName } from '../domain/normalize';
+import { noopProgress, type ProgressFn } from './progress';
 
 interface Deps {
   db: DB;
   log: pino.Logger;
   http: Http;
   geocoder: Geocoder;
+  onProgress?: ProgressFn;
 }
 
 export async function refreshOntap(deps: Deps): Promise<void> {
-  const { db, log, http, geocoder } = deps;
+  const { db, log, http, geocoder, onProgress = noopProgress } = deps;
+  await onProgress('🍻 ontap: парсю індекс…', { force: true });
   const indexHtml = await http.get('https://ontap.pl/warszawa');
   const indexPubs = parseWarsawIndex(indexHtml);
   log.info({ n: indexPubs.length }, 'ontap index parsed');
+  await onProgress(`🍻 ontap: 0/${indexPubs.length} пабів`, { force: true });
 
+  let i = 0;
+  let ok = 0;
   for (const ip of indexPubs) {
+    i++;
     try {
       const html = await http.get(`https://${ip.slug}.ontap.pl/`);
       const { pub, taps } = parsePubPage(html);
@@ -68,10 +75,13 @@ export async function refreshOntap(deps: Deps): Promise<void> {
           upsertMatch(db, t.beer_ref, beerId, 1.0);
         }
       }
+      ok++;
     } catch (e) {
       log.warn({ err: e, slug: ip.slug }, 'ontap pub refresh failed');
     }
+    await onProgress(`🍻 ontap: ${i}/${indexPubs.length} — ${ip.slug}`);
   }
+  await onProgress(`🍻 ontap: ✓ ${ok}/${indexPubs.length} пабів`, { force: true });
 }
 
 function listBeerCatalog(db: DB): { id: number; brewery: string; name: string }[] {

--- a/src/jobs/refresh-untappd.ts
+++ b/src/jobs/refresh-untappd.ts
@@ -6,17 +6,24 @@ import { allProfiles } from '../storage/user_profiles';
 import { upsertBeer, findBeerByNormalized } from '../storage/beers';
 import { mergeCheckin } from '../storage/checkins';
 import { normalizeBrewery, normalizeName } from '../domain/normalize';
+import { noopProgress, type ProgressFn } from './progress';
 
 interface Deps {
   db: DB;
   log: pino.Logger;
   http: Http;
+  onProgress?: ProgressFn;
 }
 
 export async function refreshAllUntappd(deps: Deps): Promise<void> {
-  const { db, log, http } = deps;
-  for (const p of allProfiles(db)) {
-    if (!p.untappd_username) continue;
+  const { db, log, http, onProgress = noopProgress } = deps;
+  const profiles = allProfiles(db).filter((p) => p.untappd_username);
+  await onProgress(`👤 untappd: 0/${profiles.length} профілів`, { force: true });
+
+  let i = 0;
+  let ok = 0;
+  for (const p of profiles) {
+    i++;
     try {
       const html = await http.get(`https://untappd.com/user/${p.untappd_username}/beer`);
       const items = parseUserBeerPage(html);
@@ -45,8 +52,11 @@ export async function refreshAllUntappd(deps: Deps): Promise<void> {
           venue: null,
         });
       }
+      ok++;
     } catch (e) {
       log.warn({ err: e, user: p.untappd_username }, 'untappd scrape failed');
     }
+    await onProgress(`👤 untappd: ${i}/${profiles.length} — ${p.untappd_username}`);
   }
+  await onProgress(`👤 untappd: ✓ ${ok}/${profiles.length} профілів`, { force: true });
 }


### PR DESCRIPTION
## Why
On the first CX33 run, \`/refresh\` replied \`Оновлюю…\` and then went silent for several minutes while \`refreshOntap\` walked ~50 ontap pubs and \`refreshAllUntappd\` scraped linked profiles. No way to tell from Telegram whether it was working or hung.

## What
A shared \`ProgressFn\` plumbed through both jobs, and a throttled \`editMessageText\` notifier on top of the initial \`⏳ Оновлюю…\` message.

- \`src/jobs/progress.ts\` — \`ProgressFn = (text, { force? }) => Promise<void>\` and a \`noopProgress\` default.
- \`refreshOntap\` and \`refreshAllUntappd\` take an optional \`onProgress\`. They emit:
  - phase start (forced)
  - per-item ticks: \`🍻 ontap: 12/47 — bracka\`, \`👤 untappd: 1/3 — yuriy\` (subject to throttle)
  - final \`✓\` summary (forced)
- \`src/bot/commands/refresh.ts\` — \`makeThrottledProgress(send, intervalMs, now?)\` drops non-forced calls within the window and dedupes identical text. Composer wires it to \`ctx.telegram.editMessageText\` on the original status message. Final ✅/❌ go through forced calls so they always land.
- \`src/index.ts\` — composition root passes the notifier in for the bot path; cron jobs still call the jobs without \`onProgress\` (noop falls in).

Throttle interval: 2s, same as \`/import\`'s progress strategy. Telegram's edit-rate to one chat is ~1/sec — 2s gives slack.

## Test plan
- [x] \`npm test\` — 20 suites / 47 tests pass (3 new tests cover throttle drop / force-bypass / dedup)
- [x] \`npm run typecheck\` and \`npm run build\` — clean
- [x] Local smoke (\`node dist/index.js\` with dummy token) → \`bot launched\` + 401 from Telegraf — composition root reaches network
- [ ] On CX33: trigger \`/refresh\` and watch the status message tick through ontap and untappd phases

🤖 Generated with [Claude Code](https://claude.com/claude-code)