### PR TITLE
feat: /refresh auto-shows /newbeers on success

### DIFF
--- a/src/bot/commands/newbeers-build.test.ts
+++ b/src/bot/commands/newbeers-build.test.ts
@@ -1,0 +1,108 @@
+import { openDb } from '../../storage/db';
+import { migrate } from '../../storage/schema';
+import { upsertPub } from '../../storage/pubs';
+import { createSnapshot, insertTaps } from '../../storage/snapshots';
+import { upsertBeer } from '../../storage/beers';
+import { upsertMatch } from '../../storage/match_links';
+import { createTranslator } from '../../i18n';
+import { buildNewbeersMessage } from './newbeers-build';
+
+function fresh() {
+  const db = openDb(':memory:');
+  migrate(db);
+  return db;
+}
+
+describe('buildNewbeersMessage', () => {
+  test('returns null when there are no snapshots at all', () => {
+    const db = fresh();
+    const t = createTranslator('uk');
+    expect(buildNewbeersMessage({ db, telegramId: 1, locale: 'uk', t })).toBeNull();
+  });
+
+  test('returns null when snapshots exist but no tap survives filtering', () => {
+    const db = fresh();
+    const pubId = upsertPub(db, { slug: 'p', name: 'P', address: null, lat: null, lon: null });
+    const snapId = createSnapshot(db, pubId, '2026-05-24T12:00:00Z');
+    // Tap with no match_links row → beer_id is NULL, but filterInteresting
+    // still allows it under default filters. To force an empty result we
+    // simply do not insert any taps at all.
+    void snapId;
+    const t = createTranslator('uk');
+    expect(buildNewbeersMessage({ db, telegramId: 1, locale: 'uk', t })).toBeNull();
+  });
+
+  test('returns non-null HTML containing the beer when a matched tap exists', () => {
+    const db = fresh();
+    const pubId = upsertPub(db, {
+      slug: 'pub-a', name: 'Pub A', address: null, lat: null, lon: null,
+    });
+    const snapId = createSnapshot(db, pubId, '2026-05-24T12:00:00Z');
+    const beerId = upsertBeer(db, {
+      untappd_id: 100,
+      name: 'Atak Chmielu',
+      brewery: 'Pinta',
+      style: 'AIPA',
+      abv: 6.1,
+      rating_global: 3.85,
+      normalized_name: 'atak chmielu',
+      normalized_brewery: 'pinta',
+    });
+    upsertMatch(db, 'PINTA Atak Chmielu', beerId, 1.0);
+    insertTaps(db, snapId, [
+      {
+        tap_number: 1,
+        beer_ref: 'PINTA Atak Chmielu',
+        brewery_ref: 'PINTA',
+        abv: 6.1,
+        ibu: null,
+        style: 'AIPA',
+        u_rating: 3.9,
+      },
+    ]);
+
+    const t = createTranslator('uk');
+    const out = buildNewbeersMessage({ db, telegramId: 1, locale: 'uk', t });
+    expect(out).not.toBeNull();
+    expect(out).toContain('Atak Chmielu');
+    expect(out).toContain('Pub A');
+  });
+
+  test('returns null when the user has already tried (triedBeerIds) the only tap', () => {
+    const db = fresh();
+    const pubId = upsertPub(db, {
+      slug: 'pub-a', name: 'Pub A', address: null, lat: null, lon: null,
+    });
+    const snapId = createSnapshot(db, pubId, '2026-05-24T12:00:00Z');
+    const beerId = upsertBeer(db, {
+      untappd_id: 200,
+      name: 'Buty Skejta',
+      brewery: 'Stu Mostow',
+      style: 'Pils',
+      abv: 5.0,
+      rating_global: 3.5,
+      normalized_name: 'buty skejta',
+      normalized_brewery: 'stu mostow',
+    });
+    upsertMatch(db, 'Stu Mostow Buty Skejta', beerId, 1.0);
+    insertTaps(db, snapId, [
+      {
+        tap_number: 1,
+        beer_ref: 'Stu Mostow Buty Skejta',
+        brewery_ref: 'Stu Mostow',
+        abv: 5.0,
+        ibu: null,
+        style: 'Pils',
+        u_rating: 3.7,
+      },
+    ]);
+
+    // Mark the user as having had this beer via untappd_had.
+    db.prepare(
+      'INSERT INTO untappd_had (telegram_id, beer_id, last_seen_at) VALUES (?, ?, ?)',
+    ).run(1, beerId, '2026-05-24T11:00:00Z');
+
+    const t = createTranslator('uk');
+    expect(buildNewbeersMessage({ db, telegramId: 1, locale: 'uk', t })).toBeNull();
+  });
+});

--- a/src/bot/commands/newbeers-build.ts
+++ b/src/bot/commands/newbeers-build.ts
@@ -1,0 +1,58 @@
+import type { DB } from '../../storage/db';
+import type { Locale, Translator } from '../../i18n/types';
+import { latestSnapshotsPerPub, tapsForSnapshotWithBeer } from '../../storage/snapshots';
+import { triedBeerIds } from '../../storage/untappd_had';
+import { getFilters } from '../../storage/user_filters';
+import { filterInteresting } from '../../domain/filters';
+import { listPubs } from '../../storage/pubs';
+import { normalizeBrewery, normalizeName } from '../../domain/normalize';
+import {
+  groupTaps,
+  rankGroups,
+  formatGroupedBeers,
+  type CandidateTap,
+} from './newbeers-format';
+
+export interface NewbeersDeps {
+  db: DB;
+  telegramId: number;
+  locale: Locale;
+  t: Translator;
+}
+
+export function buildNewbeersMessage(deps: NewbeersDeps): string | null {
+  const { db, telegramId, locale, t } = deps;
+  const tried = triedBeerIds(db, telegramId);
+  const filters =
+    getFilters(db, telegramId) ?? {
+      styles: [],
+      min_rating: null,
+      abv_min: null,
+      abv_max: null,
+      default_route_n: null,
+    };
+  const pubs = new Map(listPubs(db).map((p) => [p.id, p]));
+
+  const candidates: CandidateTap[] = [];
+  for (const snap of latestSnapshotsPerPub(db)) {
+    const pub = pubs.get(snap.pub_id);
+    if (!pub) continue;
+    const taps = tapsForSnapshotWithBeer(db, snap.id);
+    const good = filterInteresting(taps, tried, filters);
+    for (const tap of good) {
+      const display = tap.brewery_ref ? `${tap.brewery_ref} ${tap.beer_ref}`.trim() : tap.beer_ref;
+      candidates.push({
+        beer_id: tap.beer_id,
+        display,
+        brewery_norm: normalizeBrewery(tap.brewery_ref ?? ''),
+        name_norm: normalizeName(tap.beer_ref),
+        abv: tap.abv,
+        rating: tap.u_rating,
+        pub_name: pub.name,
+      });
+    }
+  }
+
+  const text = formatGroupedBeers(rankGroups(groupTaps(candidates)), locale, t);
+  return text || null;
+}

--- a/src/bot/commands/newbeers.ts
+++ b/src/bot/commands/newbeers.ts
@@ -1,53 +1,15 @@
 import { Composer } from 'telegraf';
 import type { BotContext } from '../index';
-import { latestSnapshotsPerPub, tapsForSnapshotWithBeer } from '../../storage/snapshots';
-import { triedBeerIds } from '../../storage/untappd_had';
-import { getFilters } from '../../storage/user_filters';
-import { filterInteresting } from '../../domain/filters';
-import { listPubs } from '../../storage/pubs';
-import { normalizeBrewery, normalizeName } from '../../domain/normalize';
-import {
-  groupTaps,
-  rankGroups,
-  formatGroupedBeers,
-  type CandidateTap,
-} from './newbeers-format';
+import { buildNewbeersMessage } from './newbeers-build';
 
 export const newbeersCommand = new Composer<BotContext>();
 
 newbeersCommand.command('newbeers', async (ctx) => {
-  const db = ctx.deps.db;
-  const tried = triedBeerIds(db, ctx.from.id);
-  const filters =
-    getFilters(db, ctx.from.id) ?? {
-      styles: [],
-      min_rating: null,
-      abv_min: null,
-      abv_max: null,
-      default_route_n: null,
-    };
-  const pubs = new Map(listPubs(db).map((p) => [p.id, p]));
-
-  const candidates: CandidateTap[] = [];
-  for (const snap of latestSnapshotsPerPub(db)) {
-    const pub = pubs.get(snap.pub_id);
-    if (!pub) continue;
-    const taps = tapsForSnapshotWithBeer(db, snap.id);
-    const good = filterInteresting(taps, tried, filters);
-    for (const t of good) {
-      const display = t.brewery_ref ? `${t.brewery_ref} ${t.beer_ref}`.trim() : t.beer_ref;
-      candidates.push({
-        beer_id: t.beer_id,
-        display,
-        brewery_norm: normalizeBrewery(t.brewery_ref ?? ''),
-        name_norm: normalizeName(t.beer_ref),
-        abv: t.abv,
-        rating: t.u_rating,
-        pub_name: pub.name,
-      });
-    }
-  }
-
-  const text = formatGroupedBeers(rankGroups(groupTaps(candidates)), ctx.locale, ctx.t);
-  await ctx.replyWithHTML(text || ctx.t('newbeers.empty'));
+  const text = buildNewbeersMessage({
+    db: ctx.deps.db,
+    telegramId: ctx.from.id,
+    locale: ctx.locale,
+    t: ctx.t,
+  });
+  await ctx.replyWithHTML(text ?? ctx.t('newbeers.empty'));
 });

--- a/src/bot/commands/refresh.test.ts
+++ b/src/bot/commands/refresh.test.ts
@@ -1,4 +1,6 @@
-import { makeThrottledProgress } from './refresh';
+import pino from 'pino';
+import { makeThrottledProgress, runRefreshPipeline } from './refresh';
+import type { Translator } from '../../i18n/types';
 
 describe('makeThrottledProgress', () => {
   test('drops non-forced calls within interval', async () => {
@@ -48,5 +50,98 @@ describe('makeThrottledProgress', () => {
     await notify('a');
     await notify('a', { force: true });
     expect(calls).toEqual(['a']);
+  });
+});
+
+const silentLog = pino({ level: 'silent' });
+
+// `(key: string) => key` is structurally wider than Translator's keyof-Messages
+// constraint, so a double-cast is the smallest type ceremony to use it as a
+// stub here. The pipeline only forwards `t(...)` calls verbatim, so identity
+// is enough.
+const tStub = ((key: string) => key) as unknown as Translator;
+
+interface NotifyCall {
+  text: string;
+  force: boolean;
+}
+
+function makeNotify() {
+  const calls: NotifyCall[] = [];
+  const notify = async (text: string, opts?: { force?: boolean }) => {
+    calls.push({ text, force: opts?.force === true });
+  };
+  return { notify, calls };
+}
+
+describe('runRefreshPipeline', () => {
+  test('on success: refresh.done emitted BEFORE postRun runs', async () => {
+    const { notify, calls } = makeNotify();
+    const events: string[] = [];
+    // Tag the notify so we can sequence notify against run/postRun.
+    const wrappedNotify = async (text: string, opts?: { force?: boolean }) => {
+      events.push(`notify:${text}`);
+      await notify(text, opts);
+    };
+    const run = async () => {
+      events.push('run');
+    };
+    const postRun = async () => {
+      events.push('postRun');
+    };
+
+    await runRefreshPipeline({ run, notify: wrappedNotify, t: tStub, log: silentLog, postRun });
+
+    expect(events).toEqual(['run', 'notify:refresh.done', 'postRun']);
+    expect(calls).toEqual([{ text: 'refresh.done', force: true }]);
+  });
+
+  test('on success without postRun: only refresh.done is emitted', async () => {
+    const { notify, calls } = makeNotify();
+    const run = async () => {};
+
+    await runRefreshPipeline({ run, notify, t: tStub, log: silentLog });
+
+    expect(calls).toEqual([{ text: 'refresh.done', force: true }]);
+  });
+
+  test('postRun throws: error is logged, pipeline still resolves, no refresh.failed', async () => {
+    const { notify, calls } = makeNotify();
+    const errors: unknown[] = [];
+    const log = {
+      error: (obj: unknown) => errors.push(obj),
+      info: () => {},
+      warn: () => {},
+      debug: () => {},
+      trace: () => {},
+      fatal: () => {},
+    } as unknown as typeof silentLog;
+    const run = async () => {};
+    const postRun = async () => {
+      throw new Error('boom');
+    };
+
+    await expect(
+      runRefreshPipeline({ run, notify, t: tStub, log, postRun }),
+    ).resolves.toBeUndefined();
+
+    expect(calls).toEqual([{ text: 'refresh.done', force: true }]);
+    expect(errors).toHaveLength(1);
+  });
+
+  test('run rejects: emits refresh.failed and never calls postRun', async () => {
+    const { notify, calls } = makeNotify();
+    let postRunCalled = false;
+    const run = async () => {
+      throw new Error('scrape died');
+    };
+    const postRun = async () => {
+      postRunCalled = true;
+    };
+
+    await runRefreshPipeline({ run, notify, t: tStub, log: silentLog, postRun });
+
+    expect(postRunCalled).toBe(false);
+    expect(calls).toEqual([{ text: 'refresh.failed', force: true }]);
   });
 });

--- a/src/bot/commands/refresh.ts
+++ b/src/bot/commands/refresh.ts
@@ -1,6 +1,9 @@
 import { Composer } from 'telegraf';
+import type pino from 'pino';
 import type { BotContext } from '../index';
 import type { ProgressFn } from '../../jobs/progress';
+import type { Translator } from '../../i18n/types';
+import type { NewbeersDeps } from './newbeers-build';
 
 const COOLDOWN_MS = 5 * 60 * 1000;
 const PROGRESS_MIN_INTERVAL_MS = 2000;
@@ -22,7 +25,36 @@ export function makeThrottledProgress(
   };
 }
 
-export function createRefreshCommand(run: (notify: ProgressFn) => Promise<void>) {
+export interface RunRefreshPipelineArgs {
+  run: (notify: ProgressFn) => Promise<void>;
+  notify: ProgressFn;
+  t: Translator;
+  log: pino.Logger;
+  postRun?: () => Promise<void>;
+}
+
+export async function runRefreshPipeline(args: RunRefreshPipelineArgs): Promise<void> {
+  const { run, notify, t, log, postRun } = args;
+  try {
+    await run(notify);
+    await notify(t('refresh.done'), { force: true });
+    if (postRun) {
+      try {
+        await postRun();
+      } catch (e) {
+        log.error({ err: e }, 'refresh post-run failed');
+      }
+    }
+  } catch (e) {
+    log.error({ err: e }, 'refresh failed');
+    await notify(t('refresh.failed'), { force: true });
+  }
+}
+
+export function createRefreshCommand(
+  run: (notify: ProgressFn) => Promise<void>,
+  postRun?: (deps: NewbeersDeps) => string | null,
+) {
   const cmd = new Composer<BotContext>();
   cmd.command('refresh', async (ctx) => {
     const prev = lastCall.get(ctx.from.id) ?? 0;
@@ -38,6 +70,10 @@ export function createRefreshCommand(run: (notify: ProgressFn) => Promise<void>)
     const telegram = ctx.telegram;
     const log = ctx.deps.log;
     const t = ctx.t;
+    const db = ctx.deps.db;
+    const telegramId = ctx.from.id;
+    const locale = ctx.locale;
+
     const notify = makeThrottledProgress(
       async (text) => {
         await telegram
@@ -47,19 +83,26 @@ export function createRefreshCommand(run: (notify: ProgressFn) => Promise<void>)
       PROGRESS_MIN_INTERVAL_MS,
     );
 
+    const postRunClosure = postRun
+      ? async () => {
+          const text = postRun({ db, telegramId, locale, t });
+          if (text) {
+            await telegram.sendMessage(chatId, text, { parse_mode: 'HTML' });
+          }
+        }
+      : undefined;
+
     // Detach the work: the refresh sweep takes minutes, but Telegraf's
     // handlerTimeout (default 90s) would otherwise kill the handler and
     // raise TimeoutError into bot.catch. Captured locals above keep the
     // background promise independent of ctx's lifetime.
-    void (async () => {
-      try {
-        await run(notify);
-        await notify(t('refresh.done'), { force: true });
-      } catch (e) {
-        log.error({ err: e }, 'refresh failed');
-        await notify(t('refresh.failed'), { force: true });
-      }
-    })();
+    void runRefreshPipeline({
+      run,
+      notify,
+      t,
+      log,
+      postRun: postRunClosure,
+    });
   });
   return cmd;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { startCommand } from './bot/commands/start';
 import { linkCommand } from './bot/commands/link';
 import { importCommand } from './bot/commands/import';
 import { newbeersCommand } from './bot/commands/newbeers';
+import { buildNewbeersMessage } from './bot/commands/newbeers-build';
 import { routeCommand } from './bot/commands/route';
 import { filtersCommand } from './bot/commands/filters';
 import { langCommand } from './bot/commands/lang';
@@ -41,10 +42,13 @@ async function main(): Promise<void> {
     routeCommand,
     filtersCommand,
     langCommand,
-    createRefreshCommand(async (notify) => {
-      await refreshOntap({ db, log, http, geocoder, onProgress: notify });
-      await refreshAllUntappd({ db, log, http, onProgress: notify });
-    }),
+    createRefreshCommand(
+      async (notify) => {
+        await refreshOntap({ db, log, http, geocoder, onProgress: notify });
+        await refreshAllUntappd({ db, log, http, onProgress: notify });
+      },
+      buildNewbeersMessage,
+    ),
   );
 
   const cronJobs = [


### PR DESCRIPTION
## Summary
- Extract `buildNewbeersMessage(deps)` from the `/newbeers` handler so the pipeline can be called outside Telegraf.
- `createRefreshCommand` gains an optional `postRun?: (deps) => string | null`; on successful `/refresh` the handler sends the returned HTML (silent when null).
- Failure path (`refresh.failed`) skips the auto-call entirely.
- Cron-triggered refreshes call the underlying jobs directly — unaffected.

Implements `docs/superpowers/specs/2026-05-24-refresh-autorun-newbeers-design.md`.

## Test plan
- [x] `npm test` green locally (4 new tests in `newbeers-build`, 4 new tests in `refresh` for `runRefreshPipeline`)
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [ ] After merge + deploy: issue `/refresh`; observe one status message editing to `refresh.done`, followed by a separate HTML message listing new beers
- [ ] After merge + deploy: with empty `triedBeerIds` exclusion (or no fresh snapshots), confirm only `refresh.done` arrives — no empty-state spam
- [ ] After merge + deploy: simulate a failure (e.g. block outbound HTTP for the scrape window) and confirm `refresh.failed` appears with no auto-newbeers follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)