### PR TITLE
fix(ops): always restart the unit on deploy

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -26,5 +26,8 @@ sudo chown -R warsaw-beer-bot:warsaw-beer-bot "$APP"
 sudo -u warsaw-beer-bot bash -lc "cd $APP && npm ci && npm run build && npm prune --omit=dev"
 sudo install -m 0644 deploy/warsaw-beer-bot.service /etc/systemd/system/warsaw-beer-bot.service
 sudo systemctl daemon-reload
-sudo systemctl enable --now warsaw-beer-bot
+sudo systemctl enable warsaw-beer-bot
+# `enable --now` is a no-op on an already-running unit, so a redeploy with new
+# code would leave the old process in memory. Always restart explicitly.
+sudo systemctl restart warsaw-beer-bot
 sudo journalctl -u warsaw-beer-bot -n 30 --no-pager


### PR DESCRIPTION
## Why
After merging #12 (live progress) and #14 (detached /refresh), the host still showed \`/refresh\` ending at \`Оновлюю…\` → \`✅ Готово\` with no ticks, and \`systemctl status\` reported \`Active: active (running) since Sat 13:17:21 UTC; 21h ago\` — the in-memory process was the one from the *first* deploy. The new \`dist/\` was on disk in \`/opt/warsaw-beer-bot\` but never loaded.

Root cause: \`systemctl enable --now\` is a no-op on an already-running unit. It only starts the unit if it was inactive.

## Fix
Split into:
- \`systemctl enable\` — idempotent, ensures unit is wired into multi-user.target
- \`systemctl restart\` — always cycles the process so the new \`dist/\` is what's loaded

## Test plan
- [x] \`bash -n deploy/deploy.sh\`
- [ ] On CX33: \`git pull && ./deploy/deploy.sh\` → \`systemctl status\` should show \`Active: active (running) since just now\`, and a fresh \`bot launched\` line in the journal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)