### PR TITLE
docs(specs): post-PR-#30 rating + cleanup roadmap (4 specs)

### DIFF
--- a/docs/superpowers/specs/2026-04-30-cleanup-polluted-ontap-design.md
+++ b/docs/superpowers/specs/2026-04-30-cleanup-polluted-ontap-design.md
@@ -1,0 +1,151 @@
+# Cleanup ABV-Polluted Ontap Rows — Design Spec
+
+**Date:** 2026-04-30
+**Status:** Approved (design); pending plan + implementation
+**Related:** Continuation of `2026-04-29-brewery-alias-dedup.md` (out-of-scope cleanup task referenced in §14 lesson "ABV-polluted ontap rows").
+
+## Problem
+
+Before Task 25 (refresh-ontap parser cleanup), the bot stored full `<h4>` text from ontap.pl as the canonical beer name — including brewery prefix, ABV/strength markers, and style suffix. Example legacy row:
+
+```
+id=306, brewery="Wagabunda Brewery",
+  name="Wagabunda Brewery Oxymel 14°·4,5% — Sour Ale",
+  normalized_name="wagabunda brewery oxymel 14 4 5 ale"
+```
+
+Current parser produces clean rows for the same beer:
+
+```
+id=11877, brewery="Wagabunda Brewery", name="Oxymel",
+  normalized_name="oxymel"
+```
+
+Both rows coexist with `untappd_id=NULL`. The polluted row never matches any future tap (its normalized_name is junk) and pollutes `/newbeers`/`/route` rendering for any user whose drunk-set links to the polluted id.
+
+**Scope check (prod DB, 2026-04-30):** 495 of 663 ontap-side rows (≈75%) match the pollution pattern (name contains `\d+\s*[°%]` or ` — `). They linger from pre-Task 25 scrapes.
+
+## Goal
+
+A single idempotent startup job that:
+1. Detects polluted ontap-side rows.
+2. Re-derives the clean beer name with the existing parser's `extractBeerName(name, brewery)`.
+3. Either **merges** the polluted row into a canonical row (when `matchBeer` finds one with confidence ≥ 0.9), repointing `match_links` + `checkins`, or **rewrites in place** (`name`, `normalized_name`).
+
+Convergence: after first boot post-deploy the catalog is clean; subsequent boots find 0 polluted rows.
+
+## Non-goals
+
+- Re-scraping ontap.pl. The cleanup operates on existing DB state only.
+- Rewriting `brewery` field — `normalized_brewery` is already correct on these rows (the polluted suffix lives in `name`, not `brewery`).
+- Touching Untappd-side rows (`untappd_id IS NOT NULL`).
+
+## Architecture
+
+New file `src/jobs/cleanup-polluted-ontap.ts` exporting:
+
+```ts
+export interface CleanupResult {
+  rewritten: number;  // in-place name updates
+  merged: number;     // polluted rows folded into canonical and deleted
+}
+
+export function cleanupPollutedOntap(db: DB, log: pino.Logger): CleanupResult
+```
+
+Called in `src/index.ts` immediately after `dedupeBreweryAliases(db, log)`.
+
+### Detection
+
+SQLite has no JS regex; pull all `untappd_id IS NULL` rows once, filter in JS:
+
+```ts
+const POLLUTION_RE = /\d+(?:[.,]\d+)?\s*[°%]| — /;
+```
+
+The ` — ` (em-dash with spaces) catches style-suffix patterns even when ABV is absent. Either marker is sufficient.
+
+### Per-row algorithm
+
+```
+polluted = rows where untappd_id IS NULL AND name matches POLLUTION_RE
+clean_pool = rows in beers where id NOT IN polluted   // candidates for merge
+
+for each polluted row P:
+  cleaned = extractBeerName(P.name, P.brewery)
+  if cleaned is empty or normalizeName(cleaned) === normalizeName(P.name):
+    skip   // either nothing to clean, or cleanup didn't help
+  match = matchBeer({brewery: P.brewery, name: cleaned, abv: P.abv}, clean_pool)
+  if match and match.confidence >= 0.9:
+    // merge — repoint match_links + checkins, delete P
+    UPDATE match_links SET untappd_beer_id = match.id WHERE untappd_beer_id = P.id
+    UPDATE checkins    SET beer_id         = match.id WHERE beer_id        = P.id
+    DELETE FROM beers WHERE id = P.id
+    merged++
+  else:
+    // in-place rewrite
+    UPDATE beers
+       SET name = cleaned,
+           normalized_name = normalizeName(cleaned)
+     WHERE id = P.id
+    rewritten++
+```
+
+Whole pass wrapped in a single `db.transaction(...)` for atomicity. After commit, re-running the job finds 0 polluted rows (the rewrite makes them clean; merges remove them).
+
+### Match confidence threshold
+
+Threshold is **0.9** — covers exact (1.0) and near-exact fuzzy hits (≥0.9 means the searcher is highly confident the beer name is the same modulo whitespace/punctuation noise). Below 0.9 we fall back to in-place rewrite rather than risk merging unrelated beers.
+
+### Why import `extractBeerName` from `src/sources/ontap/pub.ts`
+
+It is already exported and unit-tested — same logic the live parser uses. Avoids reimplementing the brewery-prefix-strip + ABV-truncate heuristic, and guarantees consistency: any string the parser would produce, the cleanup converges on.
+
+## Files
+
+**New:**
+- `src/jobs/cleanup-polluted-ontap.ts`
+- `src/jobs/cleanup-polluted-ontap.test.ts`
+
+**Modified:**
+- `src/index.ts` — import + call after `dedupeBreweryAliases`.
+- `docs/superpowers/specs/2026-04-22-warsaw-beer-bot-design.md` — append §14 lesson entry.
+
+## Tests
+
+In-memory DB seeded via `migrate(db)` + `upsertBeer`:
+
+1. **Empty DB → no-op:** `{rewritten: 0, merged: 0}`.
+2. **Single polluted row, no canonical:** rewrites in place. `name` and `normalized_name` updated. Other fields untouched.
+3. **Polluted + canonical (Wagabunda Oxymel pair):** merges polluted into canonical. `match_links`, `checkins` repointed. Polluted row gone. Canonical intact.
+4. **Polluted with both ontap and untappd canonicals (matcher prefers untappd-side):** merges into untappd-side row (matcher returns lowest-id exact match; untappd-side typically lower id since imports run first). Verifies the cross-source merge path.
+5. **Two polluted rows resolving to the same clean name:** both merge into the same canonical (or, if no canonical exists, both rewrite in place — and become a duplicate pair the next dedup-aliases pass would handle).
+6. **Idempotent:** second invocation returns `{rewritten: 0, merged: 0}`.
+7. **Negative — clean row preserved:** rows without pollution markers are untouched.
+8. **Below-threshold fuzzy match (e.g., very different cleaned name) → in-place rewrite, not merge.**
+
+Add ≥1 unit test confirming the SQL-level transaction is atomic (kill mid-loop, no partial state) — optional, depends on test ergonomics.
+
+## Edge cases
+
+- **Cleaned name equals empty string** (h4 text was just brewery + ABV with no real beer name) — skip the row. Such rows are stuck in DB but harmless once the parser stops producing them.
+- **Brewery prefix in `name` doesn't match `brewery` field** (rare data drift) — `extractBeerName` falls through and returns name truncated only at ABV. Still typically an improvement; merge or rewrite as usual.
+- **Match returns the polluted row itself or another polluted row** — prevented by passing only the `clean_pool` (catalog minus all polluted ids) to `matchBeer`. Merge targets are guaranteed clean.
+- **Two polluted rows resolving to the same clean name with no clean canonical** — both rewrite in place and become a same-brewery duplicate pair. Out of scope for this job; the existing `dedupeBreweryAliases` and any future broader dedup pass will pick them up.
+
+## Risks
+
+- **Over-aggressive merge.** A polluted row whose cleaned name accidentally fuzzy-matches an unrelated clean beer (e.g., "Oxymel" vs "Oxytocin" — fast-fuzzy is forgiving). Mitigation: 0.9 threshold + `normalizeBrewery` must overlap (already enforced by `matchBeer`'s exact-then-fuzzy flow with brewery-aliased filter).
+- **In-place rewrite collides with existing clean row** of the same brewery + cleaned name. The `UPDATE` doesn't itself fail (no unique constraint on `normalized_name + normalized_brewery`), but creates a duplicate pair. Acceptable: the existing dedup-brewery-aliases job — or a future broader dedup — picks them up. Alternatively, after the rewrite step, run a second pass that merges any new same-brewery-and-cleaned-name pairs. Defer for now.
+
+## Lesson to log in §14
+
+```markdown
+- **Polluted ontap-row cleanup**: pre-Task 25 scrapes left ~500 rows where
+  `name` was the full `<h4>` text (brewery + name + ABV + style suffix).
+  Cleaned at startup by `src/jobs/cleanup-polluted-ontap.ts`: re-runs the
+  parser's `extractBeerName` on each ontap-side (`untappd_id IS NULL`) row
+  whose name still matches the pollution regex (`\d+[°%]` or ` — `), then
+  either merges into a canonical match (confidence ≥ 0.9, exact or
+  high-fuzzy) or rewrites in place. Idempotent — second boot finds 0 rows.
+```

--- a/docs/superpowers/specs/2026-04-30-import-global-rating-design.md
+++ b/docs/superpowers/specs/2026-04-30-import-global-rating-design.md
@@ -1,0 +1,136 @@
+# Capture `global_weighted_rating_score` From Untappd Imports — Design Spec
+
+**Date:** 2026-04-30
+**Status:** Approved (design); pending plan + implementation
+**Phase:** 0 of 4 in the post-PR-#30 follow-up sequence (Designs 3, 4, 1, 2).
+
+## Problem
+
+`beers.rating_global` is populated in only 232 of 11,979 catalog rows (≈ 1.9 %). Investigation found two upstream bugs:
+
+1. **`src/bot/commands/import.ts:64`** — the JSON / CSV import flow hard-codes `rating_global: null`. The Untappd export contains `global_weighted_rating_score` (and `global_rating_score`) for every row; both are silently dropped at ingestion. This explains the bulk of the gap: ~6 000 rows from `/import` runs all have NULL.
+2. **`src/jobs/refresh-untappd.ts:42`** — `rating_global: it.rating_score` is misuse of the user's *personal* rating (`data-rating` from profile-feed scrape) as if it were a global community rating. Wrong semantics. Out of scope here; the entire job is being rewritten in Design 4.
+
+This spec addresses bug 1: read `global_weighted_rating_score` from JSON / CSV imports and store it in `beers.rating_global`.
+
+## Goal
+
+After deploy, when the user re-runs `/import` on their existing Untappd export, every row that has `global_weighted_rating_score` in the export populates `beers.rating_global`. `upsertBeer`'s existing UPDATE branch (`src/storage/beers.ts:24`) already updates `rating_global` on existing rows, so the backfill is a one-shot user action: re-import → 6 000+ rows gain a real global rating in seconds.
+
+## Non-goals
+
+- Backfilling without a user `/import` action. The existing import flow already does the right thing once we stop dropping the field.
+- Capturing both `global_weighted_rating_score` and `global_rating_score`. We pick **weighted** — the value Untappd publicly displays on every beer page. Adding a second column would require migration and provide marginal value.
+- Reading `total_toasts`, `total_comments`, `flavor_profiles`, etc. Out of scope.
+- Fixing `refresh-untappd.ts` here. Rewritten in Design 4.
+
+## Choice: weighted vs. raw global
+
+Untappd's JSON export carries two fields:
+
+- `global_rating_score` — arithmetic mean of every check-in.
+- `global_weighted_rating_score` — Bayesian-weighted average; Untappd's public "rating" displayed on beer pages and in apps. Reduces low-volume distortion.
+
+We store **`global_weighted_rating_score`** as `beers.rating_global`. Rationale:
+
+- Matches what Untappd shows users elsewhere (consistency with mental model).
+- More robust to brand-new beers with three 5-star check-ins (raw mean overstates).
+- The fallback render path (Design 2) is meant to surface a representative rating; weighted is the right choice for that.
+
+If the field is absent (e.g. very old export format, or a free-tier export), we fall back to NULL.
+
+## Architecture
+
+Two file changes, both small.
+
+### `src/sources/untappd/export.ts`
+
+Add `global_rating: number | null` to the `Checkin` interface. Both `mapCsv` and `mapJson` read `global_weighted_rating_score` (column / key) and surface it on this field. Defensive: `numOrNull` already coerces missing/invalid values to `null`.
+
+```ts
+export interface Checkin {
+  // existing fields...
+  rating_score: number | null;        // user's personal rating (unchanged)
+  global_rating: number | null;        // NEW — Untappd weighted global
+}
+
+function mapCsv(r: Record<string, string>): Checkin {
+  return {
+    // ...
+    rating_score: numOrNull(r['rating_score']),
+    global_rating: numOrNull(r['global_weighted_rating_score']),
+    // ...
+  };
+}
+
+function mapJson(r: Record<string, unknown>): Checkin {
+  return {
+    // ...
+    rating_score: numOrNull(r['rating_score']),
+    global_rating: numOrNull(r['global_weighted_rating_score']),
+    // ...
+  };
+}
+```
+
+### `src/bot/commands/import.ts:64`
+
+Replace `rating_global: null` with `rating_global: r.global_rating`.
+
+```ts
+const beerId = upsertBeer(db, {
+  // ...
+  rating_global: r.global_rating,
+  // ...
+});
+```
+
+That's the entire functional change.
+
+## Files
+
+**Modified:**
+- `src/sources/untappd/export.ts` — interface field + read in two mappers.
+- `src/sources/untappd/export.test.ts` — assertions for the new field (CSV + JSON).
+- `src/bot/commands/import.ts` — pass-through.
+
+**Not modified:** schema, storage helpers, other commands.
+
+## Tests
+
+Append to `src/sources/untappd/export.test.ts`:
+
+1. **CSV row with `global_weighted_rating_score=3.66`** → `Checkin.global_rating === 3.66`.
+2. **JSON row with `global_weighted_rating_score=3.66`** → same.
+3. **CSV row missing column** → `Checkin.global_rating === null`.
+4. **JSON row missing key** → `Checkin.global_rating === null`.
+5. **CSV row with empty string `""`** → `Checkin.global_rating === null` (`numOrNull` already handles this; just verify).
+
+Existing tests should pass unchanged — `rating_score` semantics are untouched.
+
+No need for an `import.ts` integration test; the change is a single field assignment, covered by the unit test on `mapJson` / `mapCsv` plus the existing import smoke (which still asserts row counts and basic shape).
+
+## Operational rollout
+
+After merge + deploy:
+- Tell the user (in PR description) to run `/import` once with their existing JSON / CSV export. `upsertBeer` UPDATEs `rating_global` on existing rows; ≈ 6 000 rows get a non-NULL global rating. `/newbeers` and `/route` start using the new fallback (Design 2) once that lands.
+- New imports automatically populate the field going forward.
+
+## Lesson to log in §14 of the canonical spec
+
+Append after the brewery-alias dedup entry (commit during implementation, not in this spec doc):
+
+```markdown
+- **Untappd `global_weighted_rating_score`**: the public "rating" Untappd
+  shows on each beer page. Untappd JSON / CSV exports include it on every
+  row. Read into `beers.rating_global` at `/import` time
+  (`src/sources/untappd/export.ts` + `src/bot/commands/import.ts`).
+  Re-importing the same export backfills `rating_global` for existing rows
+  via `upsertBeer`'s UPDATE branch — no migration needed.
+```
+
+## Risks
+
+- **Old export format without `global_weighted_rating_score`.** Defensive: `null` fallback. Backfill skipped for those rows; same outcome as today.
+- **Untappd renames the field in future exports.** Single line to update; no schema impact.
+- **Weighted vs. raw mismatch.** If we ever switch to raw, it's a one-line change in two mappers. Not enough churn risk to add a column.

--- a/docs/superpowers/specs/2026-04-30-rating-fallback-design.md
+++ b/docs/superpowers/specs/2026-04-30-rating-fallback-design.md
@@ -1,0 +1,127 @@
+# Rating Fallback to Catalog `rating_global` — Design Spec
+
+**Date:** 2026-04-30
+**Status:** Approved (design); pending plan + implementation
+
+## Problem
+
+`/newbeers` and `/route` render `⭐ —` whenever ontap.pl's tap snapshot lacks a Untappd rating (`tap.u_rating` is NULL). This is the case for any beer ontap.pl couldn't link to Untappd at scrape time — common for new releases or beers under non-canonical names.
+
+The bot's catalog often has a non-NULL `rating_global` for the same beer (sourced from a previous scrape of a different pub, or from the user's Untappd refresh job). Today this catalog rating is unused at render time.
+
+**Scope check (prod DB, 2026-04-30):** 232 of 11,979 catalog rows have `rating_global` populated (1.9%). User-visible impact is small but strict improvement; no risk of showing wrong data because both sources are global Untappd ratings.
+
+## Goal
+
+When a tap surfaces in `/newbeers` or `/route`:
+- If `tap.u_rating` is non-NULL → use it (current behavior).
+- Else if the tap is matched to a catalog row whose `rating_global` is non-NULL → use `rating_global`.
+- Else → render `⭐ —` (current fallback).
+
+Render layer is unchanged. Fallback is **transparent** — no asterisk, no dim star (per user decision; both values are equivalent global Untappd ratings).
+
+## Non-goals
+
+- Backfilling `taps.u_rating` at write time. Snapshots stay raw — they record what ontap.pl showed at scrape time, even if that was NULL. Fallback lives at read time only.
+- Visual distinction between rating sources.
+- Fallback for filters' `min_rating` threshold? **In scope** as a side-effect — `filterInteresting` operates on the same `u_rating` field, so it now sees fallback values. This is desirable: a beer the user filtered out for "low rating" shouldn't be excluded just because ontap.pl didn't return a rating.
+
+## Architecture
+
+Single-query JOIN: replace the per-tap `getMatch(...)` lookup in `/newbeers` and `/route` with a new storage helper that does match + rating coalesce in one SQL.
+
+### New helper
+
+`src/storage/snapshots.ts`:
+
+```ts
+export interface TapWithBeer extends TapRow {
+  beer_id: number | null;
+  // u_rating field on the parent TapRow is now the COALESCEd value:
+  // tap.u_rating ?? beers.rating_global ?? null
+}
+
+export function tapsForSnapshotWithBeer(db: DB, snapshotId: number): TapWithBeer[] {
+  return db.prepare(`
+    SELECT
+      t.id, t.snapshot_id, t.tap_number, t.beer_ref, t.brewery_ref,
+      t.abv, t.ibu, t.style,
+      COALESCE(t.u_rating, b.rating_global) AS u_rating,
+      ml.untappd_beer_id AS beer_id
+    FROM taps t
+    LEFT JOIN match_links ml ON t.beer_ref = ml.ontap_ref
+    LEFT JOIN beers b ON ml.untappd_beer_id = b.id
+    WHERE t.snapshot_id = ?
+    ORDER BY t.tap_number
+  `).all(snapshotId) as TapWithBeer[];
+}
+```
+
+The `LEFT JOIN`s preserve unmatched taps (`beer_id` becomes NULL, `u_rating` stays as raw `tap.u_rating`).
+
+### Caller refactor
+
+`src/bot/commands/newbeers.ts:36-43` and the matching block in `src/bot/commands/route.ts`:
+
+**Before:**
+```ts
+const taps = tapsForSnapshot(db, snap.id).map((t) => ({
+  beer_id: getMatch(db, t.beer_ref)?.untappd_beer_id ?? null,
+  style: t.style,
+  abv: t.abv,
+  u_rating: t.u_rating,
+  beer_ref: t.beer_ref,
+  brewery_ref: t.brewery_ref,
+}));
+```
+
+**After:**
+```ts
+const taps = tapsForSnapshotWithBeer(db, snap.id);
+```
+
+`taps` is now directly compatible with `filterInteresting` and the candidate-construction loop because `TapWithBeer` already exposes `beer_id`, `u_rating`, `beer_ref`, `brewery_ref`, `style`, `abv`.
+
+## Files
+
+**Modified:**
+- `src/storage/snapshots.ts` — add `tapsForSnapshotWithBeer` + type. Keep `tapsForSnapshot` (still used internally for raw-tap reads, e.g., when ingesting).
+- `src/storage/snapshots.test.ts` — fallback tests (see below).
+- `src/bot/commands/newbeers.ts` — replace per-tap `getMatch` with new helper.
+- `src/bot/commands/route.ts` — same.
+- (Optional) `src/bot/commands/newbeers.ts` — drop unused `getMatch` import if no remaining call sites.
+
+**Not modified:** rendering code (`newbeers-format.ts`, `route-format.ts`), filter code (`filters.ts`). They consume `u_rating` blindly.
+
+## Tests
+
+New tests in `src/storage/snapshots.test.ts`:
+
+1. **Tap with non-NULL `u_rating` and no matched beer** → returns `u_rating` from tap, `beer_id: null`.
+2. **Tap with NULL `u_rating`, matched to a beer with `rating_global`** → returns `rating_global` as `u_rating`, `beer_id` set.
+3. **Tap with non-NULL `u_rating`, matched to a beer with different `rating_global`** → returns tap's `u_rating` (not catalog) — fallback only kicks in on NULL. (Verifies COALESCE order.)
+4. **Tap with NULL `u_rating`, matched to a beer with NULL `rating_global`** → returns NULL, `beer_id` set.
+5. **Tap unmatched** → returns NULL u_rating, NULL beer_id.
+
+Existing `/newbeers` and `/route` integration tests should keep passing without changes (the field semantics are preserved; new fallback only activates when `tap.u_rating` was previously NULL).
+
+## Risks
+
+- **Stale catalog rating.** If a beer's Untappd rating drifted since it was scraped from another pub, the fallback shows yesterday's number. Acceptable: the alternative is `⭐ —`, which is strictly less informative. Catalog ratings refresh whenever ontap re-scrapes a pub that does carry the rating.
+- **Filter side-effects.** `min_rating` filter now applies to fallback ratings. This is desirable (closes a current loophole where unmatched taps bypassed the filter). Worth a release-note line.
+- **Query cost.** Two extra LEFT JOINs per snapshot read. With <100 taps per snapshot and indexed `match_links.ontap_ref` + `beers.id` (PK), negligible.
+
+## Migration
+
+None. Pure read-time change.
+
+## Lesson to log in §14
+
+```markdown
+- **Rating fallback (catalog → tap)**: `tap.u_rating` is the rating ontap.pl
+  showed at scrape time; often NULL when ontap.pl hasn't matched the beer
+  to Untappd. `tapsForSnapshotWithBeer` (`src/storage/snapshots.ts`) now
+  COALESCEs into `beers.rating_global` from the matched catalog row,
+  giving render and `min_rating` filter a usable rating in the ~2 % of
+  rows where the catalog has one but the tap doesn't.
+```

--- a/docs/superpowers/specs/2026-04-30-untappd-beers-scraper-design.md
+++ b/docs/superpowers/specs/2026-04-30-untappd-beers-scraper-design.md
@@ -1,0 +1,196 @@
+# Replace Untappd Profile-Feed Scraper With `/beers` Page Scraper — Design Spec
+
+**Date:** 2026-04-30
+**Status:** Approved (design); pending plan + implementation
+**Phase:** 1 of 4 in the post-PR-#30 follow-up sequence (Designs 3, 4, 1, 2).
+
+## Problem
+
+`src/jobs/refresh-untappd.ts` is broken at three layers and has been quietly producing junk for the bot's lifetime:
+
+1. **Wrong URL.** Line 28: `https://untappd.com/user/${username}/beer` (singular). This URL returns HTTP 303, redirecting to `/user/<username>` (the profile summary). We've been scraping the redirect target — a profile feed of recent activity — not the beer list.
+2. **Wrong selectors for the wrong page.** `parseUserBeerPage` (`src/sources/untappd/scraper.ts`) targets `.item[data-checkin-id]` and `a.time.timezoner` — selectors written for the activity feed it accidentally landed on, not the beer list it intended to land on. The fixture `tests/fixtures/untappd/user-beer.html` corroborates this: 5 `.item[data-checkin-id]` rows, no global ratings, name singular.
+3. **Wrong field semantics.** Line 42: `rating_global: it.rating_score` — stores the *user's* rating from the redirect-target activity feed as `rating_global`. Eleven untappd-side rows in prod were populated this way; all hold the user's personal rating in a field that should hold the Untappd community rating.
+
+End result: 11 catalog rows out of ~6 000 from this user have a non-NULL `rating_global`, and that value is wrong.
+
+## Goal
+
+Repurpose the job to do what it always meant to do: refresh global community ratings for the user's most recent ~25 distinct beers. This is the ceiling Untappd lets us scrape unauthenticated — `/user/<X>/beers?start=N` and similar query parameters are server-side ignored, "Show More" links to a login wall, and rate-limiting precludes per-beer detail-page scraping for 6 000 beers.
+
+The bulk of `rating_global` backfill therefore comes from Design 3 (`/import` reads `global_weighted_rating_score`). This job's role is **incremental top-up**: catch new beers and updated global ratings between full imports.
+
+## Non-goals
+
+- Bypassing Untappd's auth / pagination boundary. No cookie injection, no headless browser, no API key ladder. Single unauthenticated GET.
+- Synthesising fake check-ins. `/beers` is an aggregate per-beer view (no check-in IDs, no timestamps, no venues). The scraper updates `beers.rating_global` only — `mergeCheckin` is dropped from this code path. CSV / JSON imports remain the only source of truth for the `checkins` table.
+- Refreshing the user's personal rating. /beers does expose "Their Rating", but `checkins.user_rating` is per-checkin and CSV-sourced; introducing a separate per-beer aggregate user rating column would require a schema decision out of scope here.
+- Updating `name`, `brewery`, `style`, or `abv` on existing rows from `/beers`. Avoid clobbering CSV-import canonical fields with potentially-truncated scraped strings. New rows (no prior import) get whatever `/beers` provides.
+
+## Architecture
+
+### URL change
+
+```
+- https://untappd.com/user/${username}/beer
++ https://untappd.com/user/${username}/beers
+```
+
+Returns HTTP 200 with the user's distinct-beers list (~25 items per fetch unauthenticated). Confirmed with manual `curl -sIL` against `/user/ysilvestrov/beers`.
+
+### New scraper: `parseUserBeersPage(html)`
+
+Replaces `parseUserBeerPage`. Located in the same file (`src/sources/untappd/scraper.ts`), keeping the module boundary intact.
+
+**Page structure** (sampled from a live fetch on 2026-04-30):
+
+```html
+<div class="beer-item" data-bid="6455502">
+  <div class="beer-details">
+    <p class="name"><a href="/b/.../6455502">Captain Hazy - Foreign Legion 2025</a></p>
+    <p class="brewery"><a href="/KompaanBier">KOMPAAN Dutch Craft Beer Company</a></p>
+    <p class="style">Bock - Doppelbock</p>
+    <div class="ratings">
+      <div class="you">
+        <p>Their Rating (4)</p>
+        <div class="rating_bar_awesome">
+          <div class="caps" data-rating="4">...</div>
+        </div>
+      </div>
+      <div class="you">
+        <p>Global Rating (3.73)</p>
+        <div class="rating_bar_awesome">
+          <div class="caps" data-rating="3.73">...</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+`Global Rating` may be `(N/A)` for very new releases — parse to `null` then.
+
+**Output type:**
+
+```ts
+export interface ScrapedBeer {
+  bid: number;
+  beer_name: string;
+  brewery_name: string;
+  style: string | null;
+  their_rating: number | null;     // user's overall rating; informational, not stored today
+  global_rating: number | null;    // Untappd community rating → beers.rating_global
+}
+
+export function parseUserBeersPage(html: string): ScrapedBeer[];
+```
+
+**Selector strategy** (cheerio):
+
+- Items: `$('.beer-item[data-bid]')`. Cap at first 25 (matches what unauth gets).
+- `bid`: `data-bid` attribute, parsed.
+- `beer_name`: `.beer-details .name a`, text, whitespace-normalised.
+- `brewery_name`: `.beer-details .brewery a`, text.
+- `style`: `.beer-details .style`, text, blank → `null`.
+- `their_rating` and `global_rating`: scope to `.beer-details .ratings .you`. Each `.you` has a `<p>` with text matching `Their Rating (...)` or `Global Rating (...)`. Inside, `.caps[data-rating]` gives the value. `data-rating="N/A"` or absent → `null`.
+
+Two `.caps[data-rating]` per item — discriminate by the parent `.you > p` text. (No relying on order in case Untappd reorders.)
+
+### `src/jobs/refresh-untappd.ts` rewrite
+
+Streamlined to the new paradigm:
+
+```ts
+for (const p of profiles) {
+  const html = await http.get(`https://untappd.com/user/${p.untappd_username}/beers`);
+  const items = parseUserBeersPage(html);
+  for (const it of items) {
+    const nb = normalizeBrewery(it.brewery_name);
+    const nn = normalizeName(it.beer_name);
+    const existing = findBeerByNormalized(db, nb, nn);
+    if (existing) {
+      // Update only rating_global; leave other fields alone.
+      db.prepare('UPDATE beers SET rating_global = ? WHERE id = ?')
+        .run(it.global_rating, existing.id);
+    } else {
+      upsertBeer(db, {
+        untappd_id: it.bid,
+        name: it.beer_name,
+        brewery: it.brewery_name,
+        style: it.style,
+        abv: null,                  // /beers doesn't carry ABV
+        rating_global: it.global_rating,
+        normalized_name: nn,
+        normalized_brewery: nb,
+      });
+    }
+  }
+}
+```
+
+`mergeCheckin` is gone from this path. Profile feed iteration unchanged.
+
+### Test fixture
+
+Replace `tests/fixtures/untappd/user-beer.html` with `tests/fixtures/untappd/user-beers.html` — a saved live fetch of `/user/ysilvestrov/beers`. Curated down to ~3 representative items if size matters for repo footprint, but full ~25-item page is acceptable (it's already 215 KB; comparable to existing fixture).
+
+## Files
+
+**Modified:**
+- `src/sources/untappd/scraper.ts` — replace `parseUserBeerPage` → `parseUserBeersPage`. New types.
+- `src/sources/untappd/scraper.test.ts` — rewrite for new selectors + new interface.
+- `src/jobs/refresh-untappd.ts` — new URL, call new scraper, drop `mergeCheckin` block, drop `it.rating_score` misuse.
+
+**Replaced:**
+- `tests/fixtures/untappd/user-beer.html` → `tests/fixtures/untappd/user-beers.html` (live re-fetch).
+
+**Removed:**
+- None — no schema or storage changes.
+
+## Tests
+
+`src/sources/untappd/scraper.test.ts` (rewrite):
+
+1. **Parses every `.beer-item` in fixture.** Length matches manually counted items.
+2. **First item happy path.** Verifies bid, name, brewery, style, both ratings on a known fixture row.
+3. **Beer with `Global Rating (N/A)`** → `global_rating === null`, other fields populated.
+4. **Their Rating present, Global Rating present** → both numeric.
+5. **Cap to first 25 items** even if fixture happens to contain more (defensive; the live page may grow if Untappd changes layout).
+6. **Empty page or no `.beer-item`** → empty array.
+7. **Malformed `data-bid` (non-numeric)** → item skipped, others kept.
+
+Add to `src/jobs/refresh-untappd.test.ts` (or create if missing):
+
+1. **End-to-end: scraped beer absent from DB → upserted with rating_global from `global_rating`.**
+2. **End-to-end: scraped beer matches existing row by normalized name+brewery → only rating_global updated; name/brewery/style/abv untouched.**
+3. **`global_rating === null` → row's rating_global set to NULL (or untouched, depending on implementation; spec one explicitly).**
+
+For (3), pick **set to NULL** — it's an authoritative read, "we just checked Untappd and they have no global rating". This makes refresh idempotent.
+
+## Risks
+
+- **Untappd HTML change.** Already happened once between when this scraper was written and now. Mitigation: tight selectors, defensive `null` parsing, the bot has logged retries via `log.warn` on `try/catch`. A future Untappd redesign costs us the scraper; CSV / JSON imports (Design 3) remain.
+- **The 25-item cap is silently lossy** if a user has more than 25 new beers since last refresh. Acceptable — the next `/import` covers the gap.
+- **Rate-limiting / Cloudflare.** Untappd has been known to gate logged-out scrapes. Today's fetch worked unauthenticated; if it stops working, we have CSV / JSON imports as the safety net.
+- **`their_rating` is collected but unused.** Reserved field for future use; documented in code as such, not piped to storage. Kept on the scraped type so the scraper is reusable later if we add a per-beer user-rating column.
+
+## Operational notes
+
+- No DB migration.
+- No env var changes.
+- Roll-out order: ship Design 3 first (so `/import` populates `rating_global` for the bulk), then this job (incremental top-up). The two together close the gap end-to-end.
+- After deploy, the job runs on the existing cron schedule (no schedule change). First run will rate-update ≤ 25 beers per profile; subsequent runs converge fast.
+
+## Lesson to log in §14 of the canonical spec
+
+```markdown
+- **Untappd `/user/<X>/beers` scraper**: fetches the user's distinct-beers
+  list (top ~25 unauthenticated) for an incremental refresh of
+  `beers.rating_global`. Replaces a multi-layered broken predecessor that
+  hit `/beer` (which 303-redirects), used activity-feed selectors
+  (`.item[data-checkin-id]`), and stored the user's personal rating in
+  `rating_global`. Bulk backfill of `rating_global` is the `/import` path
+  (Design 3); this job catches new releases and rating drift between
+  imports. `/beers` does not paginate unauthenticated, so the 25-item cap
+  is a hard ceiling.
+```


### PR DESCRIPTION
## Summary
Чотири design-specs, що випливли з розслідування «Wagabunda Brewery Oxymel ⭐ —» (rating_global порожній у 232/11979 рядках; refresh-untappd мовчки поламаний на 3 шарах). Жодних code-змін — лише дизайн-документи. Імплементація — окремими PR'ами по фазах.

| Phase | Spec | Мета |
|---|---|---|
| 0 | `2026-04-30-import-global-rating-design.md` | `/import` зчитує `global_weighted_rating_score` → бекфіл ~6 000 рядків через re-import |
| 1 | `2026-04-30-untappd-beers-scraper-design.md` | refresh-untappd: `/beer` (303) → `/beers`, новий парсер, top-25 incremental, drop fake-checkins |
| 2 | `2026-04-30-cleanup-polluted-ontap-design.md` | очистити 495 legacy ABV-polluted ontap-side рядків (idempotent startup-job; threshold 0.9) |
| 3 | `2026-04-30-rating-fallback-design.md` | `/newbeers` + `/route` рендерять `COALESCE(tap.u_rating, beers.rating_global)` |

## Ключові дизайн-рішення
- **Phase 0:** `global_weighted_rating_score` (те, що Untappd публічно показує), не raw mean. Без міграції — `upsertBeer` UPDATE-гілка вже хендлить.
- **Phase 1:** 25-item cap прийнятий (без login-трюків); `mergeCheckin` випилюється з цього шляху (CSV/JSON залишається source-of-truth для `checkins`); name/brewery/style/abv не перезаписуються на existing rows.
- **Phase 2:** merge threshold 0.9 (exact + high-fuzzy); catalog для match виключає інші polluted-рядки → merge targets гарантовано чисті.
- **Phase 3:** прозорий fallback без візуального маркера; read-time COALESCE у новому хелпері `tapsForSnapshotWithBeer`.

## Test plan
- [x] Specs читабельні, без placeholder-ів, внутрішньо узгоджені.
- [x] Code review дизайну ще до імплементації — є шанс зловити хибні припущення дешево.
- [x] Перевірити, що порядок фаз ОК: 0 → 1 → 2 → 3 (3 множить ефект 0+1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)