### PR TITLE
feat(storage): rating fallback — taps coalesce u_rating over beers.rating_global

### DIFF
--- a/docs/superpowers/specs/2026-04-22-warsaw-beer-bot-design.md
+++ b/docs/superpowers/specs/2026-04-22-warsaw-beer-bot-design.md
@@ -411,5 +411,11 @@ bot /route N → domain/filters: interesting(p) для кожного пабу �
   whose name still matches the pollution regex (`\d+[°%]` or ` — `), then
   either merges into a canonical match (confidence ≥ 0.9, exact or
   high-fuzzy) or rewrites in place. Idempotent — second boot finds 0 rows.
+- **Rating fallback (catalog → tap)**: `tap.u_rating` is the rating ontap.pl
+  showed at scrape time; often NULL when ontap.pl hasn't matched the beer
+  to Untappd. `tapsForSnapshotWithBeer` (`src/storage/snapshots.ts`) now
+  COALESCEs into `beers.rating_global` from the matched catalog row,
+  giving render and `min_rating` filter a usable rating in the ~2 % of
+  rows where the catalog has one but the tap doesn't.
 
 Ці грабельки — чек-лист на першу секунду нового деплою.

--- a/src/bot/commands/newbeers.ts
+++ b/src/bot/commands/newbeers.ts
@@ -1,8 +1,7 @@
 import { Composer } from 'telegraf';
 import type { BotContext } from '../index';
-import { latestSnapshotsPerPub, tapsForSnapshot } from '../../storage/snapshots';
+import { latestSnapshotsPerPub, tapsForSnapshotWithBeer } from '../../storage/snapshots';
 import { drunkBeerIds } from '../../storage/checkins';
-import { getMatch } from '../../storage/match_links';
 import { getFilters } from '../../storage/user_filters';
 import { filterInteresting } from '../../domain/filters';
 import { listPubs } from '../../storage/pubs';
@@ -33,14 +32,7 @@ newbeersCommand.command('newbeers', async (ctx) => {
   for (const snap of latestSnapshotsPerPub(db)) {
     const pub = pubs.get(snap.pub_id);
     if (!pub) continue;
-    const taps = tapsForSnapshot(db, snap.id).map((t) => ({
-      beer_id: getMatch(db, t.beer_ref)?.untappd_beer_id ?? null,
-      style: t.style,
-      abv: t.abv,
-      u_rating: t.u_rating,
-      beer_ref: t.beer_ref,
-      brewery_ref: t.brewery_ref,
-    }));
+    const taps = tapsForSnapshotWithBeer(db, snap.id);
     const good = filterInteresting(taps, drunk, filters);
     for (const t of good) {
       const display = t.brewery_ref ? `${t.brewery_ref} ${t.beer_ref}`.trim() : t.beer_ref;

--- a/src/bot/commands/route.ts
+++ b/src/bot/commands/route.ts
@@ -1,9 +1,8 @@
 import { Composer } from 'telegraf';
 import type { BotContext } from '../index';
 import { listPubs } from '../../storage/pubs';
-import { latestSnapshotsPerPub, tapsForSnapshot } from '../../storage/snapshots';
+import { latestSnapshotsPerPub, tapsForSnapshotWithBeer } from '../../storage/snapshots';
 import { drunkBeerIds } from '../../storage/checkins';
-import { getMatch } from '../../storage/match_links';
 import { getFilters } from '../../storage/user_filters';
 import { filterInteresting } from '../../domain/filters';
 import { normalizeBrewery, normalizeName } from '../../domain/normalize';
@@ -56,14 +55,7 @@ routeCommand.command('route', async (ctx) => {
   for (const snap of latestSnapshotsPerPub(db)) {
     const pub = pubsById.get(snap.pub_id);
     if (!pub || pub.lat == null || pub.lon == null) continue;
-    const taps = tapsForSnapshot(db, snap.id).map((t) => ({
-      beer_id: getMatch(db, t.beer_ref)?.untappd_beer_id ?? null,
-      style: t.style,
-      abv: t.abv,
-      u_rating: t.u_rating,
-      beer_ref: t.beer_ref,
-      brewery_ref: t.brewery_ref,
-    }));
+    const taps = tapsForSnapshotWithBeer(db, snap.id);
     const good = filterInteresting(taps, drunk, filters);
     if (!good.length) continue;
     routePubs.push({

--- a/src/storage/snapshots.test.ts
+++ b/src/storage/snapshots.test.ts
@@ -1,7 +1,9 @@
 import { openDb } from './db';
 import { migrate } from './schema';
 import { upsertPub } from './pubs';
-import { createSnapshot, latestSnapshot, insertTaps, tapsForSnapshot } from './snapshots';
+import { createSnapshot, latestSnapshot, insertTaps, tapsForSnapshot, tapsForSnapshotWithBeer } from './snapshots';
+import { upsertBeer } from './beers';
+import { upsertMatch } from './match_links';
 
 function setup() {
   const db = openDb(':memory:'); migrate(db);
@@ -26,4 +28,106 @@ test('latestSnapshot returns most recent per pub', () => {
   createSnapshot(db, pubId, '2026-04-22T10:00:00Z');
   const s2 = createSnapshot(db, pubId, '2026-04-22T20:00:00Z');
   expect(latestSnapshot(db, pubId)?.id).toBe(s2);
+});
+
+function setupWithBeer() {
+  const out = setup();
+  const snapId = createSnapshot(out.db, out.pubId, '2026-05-01T12:00:00Z');
+  return { ...out, snapId };
+}
+
+describe('tapsForSnapshotWithBeer', () => {
+  test('tap with non-NULL u_rating and no match → keeps tap u_rating, beer_id null', () => {
+    const { db, snapId } = setupWithBeer();
+    insertTaps(db, snapId, [
+      { tap_number: 1, beer_ref: 'Mystery Beer', brewery_ref: 'Anon', abv: 5, ibu: null, style: 'IPA', u_rating: 3.9 },
+    ]);
+    const [row] = tapsForSnapshotWithBeer(db, snapId);
+    expect(row.u_rating).toBe(3.9);
+    expect(row.beer_id).toBeNull();
+  });
+
+  test('tap with NULL u_rating + matched beer carrying rating_global → fallback rating, beer_id set', () => {
+    const { db, snapId } = setupWithBeer();
+    const beerId = upsertBeer(db, {
+      untappd_id: 100,
+      name: 'Atak Chmielu',
+      brewery: 'Pinta',
+      style: 'AIPA',
+      abv: 6.1,
+      rating_global: 3.85,
+      normalized_name: 'atak chmielu',
+      normalized_brewery: 'pinta',
+    });
+    upsertMatch(db, 'PINTA Atak Chmielu', beerId, 1.0);
+    insertTaps(db, snapId, [
+      { tap_number: 1, beer_ref: 'PINTA Atak Chmielu', brewery_ref: 'PINTA', abv: 6.1, ibu: null, style: 'AIPA', u_rating: null },
+    ]);
+    const [row] = tapsForSnapshotWithBeer(db, snapId);
+    expect(row.u_rating).toBe(3.85);
+    expect(row.beer_id).toBe(beerId);
+  });
+
+  test('tap with non-NULL u_rating + matched beer with different rating_global → COALESCE keeps tap u_rating', () => {
+    const { db, snapId } = setupWithBeer();
+    const beerId = upsertBeer(db, {
+      untappd_id: 101,
+      name: 'Buty Skejta',
+      brewery: 'Stu Mostow',
+      style: 'Pilsner',
+      abv: 5.0,
+      rating_global: 3.10,
+      normalized_name: 'buty skejta',
+      normalized_brewery: 'stu mostow',
+    });
+    upsertMatch(db, 'Stu Mostow Buty Skejta', beerId, 1.0);
+    insertTaps(db, snapId, [
+      { tap_number: 1, beer_ref: 'Stu Mostow Buty Skejta', brewery_ref: 'Stu Mostow', abv: 5.0, ibu: null, style: 'Pilsner', u_rating: 3.7 },
+    ]);
+    const [row] = tapsForSnapshotWithBeer(db, snapId);
+    expect(row.u_rating).toBe(3.7);
+    expect(row.beer_id).toBe(beerId);
+  });
+
+  test('tap with NULL u_rating + matched beer with NULL rating_global → NULL u_rating, beer_id set', () => {
+    const { db, snapId } = setupWithBeer();
+    const beerId = upsertBeer(db, {
+      untappd_id: 102,
+      name: 'New Release',
+      brewery: 'New Brews',
+      style: 'Lager',
+      abv: 5.0,
+      rating_global: null,
+      normalized_name: 'new release',
+      normalized_brewery: 'new brews',
+    });
+    upsertMatch(db, 'New Brews New Release', beerId, 1.0);
+    insertTaps(db, snapId, [
+      { tap_number: 1, beer_ref: 'New Brews New Release', brewery_ref: 'New Brews', abv: 5.0, ibu: null, style: 'Lager', u_rating: null },
+    ]);
+    const [row] = tapsForSnapshotWithBeer(db, snapId);
+    expect(row.u_rating).toBeNull();
+    expect(row.beer_id).toBe(beerId);
+  });
+
+  test('tap with no matching match_links row → NULL u_rating (when tap had it NULL), NULL beer_id', () => {
+    const { db, snapId } = setupWithBeer();
+    insertTaps(db, snapId, [
+      { tap_number: 1, beer_ref: 'Unmatched', brewery_ref: 'Nobody', abv: null, ibu: null, style: null, u_rating: null },
+    ]);
+    const [row] = tapsForSnapshotWithBeer(db, snapId);
+    expect(row.u_rating).toBeNull();
+    expect(row.beer_id).toBeNull();
+  });
+
+  test('preserves ORDER BY tap_number', () => {
+    const { db, snapId } = setupWithBeer();
+    insertTaps(db, snapId, [
+      { tap_number: 3, beer_ref: 'C', brewery_ref: 'X', abv: null, ibu: null, style: null, u_rating: null },
+      { tap_number: 1, beer_ref: 'A', brewery_ref: 'X', abv: null, ibu: null, style: null, u_rating: null },
+      { tap_number: 2, beer_ref: 'B', brewery_ref: 'X', abv: null, ibu: null, style: null, u_rating: null },
+    ]);
+    const rows = tapsForSnapshotWithBeer(db, snapId);
+    expect(rows.map((r) => r.beer_ref)).toEqual(['A', 'B', 'C']);
+  });
 });

--- a/src/storage/snapshots.ts
+++ b/src/storage/snapshots.ts
@@ -52,3 +52,23 @@ export function latestSnapshotsPerPub(db: DB): SnapshotRow[] {
      ) x ON x.pub_id = s.pub_id AND x.m = s.snapshot_at`,
   ).all() as SnapshotRow[];
 }
+
+export interface TapWithBeer extends TapRow {
+  beer_id: number | null;
+  // u_rating on this row is the COALESCEd value: tap.u_rating ?? beers.rating_global ?? null
+}
+
+export function tapsForSnapshotWithBeer(db: DB, snapshotId: number): TapWithBeer[] {
+  return db.prepare(`
+    SELECT
+      t.id, t.snapshot_id, t.tap_number, t.beer_ref, t.brewery_ref,
+      t.abv, t.ibu, t.style,
+      COALESCE(t.u_rating, b.rating_global) AS u_rating,
+      ml.untappd_beer_id AS beer_id
+    FROM taps t
+    LEFT JOIN match_links ml ON t.beer_ref = ml.ontap_ref
+    LEFT JOIN beers b ON ml.untappd_beer_id = b.id
+    WHERE t.snapshot_id = ?
+    ORDER BY t.tap_number
+  `).all(snapshotId) as TapWithBeer[];
+}


### PR DESCRIPTION
## Summary
Phase 3 of the post-PR-#30 rating + cleanup roadmap (PR #31). Final phase.
Spec: `docs/superpowers/specs/2026-04-30-rating-fallback-design.md`.

When `/newbeers` or `/route` surfaces a tap whose `tap.u_rating` is NULL but the catalog has a non-NULL `rating_global` for the matched beer, render the catalog rating instead of `⭐ —`.

- New helper `tapsForSnapshotWithBeer` joins `taps` ↔ `match_links` ↔ `beers` and `COALESCE(t.u_rating, b.rating_global) AS u_rating` in one SQL — replaces the per-tap `getMatch(...)` loop in both command files.
- Fallback is transparent: both values are global Untappd ratings (no asterisk, no dim star).
- `filterInteresting`'s `min_rating` threshold now applies to fallback values too — closes a current loophole where unmatched taps bypassed the filter even when the catalog had a rating.
- Pure read-time change. No schema migration. Snapshots stay raw (no write-time backfill of `taps.u_rating`).

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx jest` — 207 / 207 (6 new cases on `tapsForSnapshotWithBeer`: tap-rating-only, fallback, COALESCE order, both-null, unmatched, ORDER BY)
- [ ] Post-deploy smoke (manual): in Telegram, run `/newbeers`. Confirm at least one row that previously showed `⭐ —` now shows a numeric rating sourced from `beers.rating_global`. Cross-check with `sqlite3 /var/lib/warsaw-beer-bot/bot.db "SELECT COUNT(*) FROM taps t JOIN match_links ml ON t.beer_ref = ml.ontap_ref JOIN beers b ON ml.untappd_beer_id = b.id WHERE t.u_rating IS NULL AND b.rating_global IS NOT NULL;"` — expect a non-zero count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)