### PR TITLE
fix(storage): upsertBeer matches by untappd_id first to survive normalization drift

### DIFF
--- a/src/storage/beers.test.ts
+++ b/src/storage/beers.test.ts
@@ -28,3 +28,78 @@ test('upsertBeer inserts then updates by normalized key', () => {
 test('findBeerByNormalized returns null when absent', () => {
   expect(findBeerByNormalized(fresh(), 'x', 'y')).toBeNull();
 });
+
+test('upsertBeer matches by untappd_id when normalization drifts', () => {
+  // Simulates the production state where a row was stored under one
+  // normalized form (e.g. legacy "captain hazy foreign legion" without
+  // numeric tokens) and re-import passes a different normalized form
+  // (current "captain hazy foreign legion 2025"). Without the
+  // untappd_id-first lookup, the SELECT misses, INSERT fires, and the
+  // UNIQUE constraint on beers.untappd_id throws.
+  const db = fresh();
+  const oldId = upsertBeer(db, {
+    untappd_id: 6455502,
+    name: 'Captain Hazy - Foreign Legion 2025',
+    brewery: 'KOMPAAN Dutch Craft Beer Company',
+    style: null, abv: null, rating_global: null,
+    normalized_name: 'captain hazy foreign legion',
+    normalized_brewery: 'kompaan dutch craft beer',
+  });
+  const newId = upsertBeer(db, {
+    untappd_id: 6455502,
+    name: 'Captain Hazy - Foreign Legion 2025',
+    brewery: 'KOMPAAN Dutch Craft Beer Company',
+    style: 'Bock - Doppelbock', abv: 8.0, rating_global: 3.55,
+    normalized_name: 'captain hazy foreign legion 2025',
+    normalized_brewery: 'kompaan dutch craft beer',
+  });
+  expect(newId).toBe(oldId);
+  const row = db
+    .prepare('SELECT name, style, abv, rating_global, normalized_name FROM beers WHERE id = ?')
+    .get(oldId) as { name: string; style: string; abv: number; rating_global: number; normalized_name: string };
+  expect(row.rating_global).toBeCloseTo(3.55);
+  expect(row.style).toBe('Bock - Doppelbock');
+  expect(row.normalized_name).toBe('captain hazy foreign legion 2025');
+});
+
+test('upsertBeer falls back to (normalized_brewery, normalized_name) when untappd_id is null', () => {
+  const db = fresh();
+  const id1 = upsertBeer(db, {
+    untappd_id: null, name: 'Foo', brewery: 'Bar',
+    style: null, abv: null, rating_global: null,
+    normalized_name: 'foo', normalized_brewery: 'bar',
+  });
+  const id2 = upsertBeer(db, {
+    untappd_id: null, name: 'Foo', brewery: 'Bar',
+    style: null, abv: 5.0, rating_global: null,
+    normalized_name: 'foo', normalized_brewery: 'bar',
+  });
+  expect(id2).toBe(id1);
+});
+
+test('upsertBeer prefers untappd_id row over a normalized-only match', () => {
+  // A canonical Untappd-side row exists with bid=42; an orphan ontap-side
+  // row exists with same normalized but null bid. Re-importing the bid'd
+  // beer must update the canonical, not the orphan.
+  const db = fresh();
+  const canonId = upsertBeer(db, {
+    untappd_id: 42, name: 'Foo', brewery: 'Bar',
+    style: null, abv: null, rating_global: null,
+    normalized_name: 'foo', normalized_brewery: 'bar',
+  });
+  const orphanId = upsertBeer(db, {
+    untappd_id: null, name: 'Foo', brewery: 'Bar',
+    style: null, abv: null, rating_global: null,
+    normalized_name: 'foo extra', normalized_brewery: 'bar',
+  });
+  expect(orphanId).not.toBe(canonId);
+  // Re-import: bid=42, but the data lookup happens to also match orphan by normalized
+  const updatedId = upsertBeer(db, {
+    untappd_id: 42, name: 'Foo Renamed', brewery: 'Bar',
+    style: null, abv: null, rating_global: 4.0,
+    normalized_name: 'foo extra', normalized_brewery: 'bar',
+  });
+  expect(updatedId).toBe(canonId);
+  const orphan = db.prepare('SELECT name FROM beers WHERE id = ?').get(orphanId) as { name: string };
+  expect(orphan.name).toBe('Foo'); // orphan untouched
+});

--- a/src/storage/beers.ts
+++ b/src/storage/beers.ts
@@ -14,16 +14,30 @@ export interface BeerInput {
 export interface BeerRow extends BeerInput { id: number; }
 
 export function upsertBeer(db: DB, b: BeerInput): number {
-  const existing = db
-    .prepare('SELECT id FROM beers WHERE normalized_brewery = ? AND normalized_name = ?')
-    .get(b.normalized_brewery, b.normalized_name) as { id: number } | undefined;
+  // Prefer match by untappd_id when provided — it's authoritative and
+  // survives normalization drift across code versions or upstream renames.
+  // A normalized-only lookup caused UNIQUE violations on re-import when a
+  // row had the bid we're assigning but stored under a stale normalized form.
+  let existing: { id: number } | undefined;
+  if (b.untappd_id != null) {
+    existing = db
+      .prepare('SELECT id FROM beers WHERE untappd_id = ?')
+      .get(b.untappd_id) as { id: number } | undefined;
+  }
+  if (!existing) {
+    existing = db
+      .prepare('SELECT id FROM beers WHERE normalized_brewery = ? AND normalized_name = ?')
+      .get(b.normalized_brewery, b.normalized_name) as { id: number } | undefined;
+  }
 
   if (existing) {
     db.prepare(
       `UPDATE beers SET untappd_id = COALESCE(?, untappd_id), name = ?, brewery = ?,
-         style = ?, abv = ?, rating_global = ? WHERE id = ?`,
+         style = ?, abv = ?, rating_global = ?,
+         normalized_name = ?, normalized_brewery = ? WHERE id = ?`,
     ).run(b.untappd_id ?? null, b.name, b.brewery, b.style ?? null,
-          b.abv ?? null, b.rating_global ?? null, existing.id);
+          b.abv ?? null, b.rating_global ?? null,
+          b.normalized_name, b.normalized_brewery, existing.id);
     return existing.id;
   }
 


### PR DESCRIPTION
## Summary
Discovered while smoke-testing PR #32: re-running \`/import\` failed with \`UNIQUE constraint failed: beers.untappd_id\` after 0 rows. Root cause: \`upsertBeer\` looked up existing rows only by \`(normalized_brewery, normalized_name)\`. When a row already had the bid we were assigning but stored under a stale normalized form (legacy code version, upstream beer rename, or refresh-untappd's profile-feed scrape with slightly different output), the SELECT missed and the INSERT collided on the UNIQUE constraint.

Concrete prod example: row \`id=11977, untappd_id=6455502\` for \"Captain Hazy - Foreign Legion 2025\" stored \`normalized_name=\"captain hazy foreign legion\"\` (no \`2025\`), while current \`normalize()\` produces \`\"captain hazy foreign legion 2025\"\`. SELECT missed, INSERT fired, UNIQUE blew up.

## Fix
- When \`untappd_id\` is non-null, look up by it first — it's authoritative and survives normalization drift.
- Fall back to the normalized lookup when no bid is provided (refresh-ontap path is unchanged).
- Include \`normalized_(name,brewery)\` in the UPDATE so the row self-heals to the current \`normalize()\` output on re-import.

## Test plan
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx jest\` — 182 / 182 (existing 179 + 3 new beers.test.ts cases: drift-recovery, null-bid fallback, bid-preferred-over-normalized).
- [ ] Post-deploy smoke (manual, again): re-run \`/import\` on the existing JSON. Expect successful completion (no UNIQUE error) and \`SELECT COUNT(*) FROM beers WHERE rating_global IS NOT NULL\` jumping from baseline 232 to several thousand.

## Risk
- Behavior change for refresh-ontap (\`untappd_id=null\`): unchanged — SELECT skips the untappd_id branch and falls back to normalized.
- Behavior change for refresh-untappd (current broken impl): also fine; that job is being rewritten in Phase 1.
- Self-healing UPDATE of \`normalized_*\` may create logical duplicates if another row already has the new normalized values. Acceptable: \`dedupe-brewery-aliases\` and Phase 2's polluted-cleanup job handle these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)