### PR TITLE
feat(jobs): cleanup polluted ontap rows at startup

### DIFF
--- a/docs/superpowers/specs/2026-04-22-warsaw-beer-bot-design.md
+++ b/docs/superpowers/specs/2026-04-22-warsaw-beer-bot-design.md
@@ -404,5 +404,12 @@ bot /route N → domain/filters: interesting(p) для кожного пабу �
   (Design 3); this job catches new releases and rating drift between
   imports. `/beers` does not paginate unauthenticated, so the 25-item cap
   is a hard ceiling.
+- **Polluted ontap-row cleanup**: pre-Task 25 scrapes left ~500 rows where
+  `name` was the full `<h4>` text (brewery + name + ABV + style suffix).
+  Cleaned at startup by `src/jobs/cleanup-polluted-ontap.ts`: re-runs the
+  parser's `extractBeerName` on each ontap-side (`untappd_id IS NULL`) row
+  whose name still matches the pollution regex (`\d+[°%]` or ` — `), then
+  either merges into a canonical match (confidence ≥ 0.9, exact or
+  high-fuzzy) or rewrites in place. Idempotent — second boot finds 0 rows.
 
 Ці грабельки — чек-лист на першу секунду нового деплою.

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import { createRefreshCommand } from './bot/commands/refresh';
 import { refreshOntap } from './jobs/refresh-ontap';
 import { refreshAllUntappd } from './jobs/refresh-untappd';
 import { dedupeBreweryAliases } from './jobs/dedupe-brewery-aliases';
+import { cleanupPollutedOntap } from './jobs/cleanup-polluted-ontap';
 import { createShutdown } from './shutdown';
 
 async function main(): Promise<void> {
@@ -26,6 +27,7 @@ async function main(): Promise<void> {
   const db = openDb(env.DATABASE_PATH);
   migrate(db);
   dedupeBreweryAliases(db, log);
+  cleanupPollutedOntap(db, log);
 
   const http = createHttp({ userAgent: env.NOMINATIM_USER_AGENT });
   const geocoder = createGeocoder({ userAgent: env.NOMINATIM_USER_AGENT });

--- a/src/jobs/cleanup-polluted-ontap.test.ts
+++ b/src/jobs/cleanup-polluted-ontap.test.ts
@@ -1,0 +1,214 @@
+import pino from 'pino';
+import { openDb } from '../storage/db';
+import { migrate } from '../storage/schema';
+import { upsertBeer } from '../storage/beers';
+import { cleanupPollutedOntap } from './cleanup-polluted-ontap';
+
+const silentLog = pino({ level: 'silent' });
+
+function fresh() {
+  const db = openDb(':memory:');
+  migrate(db);
+  return db;
+}
+
+function getRow(db: ReturnType<typeof openDb>, id: number) {
+  return db.prepare('SELECT id, name, brewery, normalized_name, normalized_brewery, untappd_id FROM beers WHERE id = ?').get(id) as
+    | { id: number; name: string; brewery: string; normalized_name: string; normalized_brewery: string; untappd_id: number | null }
+    | undefined;
+}
+
+describe('cleanupPollutedOntap', () => {
+  test('empty DB → no-op', () => {
+    const db = fresh();
+    expect(cleanupPollutedOntap(db, silentLog)).toEqual({ rewritten: 0, merged: 0 });
+  });
+
+  test('single polluted row, no canonical → rewrite in place', () => {
+    const db = fresh();
+    const id = upsertBeer(db, {
+      untappd_id: null,
+      name: 'Wagabunda Brewery Oxymel 14°·4,5% — Sour Ale',
+      brewery: 'Wagabunda Brewery',
+      style: null,
+      abv: 4.5,
+      rating_global: null,
+      normalized_name: 'wagabunda brewery oxymel 14 4 5 ale',
+      normalized_brewery: 'wagabunda',
+    });
+
+    const result = cleanupPollutedOntap(db, silentLog);
+    expect(result).toEqual({ rewritten: 1, merged: 0 });
+
+    const row = getRow(db, id)!;
+    expect(row.name).toBe('Oxymel');
+    expect(row.normalized_name).toBe('oxymel');
+    expect(row.brewery).toBe('Wagabunda Brewery');
+    expect(row.normalized_brewery).toBe('wagabunda');
+  });
+
+  test('polluted + ontap canonical → merge with match_links + checkins repointed', () => {
+    const db = fresh();
+    const cleanId = upsertBeer(db, {
+      untappd_id: null,
+      name: 'Oxymel',
+      brewery: 'Wagabunda Brewery',
+      style: 'Sour Ale',
+      abv: 4.5,
+      rating_global: null,
+      normalized_name: 'oxymel',
+      normalized_brewery: 'wagabunda',
+    });
+    const pollutedId = upsertBeer(db, {
+      untappd_id: null,
+      name: 'Wagabunda Brewery Oxymel 14°·4,5% — Sour Ale',
+      brewery: 'Wagabunda Brewery',
+      style: null,
+      abv: 4.5,
+      rating_global: null,
+      normalized_name: 'wagabunda brewery oxymel 14 4 5 ale',
+      normalized_brewery: 'wagabunda',
+    });
+    db.prepare(
+      'INSERT INTO match_links (ontap_ref, untappd_beer_id, confidence) VALUES (?, ?, ?)',
+    ).run('Wagabunda Brewery Oxymel 14°·4,5% — Sour Ale', pollutedId, 1.0);
+    db.prepare(
+      'INSERT INTO checkins (checkin_id, telegram_id, beer_id, checkin_at) VALUES (?, ?, ?, ?)',
+    ).run('chk-1', 42, pollutedId, '2026-04-01 12:00:00');
+
+    const result = cleanupPollutedOntap(db, silentLog);
+    expect(result).toEqual({ rewritten: 0, merged: 1 });
+
+    expect(getRow(db, pollutedId)).toBeUndefined();
+    expect(getRow(db, cleanId)?.name).toBe('Oxymel');
+
+    const link = db.prepare('SELECT untappd_beer_id FROM match_links WHERE ontap_ref = ?')
+      .get('Wagabunda Brewery Oxymel 14°·4,5% — Sour Ale') as { untappd_beer_id: number };
+    expect(link.untappd_beer_id).toBe(cleanId);
+
+    const checkin = db.prepare('SELECT beer_id FROM checkins WHERE checkin_id = ?')
+      .get('chk-1') as { beer_id: number };
+    expect(checkin.beer_id).toBe(cleanId);
+  });
+
+  test('polluted with both ontap and untappd canonicals → merge into the higher-id exact match', () => {
+    const db = fresh();
+    const untappdId = upsertBeer(db, {
+      untappd_id: 12345,
+      name: 'Oxymel',
+      brewery: 'Wagabunda Brewery',
+      style: 'Sour Ale',
+      abv: 4.5,
+      rating_global: 3.7,
+      normalized_name: 'oxymel',
+      normalized_brewery: 'wagabunda',
+    });
+    const ontapCleanId = upsertBeer(db, {
+      untappd_id: null,
+      name: 'Oxymel',
+      brewery: 'Wagabunda Brewery',
+      style: 'Sour Ale',
+      abv: 4.5,
+      rating_global: null,
+      normalized_name: 'oxymel',
+      normalized_brewery: 'wagabunda',
+    });
+    const pollutedId = upsertBeer(db, {
+      untappd_id: null,
+      name: 'Wagabunda Brewery Oxymel 14°·4,5% — Sour Ale',
+      brewery: 'Wagabunda Brewery',
+      style: null,
+      abv: 4.5,
+      rating_global: null,
+      normalized_name: 'wagabunda brewery oxymel 14 4 5 ale',
+      normalized_brewery: 'wagabunda',
+    });
+
+    const result = cleanupPollutedOntap(db, silentLog);
+    expect(result).toEqual({ rewritten: 0, merged: 1 });
+    expect(getRow(db, pollutedId)).toBeUndefined();
+    expect(getRow(db, untappdId)?.untappd_id).toBe(12345);
+    expect(getRow(db, ontapCleanId)?.untappd_id).toBeNull();
+  });
+
+  test('two polluted rows resolving to the same clean name, no canonical → both rewrite (become duplicates)', () => {
+    const db = fresh();
+    const aId = upsertBeer(db, {
+      untappd_id: null,
+      name: 'Wagabunda Brewery Oxymel 14°·4,5% — Sour Ale',
+      brewery: 'Wagabunda Brewery',
+      style: null,
+      abv: 4.5,
+      rating_global: null,
+      normalized_name: 'wagabunda brewery oxymel 14 4 5 ale',
+      normalized_brewery: 'wagabunda',
+    });
+    const bId = upsertBeer(db, {
+      untappd_id: null,
+      name: 'Wagabunda Brewery Oxymel 12°·4,2% — Sour',
+      brewery: 'Wagabunda Brewery',
+      style: null,
+      abv: 4.2,
+      rating_global: null,
+      normalized_name: 'wagabunda brewery oxymel 12 4 2',
+      normalized_brewery: 'wagabunda',
+    });
+
+    const result = cleanupPollutedOntap(db, silentLog);
+    expect(result).toEqual({ rewritten: 2, merged: 0 });
+
+    expect(getRow(db, aId)?.name).toBe('Oxymel');
+    expect(getRow(db, aId)?.normalized_name).toBe('oxymel');
+    expect(getRow(db, bId)?.name).toBe('Oxymel');
+    expect(getRow(db, bId)?.normalized_name).toBe('oxymel');
+  });
+
+  test('idempotent: second invocation returns {0, 0}', () => {
+    const db = fresh();
+    upsertBeer(db, {
+      untappd_id: null,
+      name: 'Wagabunda Brewery Oxymel 14°·4,5% — Sour Ale',
+      brewery: 'Wagabunda Brewery',
+      style: null,
+      abv: 4.5,
+      rating_global: null,
+      normalized_name: 'wagabunda brewery oxymel 14 4 5 ale',
+      normalized_brewery: 'wagabunda',
+    });
+
+    const first = cleanupPollutedOntap(db, silentLog);
+    expect(first).toEqual({ rewritten: 1, merged: 0 });
+
+    const second = cleanupPollutedOntap(db, silentLog);
+    expect(second).toEqual({ rewritten: 0, merged: 0 });
+  });
+
+  test('clean rows preserved — no pollution markers means no touching', () => {
+    const db = fresh();
+    const cleanId = upsertBeer(db, {
+      untappd_id: null,
+      name: 'Oxymel',
+      brewery: 'Wagabunda Brewery',
+      style: 'Sour Ale',
+      abv: 4.5,
+      rating_global: null,
+      normalized_name: 'oxymel',
+      normalized_brewery: 'wagabunda',
+    });
+    const untappdRowId = upsertBeer(db, {
+      untappd_id: 99,
+      name: 'Some Brewery Stuff 14°·5%',
+      brewery: 'Some Brewery',
+      style: null,
+      abv: 5.0,
+      rating_global: 3.5,
+      normalized_name: 'some stuff 14 5',
+      normalized_brewery: 'some',
+    });
+
+    const result = cleanupPollutedOntap(db, silentLog);
+    expect(result).toEqual({ rewritten: 0, merged: 0 });
+    expect(getRow(db, cleanId)?.name).toBe('Oxymel');
+    expect(getRow(db, untappdRowId)?.name).toBe('Some Brewery Stuff 14°·5%');
+  });
+});

--- a/src/jobs/cleanup-polluted-ontap.test.ts
+++ b/src/jobs/cleanup-polluted-ontap.test.ts
@@ -91,7 +91,7 @@ describe('cleanupPollutedOntap', () => {
     expect(checkin.beer_id).toBe(cleanId);
   });
 
-  test('polluted with both ontap and untappd canonicals → merge into the higher-id exact match', () => {
+  test('polluted ontap-side row merges into untappd-side canonical (cross-source)', () => {
     const db = fresh();
     const untappdId = upsertBeer(db, {
       untappd_id: 12345,
@@ -100,16 +100,6 @@ describe('cleanupPollutedOntap', () => {
       style: 'Sour Ale',
       abv: 4.5,
       rating_global: 3.7,
-      normalized_name: 'oxymel',
-      normalized_brewery: 'wagabunda',
-    });
-    const ontapCleanId = upsertBeer(db, {
-      untappd_id: null,
-      name: 'Oxymel',
-      brewery: 'Wagabunda Brewery',
-      style: 'Sour Ale',
-      abv: 4.5,
-      rating_global: null,
       normalized_name: 'oxymel',
       normalized_brewery: 'wagabunda',
     });
@@ -128,7 +118,7 @@ describe('cleanupPollutedOntap', () => {
     expect(result).toEqual({ rewritten: 0, merged: 1 });
     expect(getRow(db, pollutedId)).toBeUndefined();
     expect(getRow(db, untappdId)?.untappd_id).toBe(12345);
-    expect(getRow(db, ontapCleanId)?.untappd_id).toBeNull();
+    expect(getRow(db, untappdId)?.name).toBe('Oxymel');
   });
 
   test('two polluted rows resolving to the same clean name, no canonical → both rewrite (become duplicates)', () => {

--- a/src/jobs/cleanup-polluted-ontap.ts
+++ b/src/jobs/cleanup-polluted-ontap.ts
@@ -1,0 +1,97 @@
+import type pino from 'pino';
+import type { DB } from '../storage/db';
+import { extractBeerName } from '../sources/ontap/pub';
+import { matchBeer, type CatalogBeer } from '../domain/matcher';
+import { normalizeName } from '../domain/normalize';
+
+const POLLUTION_RE = /\d+(?:[.,]\d+)?\s*[°%]| — /;
+const MERGE_THRESHOLD = 0.9;
+
+interface BeerRow extends CatalogBeer {
+  normalized_name: string;
+  untappd_id: number | null;
+}
+
+export interface CleanupResult {
+  rewritten: number;
+  merged: number;
+}
+
+interface MergePlan { kind: 'merge'; pollutedId: number; targetId: number }
+interface RewritePlan { kind: 'rewrite'; pollutedId: number; cleaned: string; cleanedNormalized: string }
+type Plan = MergePlan | RewritePlan;
+
+export function cleanupPollutedOntap(db: DB, log: pino.Logger): CleanupResult {
+  const allOntap = db
+    .prepare(
+      `SELECT id, name, brewery, abv, normalized_name, untappd_id
+         FROM beers
+        WHERE untappd_id IS NULL`,
+    )
+    .all() as BeerRow[];
+
+  const pollutedIds = new Set<number>();
+  const polluted: BeerRow[] = [];
+  for (const r of allOntap) {
+    if (POLLUTION_RE.test(r.name)) {
+      polluted.push(r);
+      pollutedIds.add(r.id);
+    }
+  }
+
+  if (polluted.length === 0) {
+    log.info({ polluted: 0 }, 'cleanup-polluted-ontap: catalog clean');
+    return { rewritten: 0, merged: 0 };
+  }
+
+  const cleanPool = db
+    .prepare('SELECT id, name, brewery, abv FROM beers')
+    .all() as CatalogBeer[];
+  const pool = cleanPool.filter((c) => !pollutedIds.has(c.id));
+
+  const plans: Plan[] = [];
+  for (const p of polluted) {
+    const cleaned = extractBeerName(p.name, p.brewery);
+    if (!cleaned) continue;
+    const cleanedNorm = normalizeName(cleaned);
+    if (cleanedNorm === p.normalized_name) continue;
+
+    const match = matchBeer({ brewery: p.brewery, name: cleaned, abv: p.abv }, pool);
+    if (match && match.confidence >= MERGE_THRESHOLD) {
+      plans.push({ kind: 'merge', pollutedId: p.id, targetId: match.id });
+    } else {
+      plans.push({ kind: 'rewrite', pollutedId: p.id, cleaned, cleanedNormalized: cleanedNorm });
+    }
+  }
+
+  const updateLinks = db.prepare(
+    'UPDATE match_links SET untappd_beer_id = ? WHERE untappd_beer_id = ?',
+  );
+  const updateCheckins = db.prepare(
+    'UPDATE checkins SET beer_id = ? WHERE beer_id = ?',
+  );
+  const deleteBeer = db.prepare('DELETE FROM beers WHERE id = ?');
+  const rewriteName = db.prepare(
+    'UPDATE beers SET name = ?, normalized_name = ? WHERE id = ?',
+  );
+
+  let rewritten = 0;
+  let merged = 0;
+  const tx = db.transaction((items: Plan[]) => {
+    for (const plan of items) {
+      if (plan.kind === 'merge') {
+        updateLinks.run(plan.targetId, plan.pollutedId);
+        updateCheckins.run(plan.targetId, plan.pollutedId);
+        deleteBeer.run(plan.pollutedId);
+        merged++;
+      } else {
+        rewriteName.run(plan.cleaned, plan.cleanedNormalized, plan.pollutedId);
+        rewritten++;
+      }
+    }
+  });
+  tx(plans);
+
+  log.info({ rewritten, merged }, 'cleanup-polluted-ontap: pass complete');
+  return { rewritten, merged };
+}


### PR DESCRIPTION
## Summary
Phase 2 of the post-PR-#30 rating + cleanup roadmap (PR #31).
Spec: `docs/superpowers/specs/2026-04-30-cleanup-polluted-ontap-design.md`.

Pre-Task-25 ontap scrapes wrote the entire `<h4>` text (brewery prefix + ABV/strength + " — style") into `beers.name`, leaving ~495 / 663 ontap-side rows (~75%) unmatchable to any future tap. New idempotent startup job:

- Detects polluted rows via JS-side regex (`\d+[°%]` or ` — `) over `untappd_id IS NULL` rows.
- Re-derives the clean name with the live parser's `extractBeerName`.
- Either merges (matchBeer confidence ≥ 0.9 against a clean-pool that excludes all polluted ids) or rewrites in place.
- Wrapped in a single `db.transaction` for atomicity. Mirrors `dedupeBreweryAliases`'s structure.
- Runs in `src/index.ts` right after `dedupeBreweryAliases` so both startup-time catalog fixes converge before the bot accepts traffic.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx jest` — 201 / 201 (7 new cases: empty, single rewrite, merge with link/checkin repoint, cross-source merge into untappd-side canonical, two-polluted-no-canonical, idempotent, negative)
- [ ] Post-deploy smoke (manual): on first boot, expect a single log line `cleanup-polluted-ontap: pass complete` with non-zero `rewritten` / `merged`. Second boot: `catalog clean`. Verify with: `sqlite3 /var/lib/warsaw-beer-bot/bot.db "SELECT COUNT(*) FROM beers WHERE untappd_id IS NULL AND (name GLOB '*[0-9]*[°%]*' OR name LIKE '% — %');"` — expect 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)