### PR TITLE
feat: paren-alias brewery dedup (PR-A)

### DIFF
--- a/docs/superpowers/specs/2026-04-22-warsaw-beer-bot-design.md
+++ b/docs/superpowers/specs/2026-04-22-warsaw-beer-bot-design.md
@@ -423,5 +423,14 @@ bot /route N → domain/filters: interesting(p) для кожного пабу �
   COALESCEs into `beers.rating_global` from the matched catalog row,
   giving render and `min_rating` filter a usable rating in the ~2 % of
   rows where the catalog has one but the tap doesn't.
+- **Paren-form brewery aliases**: Untappd renders some breweries with a
+  parenthesized German alias — "Kemker Kultuur (Brauerei J. Kemker)" —
+  parallel to the "X / Y" bilingual/collab form. `breweryAliases`
+  (`src/domain/matcher.ts`) splits BOTH forms so that either side counts
+  as a valid brewery for the beer. Missing the paren form let
+  ontap-side rows fail to find their Untappd canonical and create
+  duplicates (caught 2026-05-10 via duplicated `beers#12061/12093`
+  for *Stadt Land Bier*; startup `dedupeBreweryAliases` now sweeps both
+  forms on boot).
 
 Ці грабельки — чек-лист на першу секунду нового деплою.

--- a/src/domain/matcher.test.ts
+++ b/src/domain/matcher.test.ts
@@ -42,9 +42,14 @@ describe('breweryAliases', () => {
 
   test('mixed slash + paren splits on both', () => {
     const out = breweryAliases('AleBrowar / Kemker Kultuur (Brauerei J. Kemker)');
-    expect(out).toContain('alebrowar');
-    expect(out).toContain('kemker kultuur');
-    expect(out).toContain('brauerei j kemker');
+    expect(new Set(out)).toEqual(
+      new Set([
+        'alebrowar kemker kultuur brauerei j kemker',
+        'alebrowar',
+        'kemker kultuur',
+        'brauerei j kemker',
+      ]),
+    );
   });
 
   test('empty input returns empty array', () => {

--- a/src/domain/matcher.test.ts
+++ b/src/domain/matcher.test.ts
@@ -1,4 +1,4 @@
-import { matchBeer, type CatalogBeer } from './matcher';
+import { matchBeer, breweryAliases, type CatalogBeer } from './matcher';
 
 const c = (over: Partial<CatalogBeer> & { id: number }): CatalogBeer => ({
   brewery: 'Pinta',
@@ -12,6 +12,45 @@ const catalog: CatalogBeer[] = [
   c({ id: 2, brewery: 'Stu Mostów', name: 'Buty Skejta', abv: 5.0 }),
   c({ id: 3, brewery: 'Piwne Podziemie', name: 'Hopinka', abv: 6.0 }),
 ];
+
+describe('breweryAliases', () => {
+  test('plain brewery returns one alias', () => {
+    expect(breweryAliases('Pinta')).toEqual(['pinta']);
+  });
+
+  test('drops noise words consistent with normalizeBrewery', () => {
+    expect(breweryAliases('Piwne Podziemie Brewery')).toEqual(['piwne podziemie']);
+  });
+
+  test('slash form returns full + each half', () => {
+    const out = breweryAliases('Piwne Podziemie / Beer Underground');
+    expect(new Set(out)).toEqual(
+      new Set(['piwne podziemie beer underground', 'piwne podziemie', 'beer underground']),
+    );
+  });
+
+  test('paren form returns full + outer + inner', () => {
+    const out = breweryAliases('Kemker Kultuur (Brauerei J. Kemker)');
+    expect(new Set(out)).toEqual(
+      new Set([
+        'kemker kultuur brauerei j kemker',
+        'kemker kultuur',
+        'brauerei j kemker',
+      ]),
+    );
+  });
+
+  test('mixed slash + paren splits on both', () => {
+    const out = breweryAliases('AleBrowar / Kemker Kultuur (Brauerei J. Kemker)');
+    expect(out).toContain('alebrowar');
+    expect(out).toContain('kemker kultuur');
+    expect(out).toContain('brauerei j kemker');
+  });
+
+  test('empty input returns empty array', () => {
+    expect(breweryAliases('')).toEqual([]);
+  });
+});
 
 test('exact normalized match is confidence 1', () => {
   const m = matchBeer({ brewery: 'PINTA', name: 'Atak Chmielu IPA' }, catalog);

--- a/src/domain/matcher.ts
+++ b/src/domain/matcher.ts
@@ -17,18 +17,32 @@ export interface MatchResult {
 const FUZZY_THRESHOLD = 0.75;
 const ABV_TOLERANCE = 0.3;
 
-// Untappd records breweries either as a single name ("Piwne Podziemie Brewery")
-// or as a "X / Y" alias used for two purposes:
-//   • bilingual presentation — "Piwne Podziemie / Beer Underground", same brewery
-//   • collaboration — "AleBrowar / Poppels Bryggeri", two different breweries
-// Ontap.pl renders only one half. For matching purposes both cases collapse to:
-// "the brewery on either side of '/' is also a valid brewery for this beer".
-export function brewerySlashAliases(brewery: string): string[] {
+// Untappd records breweries either as a single name ("Piwne Podziemie Brewery"),
+// as an "X / Y" alias used for bilingual ("Piwne Podziemie / Beer Underground")
+// or collaboration ("AleBrowar / Poppels Bryggeri") pairs, or as an "X (Y)"
+// form for German aliases ("Kemker Kultuur (Brauerei J. Kemker)").
+// Ontap.pl renders only one of these. For matching purposes all three forms
+// collapse to: "any side of the separator is a valid brewery for this beer".
+export function breweryAliases(brewery: string): string[] {
+  const aliases = new Set<string>();
   const full = normalizeBrewery(brewery);
-  if (!brewery.includes(' / ')) return full ? [full] : [];
-  const parts = brewery.split(' / ').map((p) => normalizeBrewery(p)).filter(Boolean);
-  const all = [full, ...parts].filter(Boolean);
-  return Array.from(new Set(all));
+  if (full) aliases.add(full);
+
+  const slashParts = brewery.includes(' / ') ? brewery.split(' / ') : [brewery];
+  for (const part of slashParts) {
+    const parenMatch = part.match(/^(.+?)\s*\((.+)\)\s*$/);
+    if (parenMatch) {
+      const outer = normalizeBrewery(parenMatch[1]);
+      const inner = normalizeBrewery(parenMatch[2]);
+      if (outer) aliases.add(outer);
+      if (inner) aliases.add(inner);
+    } else {
+      const norm = normalizeBrewery(part);
+      if (norm) aliases.add(norm);
+    }
+  }
+
+  return Array.from(aliases);
 }
 
 function brewerySetsOverlap(a: string[], b: Set<string>): boolean {
@@ -39,7 +53,7 @@ export function matchBeer(
   input: { brewery: string; name: string; abv?: number | null },
   catalog: CatalogBeer[],
 ): MatchResult | null {
-  const inputAliases = new Set(brewerySlashAliases(input.brewery));
+  const inputAliases = new Set(breweryAliases(input.brewery));
   const nn = normalizeName(input.name);
 
   // Exact-normalized hits — multiple rows are common when Untappd has
@@ -47,7 +61,7 @@ export function matchBeer(
   const exacts = catalog
     .filter(
       (c) =>
-        brewerySetsOverlap(brewerySlashAliases(c.brewery), inputAliases) &&
+        brewerySetsOverlap(breweryAliases(c.brewery), inputAliases) &&
         normalizeName(c.name) === nn,
     )
     .sort((a, b) => b.id - a.id);
@@ -66,7 +80,7 @@ export function matchBeer(
   // Fuzzy fallback: prefer rows whose brewery aliases overlap the input's,
   // otherwise full catalog.
   const pool = catalog.filter((c) =>
-    brewerySetsOverlap(brewerySlashAliases(c.brewery), inputAliases),
+    brewerySetsOverlap(breweryAliases(c.brewery), inputAliases),
   );
   const candidates = pool.length ? pool : catalog;
   const searcher = new Searcher(candidates, {
@@ -75,7 +89,7 @@ export function matchBeer(
     returnMatchData: true,
   });
   // Use the first alias as the search seed — full normalized brewery already
-  // appears at index 0 of brewerySlashAliases when no slash is present.
+  // appears at index 0 of breweryAliases when no slash is present.
   const seedBrewery = Array.from(inputAliases)[0] ?? '';
   const results = searcher.search(`${seedBrewery} ${nn}`);
   if (!results.length) return null;

--- a/src/jobs/dedupe-brewery-aliases.test.ts
+++ b/src/jobs/dedupe-brewery-aliases.test.ts
@@ -164,4 +164,60 @@ describe('dedupeBreweryAliases', () => {
     const r2 = dedupeBreweryAliases(db, silentLog);
     expect(r2).toEqual({ pairsMerged: 0, beersDeleted: 0 });
   });
+
+  test('merges paren-form alias pair (Kemker Kultuur case)', () => {
+    const db = fresh();
+    // Canonical Untappd-side row — brewery in "X (Y)" form.
+    const aId = upsertBeer(db, {
+      untappd_id: 2133795,
+      name: 'Stadt Land Bier',
+      brewery: 'Kemker Kultuur (Brauerei J. Kemker)',
+      style: null,
+      abv: null,
+      rating_global: null,
+      normalized_name: 'stadt land bier',
+      normalized_brewery: 'kemker kultuur brauerei j kemker',
+    });
+    // Orphan ontap-side row — normalized brewery matches one alias half.
+    const bId = upsertBeer(db, {
+      untappd_id: null,
+      name: 'Stadt Land Bier',
+      brewery: 'Kemker Kultuur Brewery',
+      style: null,
+      abv: null,
+      rating_global: null,
+      normalized_name: 'stadt land bier',
+      normalized_brewery: 'kemker kultuur',
+    });
+    upsertMatch(db, 'Stadt Land Bier', bId, 1.0);
+    ensureProfile(db, 42);
+    mergeCheckin(db, {
+      checkin_id: 'kemker-1',
+      telegram_id: 42,
+      beer_id: bId,
+      user_rating: 4.5,
+      checkin_at: '2026-05-10T12:00:00Z',
+      venue: null,
+    });
+
+    const result = dedupeBreweryAliases(db, silentLog);
+
+    expect(result).toEqual({ pairsMerged: 1, beersDeleted: 1 });
+    // Orphan deleted.
+    const orphan = db.prepare('SELECT id FROM beers WHERE id = ?').get(bId);
+    expect(orphan).toBeUndefined();
+    // Canonical survives.
+    const canonical = db.prepare('SELECT id FROM beers WHERE id = ?').get(aId);
+    expect(canonical).toEqual({ id: aId });
+    // match_link transferred to canonical.
+    const link = db
+      .prepare('SELECT untappd_beer_id FROM match_links WHERE ontap_ref = ?')
+      .get('Stadt Land Bier') as { untappd_beer_id: number };
+    expect(link.untappd_beer_id).toBe(aId);
+    // Checkin re-pointed to canonical.
+    const checkin = db
+      .prepare('SELECT beer_id FROM checkins WHERE checkin_id = ?')
+      .get('kemker-1') as { beer_id: number };
+    expect(checkin.beer_id).toBe(aId);
+  });
 });

--- a/src/jobs/dedupe-brewery-aliases.ts
+++ b/src/jobs/dedupe-brewery-aliases.ts
@@ -15,7 +15,8 @@ export interface DedupeResult {
 }
 
 export function dedupeBreweryAliases(db: DB, log: pino.Logger): DedupeResult {
-  // Find candidates: same normalized_name, A has untappd_id + slash, B has neither.
+  // Find candidates: same normalized_name, A has untappd_id and a brewery
+  // in either "X / Y" slash form or "X (Y)" paren form, B has neither.
   // Return brewery raw so we can compute aliases in JS (SQLite has no JS regex).
   const candidates = db
     .prepare(

--- a/src/jobs/dedupe-brewery-aliases.ts
+++ b/src/jobs/dedupe-brewery-aliases.ts
@@ -1,6 +1,6 @@
 import type pino from 'pino';
 import type { DB } from '../storage/db';
-import { brewerySlashAliases } from '../domain/matcher';
+import { breweryAliases } from '../domain/matcher';
 
 interface PairCandidate {
   canonical_id: number;
@@ -39,7 +39,7 @@ export function dedupeBreweryAliases(db: DB, log: pino.Logger): DedupeResult {
   // Group by orphan_id to ensure each orphan is merged into its earliest canonical.
   const pairsByOrphan = new Map<number, PairCandidate>();
   for (const c of candidates) {
-    const aliases = new Set(brewerySlashAliases(c.canonical_brewery));
+    const aliases = new Set(breweryAliases(c.canonical_brewery));
     if (!aliases.has(c.orphan_norm_brewery)) continue;
     if (!pairsByOrphan.has(c.orphan_id)) pairsByOrphan.set(c.orphan_id, c);
   }

--- a/src/jobs/dedupe-brewery-aliases.ts
+++ b/src/jobs/dedupe-brewery-aliases.ts
@@ -30,7 +30,8 @@ export function dedupeBreweryAliases(db: DB, log: pino.Logger): DedupeResult {
         AND a.id <> b.id
        WHERE a.untappd_id IS NOT NULL
          AND b.untappd_id IS NULL
-         AND a.brewery LIKE '% / %'
+         AND (a.brewery LIKE '% / %'
+              OR (a.brewery LIKE '%(%' AND a.brewery LIKE '%)%'))
        ORDER BY a.id, b.id`,
     )
     .all() as PairCandidate[];


### PR DESCRIPTION
## Summary
- Extend `breweryAliases` (renamed from `brewerySlashAliases`) to split `X (Y)` paren-form German aliases alongside the existing `X / Y` slash form.
- Broaden `dedupeBreweryAliases` SQL candidate filter to surface paren-form canonical rows; the startup job now collapses duplicates of both shapes on boot.
- Add §10 footgun bullet to the master spec documenting the new alias form.

Implements PR-A from \`docs/superpowers/specs/2026-05-10-paren-alias-and-had-list.md\`. PR-B (scrape-based had-list) follows.

## Root cause this fixes
User reported \`/newbeers\` showing \"Kemker Kultuur Brewery — Stadt Land Bier\" after drinking it on Untappd. Investigation found two rows in \`beers\` for that beer (id 12061 ontap-side, id 12093 untappd-side) — different \`normalized_brewery\` because the paren form \"Kemker Kultuur (Brauerei J. Kemker)\" did not alias-overlap with \"Kemker Kultuur Brewery\". 6 known paren-form dup pairs in prod data (Kemker, Smykan, DOM Brewery, Maryensztadt, etc.).

## Test plan
- [x] Full Jest suite green locally (214 / 214 across 33 suites)
- [x] \`npm run typecheck\` clean
- [ ] After merge + deploy: startup logs show \`dedupe-brewery-aliases: merged orphan ontap rows\` with non-zero pairs count
- [ ] After merge + deploy: \`SELECT COUNT(*) FROM beers WHERE name='Stadt Land Bier'\` returns 1, not 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)