### PR TITLE
docs: spec + plan for paren-alias dedup and had-list

### DIFF
--- a/docs/superpowers/plans/2026-05-10-paren-alias-dedup.md
+++ b/docs/superpowers/plans/2026-05-10-paren-alias-dedup.md
@@ -1,0 +1,445 @@
+# Paren-alias dedup (PR-A) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend brewery alias matching to handle parenthesized German aliases ("X (Y)") parallel to the existing slash form, and let the startup dedupe job collapse the duplicates this gap left in the catalog.
+
+**Architecture:** Rename `brewerySlashAliases` → `breweryAliases` in `src/domain/matcher.ts` and broaden its return to include both `/`-split halves and `(...)`-split inner/outer segments. Extend `dedupeBreweryAliases`' SQL candidate filter to also match `LIKE '%(%' AND LIKE '%)%'`. No schema changes, no new tables. The same alias-overlap check carries through both consumers.
+
+**Tech Stack:** TypeScript, Jest, better-sqlite3 (`:memory:` for tests), pino logger. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-05-10-paren-alias-and-had-list.md` (PR-A section).
+
+**Branch:** `feat/paren-alias-dedup` off `main`.
+
+---
+
+## File Structure
+
+- **Modify** `src/domain/matcher.ts` — rename `brewerySlashAliases` to `breweryAliases`, extend logic to handle `X (Y)` form; update all call sites in this file.
+- **Modify** `src/domain/matcher.test.ts` — add tests for the paren-alias form (plain `X`, `X / Y`, `X (Y)`, mixed `X / Y (Z)`).
+- **Modify** `src/jobs/dedupe-brewery-aliases.ts` — update import to new name, extend SQL `WHERE` clause to include paren-form candidates.
+- **Modify** `src/jobs/dedupe-brewery-aliases.test.ts` — add test that paren-form duplicate pair (Kemker case) is merged.
+- **Modify** `docs/superpowers/specs/2026-04-22-warsaw-beer-bot-design.md` — add §10 bullet documenting paren-alias matching as a known footgun.
+
+---
+
+## Task 1: Worktree + branch setup
+
+**Files:** none yet — workspace prep only.
+
+- [ ] **Step 1: Create isolated worktree off main**
+
+Run:
+```bash
+cd /root/warsaw-beer-bot
+git fetch origin main
+git worktree add -b feat/paren-alias-dedup ../warsaw-beer-bot-paren-alias origin/main
+cd ../warsaw-beer-bot-paren-alias
+```
+
+Expected: new worktree at `../warsaw-beer-bot-paren-alias` on branch `feat/paren-alias-dedup`.
+
+- [ ] **Step 2: Install dependencies**
+
+Run: `npm ci`
+Expected: clean install, exits 0.
+
+- [ ] **Step 3: Baseline green suite**
+
+Run: `npm test -- --silent`
+Expected: all tests pass. Confirms baseline before edits.
+
+---
+
+## Task 2: TDD — failing test for `breweryAliases` paren form
+
+**Files:**
+- Modify: `src/domain/matcher.test.ts` (add tests above existing block)
+
+- [ ] **Step 1: Add failing tests for `breweryAliases`**
+
+At the top of `src/domain/matcher.test.ts`, change the import line:
+
+```typescript
+import { matchBeer, breweryAliases, type CatalogBeer } from './matcher';
+```
+
+Then add this `describe` block immediately after the imports and `c` factory (before the existing top-level `test('exact normalized match...')`):
+
+```typescript
+describe('breweryAliases', () => {
+  test('plain brewery returns one alias', () => {
+    expect(breweryAliases('Pinta')).toEqual(['pinta']);
+  });
+
+  test('drops noise words consistent with normalizeBrewery', () => {
+    expect(breweryAliases('Piwne Podziemie Brewery')).toEqual(['piwne podziemie']);
+  });
+
+  test('slash form returns full + each half', () => {
+    const out = breweryAliases('Piwne Podziemie / Beer Underground');
+    expect(new Set(out)).toEqual(
+      new Set(['piwne podziemie beer underground', 'piwne podziemie', 'beer underground']),
+    );
+  });
+
+  test('paren form returns full + outer + inner', () => {
+    const out = breweryAliases('Kemker Kultuur (Brauerei J. Kemker)');
+    expect(new Set(out)).toEqual(
+      new Set([
+        'kemker kultuur brauerei j kemker',
+        'kemker kultuur',
+        'brauerei j kemker',
+      ]),
+    );
+  });
+
+  test('mixed slash + paren splits on both', () => {
+    const out = breweryAliases('AleBrowar / Kemker Kultuur (Brauerei J. Kemker)');
+    expect(out).toContain('alebrowar');
+    expect(out).toContain('kemker kultuur');
+    expect(out).toContain('brauerei j kemker');
+  });
+
+  test('empty input returns empty array', () => {
+    expect(breweryAliases('')).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the new tests and confirm they fail**
+
+Run: `npm test -- --testPathPattern=matcher --silent`
+Expected: import error / "breweryAliases is not a function" — the symbol doesn't exist yet. Existing `matcher.test.ts` tests should still attempt to run (the file-level import failure will fail every test in the file; that is OK and expected for this red phase).
+
+---
+
+## Task 3: Implement `breweryAliases`
+
+**Files:**
+- Modify: `src/domain/matcher.ts:26-32` (rename + replace body)
+
+- [ ] **Step 1: Replace `brewerySlashAliases` with `breweryAliases`**
+
+In `src/domain/matcher.ts`, replace the existing function and the comment block immediately preceding it (lines 20-32) with:
+
+```typescript
+// Untappd records breweries either as a single name ("Piwne Podziemie Brewery"),
+// as an "X / Y" alias used for bilingual ("Piwne Podziemie / Beer Underground")
+// or collaboration ("AleBrowar / Poppels Bryggeri") pairs, or as an "X (Y)"
+// form for German aliases ("Kemker Kultuur (Brauerei J. Kemker)").
+// Ontap.pl renders only one of these. For matching purposes all three forms
+// collapse to: "any side of the separator is a valid brewery for this beer".
+export function breweryAliases(brewery: string): string[] {
+  const aliases = new Set<string>();
+  const full = normalizeBrewery(brewery);
+  if (full) aliases.add(full);
+
+  const slashParts = brewery.includes(' / ') ? brewery.split(' / ') : [brewery];
+  for (const part of slashParts) {
+    const parenMatch = part.match(/^(.+?)\s*\((.+)\)\s*$/);
+    if (parenMatch) {
+      const outer = normalizeBrewery(parenMatch[1]);
+      const inner = normalizeBrewery(parenMatch[2]);
+      if (outer) aliases.add(outer);
+      if (inner) aliases.add(inner);
+    } else {
+      const norm = normalizeBrewery(part);
+      if (norm) aliases.add(norm);
+    }
+  }
+
+  return Array.from(aliases);
+}
+```
+
+- [ ] **Step 2: Update call sites in matcher.ts**
+
+In the same file, replace every occurrence of `brewerySlashAliases` with `breweryAliases`. The current call sites (per `grep -n 'brewerySlashAliases'`) are lines 42, 50, 69, and a comment reference on line 78. Use `replace_all` on the symbol; then in the line-78 comment update the wording from "appears at index 0 of brewerySlashAliases" to "appears at index 0 of breweryAliases".
+
+- [ ] **Step 3: Run the `breweryAliases` tests**
+
+Run: `npm test -- --testPathPattern=matcher --silent`
+Expected: all `breweryAliases` tests pass; the existing `matchBeer` tests still pass (they exercise the same path through the renamed function).
+
+- [ ] **Step 4: Typecheck**
+
+Run: `npm run typecheck`
+Expected: exit 0. If the dedupe job still imports the old name it will error here — that's fixed in Task 4.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/domain/matcher.ts src/domain/matcher.test.ts
+git commit -m "feat(matcher): extend breweryAliases to handle X (Y) paren form"
+```
+
+(Typecheck failure on `dedupe-brewery-aliases.ts` import is expected until Task 4; do NOT amend or skip the commit.)
+
+---
+
+## Task 4: Update dedupe job import
+
+**Files:**
+- Modify: `src/jobs/dedupe-brewery-aliases.ts:3` (import) and `:42` (call site)
+
+- [ ] **Step 1: Update import + call site**
+
+In `src/jobs/dedupe-brewery-aliases.ts`, change line 3 from:
+
+```typescript
+import { brewerySlashAliases } from '../domain/matcher';
+```
+
+to:
+
+```typescript
+import { breweryAliases } from '../domain/matcher';
+```
+
+And on line 42, change:
+
+```typescript
+    const aliases = new Set(brewerySlashAliases(c.canonical_brewery));
+```
+
+to:
+
+```typescript
+    const aliases = new Set(breweryAliases(c.canonical_brewery));
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npm run typecheck`
+Expected: exit 0.
+
+- [ ] **Step 3: Run dedupe tests (paren handling not yet wired through SQL — slash tests must still pass)**
+
+Run: `npm test -- --testPathPattern=dedupe-brewery-aliases --silent`
+Expected: all existing tests still pass. The job behaves identically for slash-form input because the SQL filter hasn't changed yet.
+
+---
+
+## Task 5: TDD — failing test for paren-form dedup
+
+**Files:**
+- Modify: `src/jobs/dedupe-brewery-aliases.test.ts` (add new test)
+
+- [ ] **Step 1: Add failing test for the Kemker case**
+
+Read the bottom of `src/jobs/dedupe-brewery-aliases.test.ts` to find where to insert. Add the following test inside the existing `describe('dedupeBreweryAliases', ...)` block, after the last existing `test(...)`:
+
+```typescript
+  test('merges paren-form alias pair (Kemker Kultuur case)', () => {
+    const db = fresh();
+    // Canonical Untappd-side row — brewery in "X (Y)" form.
+    const aId = upsertBeer(db, {
+      untappd_id: 2133795,
+      name: 'Stadt Land Bier',
+      brewery: 'Kemker Kultuur (Brauerei J. Kemker)',
+      style: null,
+      abv: null,
+      rating_global: null,
+      normalized_name: 'stadt land bier',
+      normalized_brewery: 'kemker kultuur brauerei j kemker',
+    });
+    // Orphan ontap-side row — normalized brewery matches one alias half.
+    const bId = upsertBeer(db, {
+      untappd_id: null,
+      name: 'Stadt Land Bier',
+      brewery: 'Kemker Kultuur Brewery',
+      style: null,
+      abv: null,
+      rating_global: null,
+      normalized_name: 'stadt land bier',
+      normalized_brewery: 'kemker kultuur',
+    });
+    upsertMatch(db, 'Stadt Land Bier', bId, 1.0);
+    ensureProfile(db, 42);
+    mergeCheckin(db, {
+      checkin_id: 'kemker-1',
+      telegram_id: 42,
+      beer_id: bId,
+      user_rating: 4.5,
+      checkin_at: '2026-05-10T12:00:00Z',
+      venue: null,
+    });
+
+    const result = dedupeBreweryAliases(db, silentLog);
+
+    expect(result).toEqual({ pairsMerged: 1, beersDeleted: 1 });
+    // Orphan deleted.
+    const orphan = db.prepare('SELECT id FROM beers WHERE id = ?').get(bId);
+    expect(orphan).toBeUndefined();
+    // Canonical survives.
+    const canonical = db.prepare('SELECT id FROM beers WHERE id = ?').get(aId);
+    expect(canonical).toEqual({ id: aId });
+    // match_link transferred to canonical.
+    const link = db
+      .prepare('SELECT untappd_beer_id FROM match_links WHERE ontap_ref = ?')
+      .get('Stadt Land Bier') as { untappd_beer_id: number };
+    expect(link.untappd_beer_id).toBe(aId);
+    // Checkin re-pointed to canonical.
+    const checkin = db
+      .prepare('SELECT beer_id FROM checkins WHERE checkin_id = ?')
+      .get('kemker-1') as { beer_id: number };
+    expect(checkin.beer_id).toBe(aId);
+  });
+```
+
+- [ ] **Step 2: Run and confirm the new test fails**
+
+Run: `npm test -- --testPathPattern=dedupe-brewery-aliases --silent`
+Expected: the new "paren-form alias pair" test fails because the SQL filter `WHERE a.brewery LIKE '% / %'` excludes the canonical row (no slash in its brewery name). All other tests still pass.
+
+---
+
+## Task 6: Extend dedupe SQL candidate filter
+
+**Files:**
+- Modify: `src/jobs/dedupe-brewery-aliases.ts:33` (the `WHERE` clause)
+
+- [ ] **Step 1: Broaden the `WHERE` clause**
+
+In `src/jobs/dedupe-brewery-aliases.ts`, locate the SELECT statement (around lines 21-35). Change the filter line from:
+
+```typescript
+         AND a.brewery LIKE '% / %'
+```
+
+to:
+
+```typescript
+         AND (a.brewery LIKE '% / %'
+              OR (a.brewery LIKE '%(%' AND a.brewery LIKE '%)%'))
+```
+
+The outer parentheses keep the OR scoped under the preceding `AND a.untappd_id IS NOT NULL AND b.untappd_id IS NULL` conditions.
+
+- [ ] **Step 2: Run the dedupe test suite**
+
+Run: `npm test -- --testPathPattern=dedupe-brewery-aliases --silent`
+Expected: all tests pass, including the new Kemker case. The existing Piwne-Podziemie slash test still passes (the new OR-branch is additive).
+
+- [ ] **Step 3: Full suite + typecheck**
+
+Run: `npm test -- --silent`
+Then: `npm run typecheck`
+Expected: both exit 0. No unrelated regressions.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/jobs/dedupe-brewery-aliases.ts src/jobs/dedupe-brewery-aliases.test.ts
+git commit -m "feat(dedupe): merge paren-form brewery alias duplicates at startup"
+```
+
+---
+
+## Task 7: Update master spec §10 (footgun list)
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-04-22-warsaw-beer-bot-design.md`
+
+- [ ] **Step 1: Locate the §10 list**
+
+Open `docs/superpowers/specs/2026-04-22-warsaw-beer-bot-design.md` and find the bullet list under the "Грабельки що ми вже наступили" heading (per prior `grep`, around lines 395-426 — verify with a Read before editing). The last bullet today is **Rating fallback (catalog → tap)** ending with the line that says "...the ~2 % of rows where the catalog has one but the tap doesn't."
+
+- [ ] **Step 2: Insert the new bullet immediately after the rating-fallback bullet, before the closing line `Ці грабельки — чек-лист на першу секунду нового деплою.`**
+
+Append exactly:
+
+```markdown
+- **Paren-form brewery aliases**: Untappd renders some breweries with a
+  parenthesized German alias — "Kemker Kultuur (Brauerei J. Kemker)" —
+  parallel to the "X / Y" bilingual/collab form. `breweryAliases`
+  (`src/domain/matcher.ts`) splits BOTH forms so that either side counts
+  as a valid brewery for the beer. Missing the paren form let
+  ontap-side rows fail to find their Untappd canonical and create
+  duplicates (caught 2026-05-10 via duplicated `beers#12061/12093`
+  for *Stadt Land Bier*; startup `dedupeBreweryAliases` now sweeps both
+  forms on boot).
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-04-22-warsaw-beer-bot-design.md
+git commit -m "docs(spec): document paren-form brewery aliases in §10 footguns"
+```
+
+---
+
+## Task 8: Verification before push
+
+**Files:** none — final checks only.
+
+- [ ] **Step 1: Final full suite**
+
+Run: `npm test -- --silent`
+Expected: every test passes.
+
+- [ ] **Step 2: Final typecheck**
+
+Run: `npm run typecheck`
+Expected: exit 0.
+
+- [ ] **Step 3: Inspect git log on the branch**
+
+Run: `git log --oneline main..HEAD`
+Expected: three commits in order — matcher rename/extend, dedupe SQL change, spec §10 update.
+
+- [ ] **Step 4: Inspect cumulative diff**
+
+Run: `git diff main...HEAD --stat`
+Expected: five files touched — `src/domain/matcher.ts`, `src/domain/matcher.test.ts`, `src/jobs/dedupe-brewery-aliases.ts`, `src/jobs/dedupe-brewery-aliases.test.ts`, `docs/superpowers/specs/2026-04-22-warsaw-beer-bot-design.md`. No stray edits.
+
+---
+
+## Task 9: Push + open PR
+
+**Files:** none — GitHub interaction.
+
+- [ ] **Step 1: Push the branch**
+
+Run: `git push -u origin feat/paren-alias-dedup`
+Expected: branch published to origin.
+
+- [ ] **Step 2: Open PR via gh**
+
+Run:
+```bash
+gh pr create --title "feat: paren-alias brewery dedup (PR-A)" --body "$(cat <<'EOF'
+## Summary
+- Extend `breweryAliases` (renamed from `brewerySlashAliases`) to split `X (Y)` paren-form German aliases alongside the existing `X / Y` slash form.
+- Broaden `dedupeBreweryAliases` SQL candidate filter to match paren-form canonical rows; the startup job now collapses duplicates of both shapes on boot.
+- Add §10 footgun bullet to the master spec.
+
+Implements PR-A from `docs/superpowers/specs/2026-05-10-paren-alias-and-had-list.md`.
+PR-B (scrape-based had-list) follows.
+
+## Test plan
+- [ ] `npm test` green locally
+- [ ] After merge + deploy: startup logs show `dedupe-brewery-aliases: merged orphan ontap rows` for the Kemker pair (and ~5 other paren pairs in prod data)
+- [ ] After merge + deploy: `SELECT COUNT(*) FROM beers WHERE name='Stadt Land Bier'` returns 1, not 2
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR URL printed.
+
+- [ ] **Step 3: Report PR URL back to the user**
+
+Stop here. User reviews + merges. Deployment smoke (the two checkbox items in the PR body) happens after merge.
+
+---
+
+## What this plan does NOT cover
+
+- The new `untappd_had` table, `markHad` / `hadBeerIds` / `triedBeerIds` helpers, and the scrape-job + filter wiring — all of those belong to PR-B, with its own plan in a follow-up branch (`feat/scrape-had-list`).
+- USER-GUIDE changes — none in PR-A; user-facing behavior is unchanged. PR-B will update USER-GUIDE.
+- Worktree teardown — done after PR merges, not part of this plan.

--- a/docs/superpowers/specs/2026-05-10-paren-alias-and-had-list.md
+++ b/docs/superpowers/specs/2026-05-10-paren-alias-and-had-list.md
@@ -1,0 +1,224 @@
+# Paren-alias dedup + scrape-based had-list
+
+**Date:** 2026-05-10
+**Branch sequence:** `feat/paren-alias-dedup` (PR-A) → `feat/scrape-had-list` (PR-B)
+
+## Background
+
+Bug report: `/newbeers` showed *Kemker Kultuur Brewery — Stadt Land Bier* even
+though the user had drunk it according to Untappd.
+
+Investigation revealed two independent gaps that compound:
+
+1. **Catalog dedup gap.** The `beers` table held two rows for the same beer:
+   - `id=12061`, `untappd_id=NULL`, `brewery="Kemker Kultuur Brewery"`,
+     `normalized_brewery="kemker kultuur"` (ontap-side row).
+   - `id=12093`, `untappd_id=2133795`, `brewery="Kemker Kultuur (Brauerei J. Kemker)"`,
+     `normalized_brewery="kemker kultuur brauerei j kemker"` (untappd-side row).
+
+   `brewerySlashAliases` collapses `X / Y` collaboration/bilingual breweries
+   into either-side aliases, but does NOT handle the parenthesized form
+   `X (Y)` Untappd uses for German breweries. So `matchBeer` in the ontap
+   pipeline did not find the existing Untappd row and inserted a duplicate.
+   `dedupeBreweryAliases` (the startup cleanup) only inspects `LIKE '% / %'`
+   rows, so it never fired for paren-form pairs either.
+
+2. **Drunk-set coverage gap.** `drunkBeerIds(db, tg_id)` returns only beers
+   present in `checkins`, which is populated exclusively by manual
+   `/import`. The `refreshAllUntappd` job scrapes the user's
+   `/user/<X>/beers` page (the trailing-25 had-list, hard cap because the
+   page does not paginate unauthenticated) but only writes `rating_global` —
+   it does not record per-user "had" state. A user who hasn't re-imported
+   since their last check-in still sees that beer in `/newbeers`.
+
+The user's stated workflow: `/import` is a one-off backfill plus a
+post-festival catch-up. Day-to-day filtering must work without it.
+
+## Goals
+
+- After PR-A: existing paren-form duplicates merge into the Untappd-side
+  canonical row at next startup, and future ontap scrapes match the
+  canonical row directly.
+- After PR-B: a beer is filtered out of `/newbeers` and `/route` if either
+  the user has a checkin for it OR the daily scrape has seen it on their
+  Untappd had-list. `/import` is no longer required for daily use; it
+  remains the bulk-backfill / post-festival path.
+
+## Non-goals
+
+- Increasing the 25-item scrape cap. Untappd does not paginate the
+  `/user/<X>/beers` page anonymously; logged-in scraping is out of scope.
+- Migrating existing checkins out of the `checkins` table. The two stores
+  coexist and are unioned at read time.
+- A general-purpose alias system for arbitrary brewery name variations
+  beyond `/` and `(...)`.
+
+## PR-A — Paren-alias dedup
+
+### Matcher change
+
+Rename `brewerySlashAliases` to `breweryAliases` and extend it to return
+the union of:
+
+1. The full normalized brewery (always present).
+2. For each `/`-separated half: that half's normalized form.
+3. For each `(...)`-enclosed segment: the inner text's normalized form,
+   AND the outer text (everything outside parentheses) as its normalized
+   form.
+
+Example: `Kemker Kultuur (Brauerei J. Kemker)` →
+`["kemker kultuur brauerei j kemker", "kemker kultuur", "brauerei j kemker"]`.
+
+Mixed forms (`X / Y (Z)`) split on `/` first, then each half splits on
+`(...)`. We have not seen this in production data but the algorithm
+handles it for free.
+
+`matchBeer` continues to call `breweryAliases` for both input and each
+catalog row and computes overlap. No further changes there — the existing
+`brewerySetsOverlap` + fuzzy fallback logic carries through.
+
+### Dedup job change
+
+`dedupeBreweryAliases` currently filters candidates with
+`a.brewery LIKE '% / %'`. Extend to also match paren form:
+
+```sql
+WHERE (a.brewery LIKE '% / %' OR (a.brewery LIKE '%(%' AND a.brewery LIKE '%)%'))
+```
+
+The in-JS overlap check (`brewerySlashAliases(canonical)` → set, check
+`orphan.normalized_brewery` membership) keeps the same shape but uses the
+new `breweryAliases` function. The merge transaction (transfer
+`match_links`, transfer `checkins`, delete orphan) is unchanged.
+
+### One-time cleanup
+
+The dedup job already runs at startup. The first boot after PR-A merges
+will pick up paren-form duplicates and merge them. The
+`Stadt Land Bier` pair (12061 → 12093) and the ~5 other identified pairs
+collapse on that boot. Idempotent — second boot finds zero candidates.
+
+### Tests
+
+- Unit: `breweryAliases` for three forms (plain, `X / Y`, `X (Y)`) and
+  the mixed `X / Y (Z)` form.
+- Unit/integration: `dedupeBreweryAliases` with an in-memory DB seeded
+  with a paren-form duplicate pair, asserting merge + match_link
+  transfer + orphan deletion.
+
+## PR-B — Scrape-based had-list
+
+### New table
+
+```sql
+CREATE TABLE untappd_had (
+  telegram_id INTEGER NOT NULL,
+  beer_id INTEGER NOT NULL REFERENCES beers(id) ON DELETE CASCADE,
+  last_seen_at TEXT NOT NULL,
+  PRIMARY KEY (telegram_id, beer_id)
+);
+CREATE INDEX idx_untappd_had_telegram ON untappd_had(telegram_id);
+```
+
+Append-only with respect to user intent — once a beer is marked had, it
+stays had even if it falls out of the trailing-25 window on Untappd.
+`last_seen_at` is informational; not used for filtering.
+
+### Storage helpers
+
+`src/storage/untappd_had.ts`:
+
+```ts
+export function markHad(db: DB, telegramId: number, beerId: number, at: string): void;
+export function hadBeerIds(db: DB, telegramId: number): Set<number>;
+```
+
+`markHad` uses `INSERT ... ON CONFLICT(telegram_id, beer_id) DO UPDATE
+SET last_seen_at = excluded.last_seen_at`.
+
+### Scrape job change
+
+In `refreshAllUntappd`, after the `upsertBeer` / `findBeerByNormalized`
+branch resolves to a `beer_id`, call `markHad(db, p.telegram_id,
+beer_id, new Date().toISOString())`. The existing job runs each
+beer-row write inline (no transaction), and a partial scrape is
+already tolerated — `had` marks share that semantics. Wrap the
+per-profile inner loop in `db.transaction(...)` only if the row count
+warrants it during implementation; the spec does not require it.
+
+### Read-side filter change
+
+Introduce `triedBeerIds(db, telegramId): Set<number>` =
+`drunkBeerIds ∪ hadBeerIds`. `drunkBeerIds` keeps its current signature
+(internal, used by checkin-specific code paths). `/newbeers` and `/route`
+switch their filter input to `triedBeerIds`.
+
+`filterInteresting`'s parameter is currently named `drunk` — rename to
+`tried` for clarity; the type stays `Set<number>`.
+
+### Tests
+
+- Unit: `markHad` (insert + upsert) and `hadBeerIds` returning the right
+  set for the right user.
+- Unit: `triedBeerIds` returning the union, with cases where only
+  checkins / only had / both / neither match.
+- Integration: stub the scraper, run `refreshAllUntappd` against an
+  in-memory DB with a profile, assert `untappd_had` rows for that
+  user-beer pair after the run.
+- Integration: `/newbeers` excludes a beer that's only in `untappd_had`
+  (no checkin), confirming the union flows end-to-end.
+
+## Architecture spec updates (master spec §10)
+
+Two new bullets under "Грабельки що ми вже наступили":
+
+- **Paren-form brewery aliases.** Untappd renders breweries as `X (Y)`
+  for German aliases ("Kemker Kultuur (Brauerei J. Kemker)"), parallel
+  to the `X / Y` collaboration/bilingual form. Alias-overlap matching
+  must treat both forms as "either side is a valid brewery for this
+  beer", or ontap-side rows fail to find their Untappd canonical and
+  duplicate. Caught 2026-05-10 via duplicate `beers#12061/12093`.
+
+- **Two-source drunk model.** A beer is filtered from `/newbeers` and
+  `/route` if it appears in EITHER `checkins` (manual `/import` bulk and
+  post-festival catch-up) OR `untappd_had` (per-user trailing-25
+  incremental scrape, populated by `refreshAllUntappd`). Relying on
+  checkins alone forces users into a constant re-import loop for
+  day-to-day use. Caught 2026-05-10 — same bug report as above.
+
+## USER-GUIDE updates
+
+Insert near the existing `/import` description:
+
+> Для повсякденного відстеження достатньо вказати свій Untappd username
+> через `/setuser <ім'я>`. Бот раз на добу підхоплює останні 25 пив зі
+> сторінки `/user/<ім'я>/beers` і виключає їх з `/newbeers` та `/route`.
+>
+> `/import` потрібен для одноразового завантаження повної історії та
+> після фестивалів, коли check-ins за день набагато перевищують 25.
+
+## Rollout
+
+1. Ship PR-A. Smoke after merge: confirm duplicate pairs (Kemker, Smykan
+   etc.) merged in startup logs. Verify `/newbeers` no longer references
+   a duplicated row in production data.
+2. Ship PR-B. Wait for one full `refreshAllUntappd` cycle (≤24h) to
+   populate `untappd_had` for the active user. Smoke `/newbeers` —
+   beers from the user's recent had-list should disappear.
+3. Capture any new gaps in §14 lessons.
+
+## Risks
+
+- **Paren-alias false positives.** A brewery legitimately named
+  `Browar X (od 1923 r.)` would have its parenthetical interpreted as
+  an alias. Mitigation: alias overlap is checked against actual catalog
+  rows — a non-brewery parenthetical won't match any other row's
+  brewery, so false aliasing is harmless in practice. We accept the
+  imperfection; an allowlist of "known brewery aliases" is overkill.
+- **Backfill cost on first boot.** PR-A's startup cleanup runs over the
+  whole catalog (~12k rows). Already true today for the slash form;
+  paren scan is the same shape and SQL plan. No new cost concern.
+- **Untappd HTML drift.** `MAX_ITEMS = 25` is enforced in the parser; if
+  Untappd changes the page structure, both the rating refresh and the
+  had-list mark fail at once. Already a known fragility — same code
+  path. Existing `userBeersScrape` tests cover the parser.


### PR DESCRIPTION
## Summary
Adds documentation for the two-part fix that PR #39 began:
- `docs/superpowers/specs/2026-05-10-paren-alias-and-had-list.md` — combined spec for PR-A (paren-alias dedup, shipped) and PR-B (scrape-based had-list, next).
- `docs/superpowers/plans/2026-05-10-paren-alias-dedup.md` — the TDD implementation plan PR #39 executed against.

Docs only, no code changes.

## Test plan
- [x] No code touched (verified by `git diff` — 2 new files only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)