### PR TITLE
fix(bot): detach /refresh from Telegraf handler timeout

### DIFF
--- a/src/bot/commands/refresh.ts
+++ b/src/bot/commands/refresh.ts
@@ -33,22 +33,32 @@ export function createRefreshCommand(run: (notify: ProgressFn) => Promise<void>)
     lastCall.set(ctx.from.id, Date.now());
 
     const status = await ctx.reply('⏳ Оновлюю…');
+    const chatId = ctx.chat.id;
+    const messageId = status.message_id;
+    const telegram = ctx.telegram;
+    const log = ctx.deps.log;
     const notify = makeThrottledProgress(
       async (text) => {
-        await ctx.telegram
-          .editMessageText(ctx.chat.id, status.message_id, undefined, text)
+        await telegram
+          .editMessageText(chatId, messageId, undefined, text)
           .catch(() => {});
       },
       PROGRESS_MIN_INTERVAL_MS,
     );
 
-    try {
-      await run(notify);
-      await notify('✅ Готово.', { force: true });
-    } catch (e) {
-      ctx.deps.log.error({ err: e }, 'refresh failed');
-      await notify('❌ Не вдалось — подивись логи.', { force: true });
-    }
+    // Detach the work: the refresh sweep takes minutes, but Telegraf's
+    // handlerTimeout (default 90s) would otherwise kill the handler and
+    // raise TimeoutError into bot.catch. Captured locals above keep the
+    // background promise independent of ctx's lifetime.
+    void (async () => {
+      try {
+        await run(notify);
+        await notify('✅ Готово.', { force: true });
+      } catch (e) {
+        log.error({ err: e }, 'refresh failed');
+        await notify('❌ Не вдалось — подивись логи.', { force: true });
+      }
+    })();
   });
   return cmd;
 }


### PR DESCRIPTION
## Why
Spotted in CX33 journal:

\`\`\`
TimeoutError: Promise timed out after 90000 milliseconds
  at Timeout._onTimeout (.../telegraf/.../p-timeout/index.js:39:64)
msg: bot error  // (bot.catch)
\`\`\`

Telegraf's default \`handlerTimeout\` is 90s. \`/refresh\` walks ~43 ontap pubs (sequential HTTPS + parse + DB writes) — that comfortably blows past 90s on the host. Adding the live-progress notifier (#12) doesn't help here: the handler is still awaiting the work, so the timeout still fires and \`bot.catch\` logs \`bot error\`. The 00:00 cron entry doesn't show the timeout because it doesn't go through Telegraf's update pipeline at all.

## Fix
Detach the work. The handler now returns as soon as the \`⏳ Оновлюю…\` message is sent; the refresh runs in a fire-and-forget IIFE that captures \`ctx.telegram\`, \`chatId\`, \`messageId\`, and \`log\` upfront. \`ctx.telegram\` is owned by the Telegraf instance and outlives any single handler, so \`editMessageText\` and the throttled notifier keep working through the whole sweep.

The 5-minute per-user cooldown is still set *before* the detach, so repeated \`/refresh\` during an in-flight sweep is still gated.

## Test plan
- [x] \`npm test\` — 20 suites / 47 tests pass (existing throttle tests stay green; the detach is a structural change in the handler, not in the throttle helper)
- [x] \`npm run typecheck\` and \`npm run build\` — clean
- [x] Local smoke (\`node dist/index.js\` with dummy token) — \`bot launched\` + 401, composition root reaches network
- [ ] On CX33: trigger \`/refresh\` and confirm the journal no longer shows \`TimeoutError\` after ~90s, and the status message keeps ticking through to \`✅ Готово.\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)