### PR TITLE
feat(bot): /newbeers — group by beer, HTML formatting

### DIFF
--- a/docs/superpowers/plans/2026-04-26-newbeers-grouped.md
+++ b/docs/superpowers/plans/2026-04-26-newbeers-grouped.md
@@ -1,0 +1,71 @@
+# Plan: /newbeers — group by beer + format
+
+Closes ysilvestrov/warsaw-beer-bot#13 (duplicates) and #11 (formatting).
+
+## Scope
+
+Single PR `feat/newbeers-grouped` rewrites the response of the `/newbeers`
+handler. No schema, storage, or domain changes.
+
+## Decisions (confirmed by user)
+
+- **Group key**: `match_links.untappd_beer_id` when available; otherwise
+  fallback to `${normalizeBrewery(brewery_ref)}|${normalizeName(beer_ref)}`.
+  This collapses the same physical beer pulled from different ontap
+  pub-page strings, while still grouping unmatched ones sensibly.
+- **Per-line format** (Telegram HTML parse mode):
+  ```
+  1. <b>{beer name}</b>  ⭐ {rating}
+       · {pub1}, {pub2}, {pub3}
+  ```
+  Two lines per beer; `⭐ —` if rating is null.
+- **Pub-list cap**: max 3 pubs shown; if more, append `+N інших`.
+
+## Modules
+
+- New: `src/bot/commands/newbeers-format.ts`
+  - `interface CandidateTap { beer_id, beer_ref, brewery_norm, name_norm, rating, pub_name }`
+  - `interface BeerGroup { display, rating, pubs: string[] }`
+  - `groupTaps(taps: CandidateTap[]): BeerGroup[]`
+    - Group key as above.
+    - Per group: representative `display` = `beer_ref` of the highest-rated
+      tap (ties → first seen). `rating` = max non-null rating (or null).
+      `pubs` = unique pub names, alphabetically sorted (deterministic for tests).
+  - `rankGroups(groups: BeerGroup[]): BeerGroup[]`
+    - Sort: rating desc (nulls last), pub-count desc, display asc.
+  - `formatGroupedBeers(groups, { topN=15, maxPubs=3 }): string`
+    - HTML-escape `<>&` in every dynamic field.
+    - Numbered list, format as above. Empty input → empty string (caller
+      decides on the "Нічого цікавого" fallback).
+
+- New: `src/bot/commands/newbeers-format.test.ts`
+  - groupTaps: groups by matched id, dedups same id with different beer_ref;
+    falls back to normalized tuple for null id; chooses highest-rated
+    representative; ties broken stably.
+  - rankGroups: rating-then-pub-count-then-name; nulls last.
+  - formatGroupedBeers: pub cap with +N, HTML escaping, "—" for null rating,
+    numbering, empty input → "".
+
+- Modified: `src/bot/commands/newbeers.ts`
+  - Build `CandidateTap[]` directly from `latestSnapshotsPerPub` →
+    `tapsForSnapshot` → `filterInteresting`. Drop the per-pub top-3 cut
+    (it pre-emptively hid grouping options); instead pass everything to
+    `groupTaps` then trim with `topN` in formatter.
+  - `await ctx.replyWithHTML(text || 'Нічого цікавого — спробуй /refresh.')`.
+
+## Sequence (TDD)
+
+1. Write `newbeers-format.test.ts` with failing tests for the three exports.
+2. Implement `newbeers-format.ts` until green.
+3. Rewire `newbeers.ts` (handler stays a thin wrapper).
+4. `npm run typecheck && npm test && npm run build` → green.
+5. Smoke composition root locally with dummy token.
+6. Commit, PR `Closes #13, #11`.
+
+## Risks / non-goals
+
+- The previous per-pub top-3 cut is gone; if a single pub has 50 interesting
+  unmatched taps, it could skew the global list. Acceptable for MVP — we can
+  add a per-pub cap later if it bites.
+- HTML escape only on user-visible strings; rating is numeric. Should be
+  enough for Telegram parse mode without a full sanitizer.

--- a/src/bot/commands/newbeers-format.test.ts
+++ b/src/bot/commands/newbeers-format.test.ts
@@ -1,0 +1,143 @@
+import {
+  groupTaps,
+  rankGroups,
+  formatGroupedBeers,
+  type CandidateTap,
+  type BeerGroup,
+} from './newbeers-format';
+
+const tap = (over: Partial<CandidateTap> = {}): CandidateTap => ({
+  beer_id: null,
+  beer_ref: 'X',
+  brewery_norm: 'b',
+  name_norm: 'x',
+  rating: null,
+  pub_name: 'P',
+  ...over,
+});
+
+describe('groupTaps', () => {
+  test('groups by matched beer_id across pubs', () => {
+    const r = groupTaps([
+      tap({ beer_id: 1, beer_ref: 'Salamander', rating: 3.9, pub_name: 'Cuda' }),
+      tap({ beer_id: 1, beer_ref: 'Salamander IPA', rating: 3.8, pub_name: 'PiwPaw' }),
+    ]);
+    expect(r).toHaveLength(1);
+    expect(r[0].pubs).toEqual(['Cuda', 'PiwPaw']);
+    expect(r[0].rating).toBe(3.9);
+    expect(r[0].display).toBe('Salamander');
+  });
+
+  test('falls back to (brewery_norm,name_norm) when beer_id is null', () => {
+    const r = groupTaps([
+      tap({ beer_id: null, brewery_norm: 'b', name_norm: 'x', beer_ref: 'X', pub_name: 'A' }),
+      tap({ beer_id: null, brewery_norm: 'b', name_norm: 'x', beer_ref: 'X', pub_name: 'B' }),
+      tap({ beer_id: null, brewery_norm: 'b', name_norm: 'y', beer_ref: 'Y', pub_name: 'A' }),
+    ]);
+    expect(r).toHaveLength(2);
+    const xs = r.find((g) => g.display === 'X')!;
+    expect(xs.pubs).toEqual(['A', 'B']);
+  });
+
+  test('dedups identical pub names', () => {
+    const r = groupTaps([
+      tap({ beer_id: 1, pub_name: 'Cuda' }),
+      tap({ beer_id: 1, pub_name: 'Cuda' }),
+    ]);
+    expect(r[0].pubs).toEqual(['Cuda']);
+  });
+
+  test('group rating is max of non-null ratings', () => {
+    const r = groupTaps([
+      tap({ beer_id: 1, rating: null, pub_name: 'A' }),
+      tap({ beer_id: 1, rating: 3.5, pub_name: 'B' }),
+      tap({ beer_id: 1, rating: 3.9, pub_name: 'C' }),
+    ]);
+    expect(r[0].rating).toBe(3.9);
+  });
+
+  test('group rating null when all ratings null', () => {
+    const r = groupTaps([
+      tap({ beer_id: 1, rating: null, pub_name: 'A' }),
+      tap({ beer_id: 1, rating: null, pub_name: 'B' }),
+    ]);
+    expect(r[0].rating).toBeNull();
+  });
+});
+
+describe('rankGroups', () => {
+  const g = (display: string, rating: number | null, pubs: string[]): BeerGroup => ({
+    display,
+    rating,
+    pubs,
+  });
+
+  test('sorts by rating desc, nulls last', () => {
+    const r = rankGroups([g('a', null, ['p']), g('b', 3.9, ['p']), g('c', 4.0, ['p'])]);
+    expect(r.map((x) => x.display)).toEqual(['c', 'b', 'a']);
+  });
+
+  test('breaks rating ties by pub-count desc', () => {
+    const r = rankGroups([g('a', 3.9, ['p1']), g('b', 3.9, ['p1', 'p2', 'p3'])]);
+    expect(r.map((x) => x.display)).toEqual(['b', 'a']);
+  });
+
+  test('breaks pub-count ties by display asc', () => {
+    const r = rankGroups([g('b', 3.9, ['p1']), g('a', 3.9, ['p1'])]);
+    expect(r.map((x) => x.display)).toEqual(['a', 'b']);
+  });
+});
+
+describe('formatGroupedBeers', () => {
+  test('numbered list with bold name and rating', () => {
+    const text = formatGroupedBeers([{ display: 'Salamander', rating: 3.9, pubs: ['Cuda'] }]);
+    expect(text).toContain('1. <b>Salamander</b>');
+    expect(text).toContain('⭐ 3.9');
+    expect(text).toContain('· Cuda');
+  });
+
+  test('caps pub list at maxPubs and appends +N інших', () => {
+    const text = formatGroupedBeers(
+      [{ display: 'X', rating: 4.0, pubs: ['A', 'B', 'C', 'D', 'E'] }],
+      { maxPubs: 3 },
+    );
+    expect(text).toContain('A, B, C +2 інших');
+  });
+
+  test('renders null rating as ⭐ —', () => {
+    const text = formatGroupedBeers([{ display: 'X', rating: null, pubs: ['A'] }]);
+    expect(text).toContain('⭐ —');
+  });
+
+  test('HTML-escapes special chars in name and pubs', () => {
+    const text = formatGroupedBeers([
+      { display: 'Pivo & <Co>', rating: null, pubs: ['Bar & Grill'] },
+    ]);
+    expect(text).toContain('Pivo &amp; &lt;Co&gt;');
+    expect(text).toContain('Bar &amp; Grill');
+  });
+
+  test('respects topN', () => {
+    const groups: BeerGroup[] = Array.from({ length: 20 }, (_, i) => ({
+      display: `B${i}`,
+      rating: 5 - i * 0.1,
+      pubs: ['P'],
+    }));
+    const text = formatGroupedBeers(groups, { topN: 3 });
+    expect(text).toContain('1. <b>B0</b>');
+    expect(text).toContain('3. <b>B2</b>');
+    expect(text).not.toContain('4. <b>B3</b>');
+  });
+
+  test('empty input → empty string', () => {
+    expect(formatGroupedBeers([])).toBe('');
+  });
+
+  test('two-line layout per beer', () => {
+    const text = formatGroupedBeers([{ display: 'X', rating: 4.0, pubs: ['A', 'B'] }]);
+    const lines = text.split('\n');
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toMatch(/^1\. <b>X<\/b>/);
+    expect(lines[1]).toMatch(/^\s+· /);
+  });
+});

--- a/src/bot/commands/newbeers-format.ts
+++ b/src/bot/commands/newbeers-format.ts
@@ -1,0 +1,79 @@
+export interface CandidateTap {
+  beer_id: number | null;
+  beer_ref: string;
+  brewery_norm: string;
+  name_norm: string;
+  rating: number | null;
+  pub_name: string;
+}
+
+export interface BeerGroup {
+  display: string;
+  rating: number | null;
+  pubs: string[];
+}
+
+const groupKey = (t: CandidateTap): string =>
+  t.beer_id !== null ? `id:${t.beer_id}` : `nb:${t.brewery_norm}|${t.name_norm}`;
+
+const maxRating = (a: number | null, b: number | null): number | null => {
+  if (a === null) return b;
+  if (b === null) return a;
+  return a > b ? a : b;
+};
+
+export function groupTaps(taps: CandidateTap[]): BeerGroup[] {
+  const acc = new Map<
+    string,
+    { display: string; bestRating: number | null; pubs: Set<string> }
+  >();
+  for (const t of taps) {
+    const k = groupKey(t);
+    const cur = acc.get(k);
+    if (!cur) {
+      acc.set(k, { display: t.beer_ref, bestRating: t.rating, pubs: new Set([t.pub_name]) });
+      continue;
+    }
+    cur.pubs.add(t.pub_name);
+    if (t.rating !== null && (cur.bestRating === null || t.rating > cur.bestRating)) {
+      cur.display = t.beer_ref;
+    }
+    cur.bestRating = maxRating(cur.bestRating, t.rating);
+  }
+  return [...acc.values()].map((g) => ({
+    display: g.display,
+    rating: g.bestRating,
+    pubs: [...g.pubs].sort((a, b) => a.localeCompare(b)),
+  }));
+}
+
+export function rankGroups(groups: BeerGroup[]): BeerGroup[] {
+  return [...groups].sort((a, b) => {
+    const ra = a.rating ?? -Infinity;
+    const rb = b.rating ?? -Infinity;
+    if (rb !== ra) return rb - ra;
+    if (b.pubs.length !== a.pubs.length) return b.pubs.length - a.pubs.length;
+    return a.display.localeCompare(b.display);
+  });
+}
+
+const escapeHtml = (s: string): string =>
+  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+const fmtRating = (r: number | null): string =>
+  r === null ? '⭐ —' : `⭐ ${r.toFixed(2).replace(/\.?0+$/, '')}`;
+
+export function formatGroupedBeers(
+  groups: BeerGroup[],
+  opts: { topN?: number; maxPubs?: number } = {},
+): string {
+  const { topN = 15, maxPubs = 3 } = opts;
+  const lines: string[] = [];
+  groups.slice(0, topN).forEach((g, i) => {
+    const head = `${i + 1}. <b>${escapeHtml(g.display)}</b>  ${fmtRating(g.rating)}`;
+    const shown = g.pubs.slice(0, maxPubs).map(escapeHtml).join(', ');
+    const extra = g.pubs.length > maxPubs ? ` +${g.pubs.length - maxPubs} інших` : '';
+    lines.push(head, `     · ${shown}${extra}`);
+  });
+  return lines.join('\n');
+}

--- a/src/bot/commands/newbeers.ts
+++ b/src/bot/commands/newbeers.ts
@@ -4,8 +4,15 @@ import { latestSnapshotsPerPub, tapsForSnapshot } from '../../storage/snapshots'
 import { drunkBeerIds } from '../../storage/checkins';
 import { getMatch } from '../../storage/match_links';
 import { getFilters } from '../../storage/user_filters';
-import { filterInteresting, rankByRating } from '../../domain/filters';
+import { filterInteresting } from '../../domain/filters';
 import { listPubs } from '../../storage/pubs';
+import { normalizeBrewery, normalizeName } from '../../domain/normalize';
+import {
+  groupTaps,
+  rankGroups,
+  formatGroupedBeers,
+  type CandidateTap,
+} from './newbeers-format';
 
 export const newbeersCommand = new Composer<BotContext>();
 
@@ -22,26 +29,31 @@ newbeersCommand.command('newbeers', async (ctx) => {
     };
   const pubs = new Map(listPubs(db).map((p) => [p.id, p]));
 
-  const ranked: { pubName: string; beer: string; rating: number | null }[] = [];
+  const candidates: CandidateTap[] = [];
   for (const snap of latestSnapshotsPerPub(db)) {
+    const pub = pubs.get(snap.pub_id);
+    if (!pub) continue;
     const taps = tapsForSnapshot(db, snap.id).map((t) => ({
       beer_id: getMatch(db, t.beer_ref)?.untappd_beer_id ?? null,
       style: t.style,
       abv: t.abv,
       u_rating: t.u_rating,
       beer_ref: t.beer_ref,
+      brewery_ref: t.brewery_ref,
     }));
     const good = filterInteresting(taps, drunk, filters);
-    for (const t of rankByRating(good).slice(0, 3)) {
-      ranked.push({
-        pubName: pubs.get(snap.pub_id)!.name,
-        beer: t.beer_ref,
+    for (const t of good) {
+      candidates.push({
+        beer_id: t.beer_id,
+        beer_ref: t.beer_ref,
+        brewery_norm: normalizeBrewery(t.brewery_ref ?? ''),
+        name_norm: normalizeName(t.beer_ref),
         rating: t.u_rating,
+        pub_name: pub.name,
       });
     }
   }
 
-  ranked.sort((a, b) => (b.rating ?? 0) - (a.rating ?? 0));
-  const head = ranked.slice(0, 15).map((r) => `• ${r.beer} — ${r.pubName} (${r.rating ?? '—'})`);
-  await ctx.reply(head.length ? head.join('\n') : 'Нічого цікавого — спробуй /refresh.');
+  const text = formatGroupedBeers(rankGroups(groupTaps(candidates)));
+  await ctx.replyWithHTML(text || 'Нічого цікавого — спробуй /refresh.');
 });


### PR DESCRIPTION
Closes #13, closes #11.

## Why
- **#13**: previous /newbeers emitted one line per (pub, beer) pair, so a single popular beer on tap at three pubs ate three slots in the top-15.
- **#11**: response was plain text — hard to scan when a beer name and pub are on the same line.

## What
New pure-function module \`src/bot/commands/newbeers-format.ts\` (full unit-test coverage) handles grouping + ranking + rendering. The handler in \`newbeers.ts\` is now a thin wrapper.

- **Group key**: \`match_links.untappd_beer_id\` when present; fallback to \`(normalizeBrewery(brewery_ref), normalizeName(beer_ref))\` tuple.
- **Per-line format** (Telegram HTML parse mode):
  \`\`\`
  1. <b>Salamander</b>  ⭐ 3.92
       · Cuda na kiju, PiwPaw, Same Krafty +2 інших
  \`\`\`
  Pubs deduped, sorted alphabetically, capped at 3 with \`+N інших\`.
- **Rank**: rating desc → pub-count desc → display name asc.
- Removed the per-pub top-3 cut that pre-emptively hid grouping opportunities. Global topN (15) handles the cap.

## Test plan
- [x] \`npm test\` — 21 suites / 62 tests pass (15 new tests cover groupTaps / rankGroups / formatGroupedBeers including HTML escape, pub cap, null rating, tie-breaking)
- [x] \`npm run typecheck\` and \`npm run build\` — clean
- [x] Local smoke (\`node dist/index.js\` with dummy token) — \`bot launched\` + 401, composition root reaches network
- [ ] On CX33 after deploy: \`/newbeers\` should render the new layout, with grouped lines for beers that appear on multiple taps

Plan: \`docs/superpowers/plans/2026-04-26-newbeers-grouped.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)