### PR TITLE
feat: bidirectional slash-alias dedup (PR-C)

### DIFF
--- a/docs/superpowers/specs/2026-04-22-warsaw-beer-bot-design.md
+++ b/docs/superpowers/specs/2026-04-22-warsaw-beer-bot-design.md
@@ -442,5 +442,16 @@ bot /route N → domain/filters: interesting(p) для кожного пабу �
   consume. Caught 2026-05-10 — `/newbeers` showed *Stadt Land Bier*
   because the scrape rewrote `beers.rating_global` but never marked
   the user as having had it.
+- **Bare-slash brewery aliases (any side)**: Polish collab breweries
+  often render with no spaces around `/` ("Sady/Beer Bacon and Liberty
+  Brewery", "Nieczajna/Craftownia Brewery"). The original PR-A
+  assumption was that the compound form lives on the Untappd-canonical
+  side and uses `' / '` with spaces — both wrong for this case.
+  `breweryAliases` (`src/domain/matcher.ts`) now splits on `/\s*\/\s*/`
+  to absorb any spacing, and `dedupeBreweryAliases`
+  (`src/jobs/dedupe-brewery-aliases.ts`) detects compound form on
+  either pair side with a symmetric alias-overlap check. Caught
+  2026-05-25 via 17 prod orphans (e.g. *Midnight Mass* duplicated as
+  `beers#12276/12286`); merged on next boot.
 
 Ці грабельки — чек-лист на першу секунду нового деплою.

--- a/src/domain/matcher.test.ts
+++ b/src/domain/matcher.test.ts
@@ -52,6 +52,38 @@ describe('breweryAliases', () => {
     );
   });
 
+  test('slash without spaces (Sady/Beer Bacon collab style) splits both halves', () => {
+    const out = breweryAliases('Sady/Beer Bacon and Liberty Brewery');
+    expect(new Set(out)).toEqual(
+      new Set([
+        'sady beer bacon and liberty',
+        'sady',
+        'beer bacon and liberty',
+      ]),
+    );
+  });
+
+  test('slash with right-side space only (Nieczajna/ Monsters style) splits both halves', () => {
+    const out = breweryAliases('Nieczajna/ Monsters Brewery');
+    expect(new Set(out)).toEqual(
+      new Set(['nieczajna monsters', 'nieczajna', 'monsters']),
+    );
+  });
+
+  test('slash with left-side space only (Stu Mostów /Ophiussa style) splits both halves', () => {
+    const out = breweryAliases('Stu Mostów /Ophiussa Brewery');
+    expect(new Set(out)).toEqual(
+      new Set(['stu mostow ophiussa', 'stu mostow', 'ophiussa']),
+    );
+  });
+
+  test('multi-slash collab (A/B/C) splits into all parts', () => {
+    const out = breweryAliases('Nieczajna/Craftownia Brewery');
+    expect(new Set(out)).toEqual(
+      new Set(['nieczajna craftownia', 'nieczajna', 'craftownia']),
+    );
+  });
+
   test('empty input returns empty array', () => {
     expect(breweryAliases('')).toEqual([]);
   });
@@ -71,64 +103,6 @@ test('fuzzy match above the lowered 0.75 threshold returns < 1 confidence', () =
 
 test('no match below threshold returns null', () => {
   expect(matchBeer({ brewery: 'Random', name: 'Xyz' }, catalog)).toBeNull();
-});
-
-describe('vintage handling', () => {
-  const vintages: CatalogBeer[] = [
-    c({ id: 10, brewery: 'Harpagan', name: 'Buzdygan Rozkoszy 2024', abv: 8.0 }),
-    c({ id: 11, brewery: 'Harpagan', name: 'Buzdygan Rozkoszy 2025', abv: 8.5 }),
-    c({ id: 12, brewery: 'Harpagan', name: 'Buzdygan Rozkoszy 2026', abv: 9.5 }),
-  ];
-
-  test('picks the latest vintage when ABV not provided', () => {
-    const m = matchBeer({ brewery: 'Harpagan', name: 'Buzdygan Rozkoszy' }, vintages);
-    expect(m?.id).toBe(12); // highest id = newest
-    expect(m?.source).toBe('exact');
-  });
-
-  test('picks ABV-matching vintage when ABV provided', () => {
-    const m = matchBeer(
-      { brewery: 'Harpagan', name: 'Buzdygan Rozkoszy', abv: 8.5 },
-      vintages,
-    );
-    expect(m?.id).toBe(11); // 2025 matches ABV 8.5
-  });
-
-  test('falls back to latest when no ABV in catalog matches input', () => {
-    const m = matchBeer(
-      { brewery: 'Harpagan', name: 'Buzdygan Rozkoszy', abv: 12.0 },
-      vintages,
-    );
-    expect(m?.id).toBe(12); // none match — return latest anyway
-  });
-
-  test('ABV tolerance: 0.3 absolute', () => {
-    const m = matchBeer(
-      { brewery: 'Harpagan', name: 'Buzdygan Rozkoszy', abv: 8.7 },
-      vintages,
-    );
-    expect(m?.id).toBe(11); // 8.5 within 0.3 of 8.7
-  });
-
-  test('ignores catalog ABV nulls when picking by ABV', () => {
-    const mixed: CatalogBeer[] = [
-      c({ id: 20, brewery: 'X', name: 'Foo', abv: null }),
-      c({ id: 21, brewery: 'X', name: 'Foo', abv: 5.0 }),
-    ];
-    const m = matchBeer({ brewery: 'X', name: 'Foo', abv: 5.0 }, mixed);
-    expect(m?.id).toBe(21);
-  });
-});
-
-test('ontap-style raw beer_ref + ABV maps to clean Untappd entry', () => {
-  // Real-world scenario from issue #18: ontap parser used to leave
-  // "Buzdygan Rozkoszy 24°·8,5% — Caribbean Imperial Stout" in beer_ref,
-  // but with the fix beer_ref is clean.
-  const m = matchBeer(
-    { brewery: 'Harpagan Brewery', name: 'Buzdygan Rozkoszy', abv: 8.5 },
-    [c({ id: 99, brewery: 'Harpagan', name: 'Buzdygan Rozkoszy', abv: 8.5 })],
-  );
-  expect(m?.id).toBe(99);
 });
 
 describe('matchBeer — slash-alias breweries', () => {
@@ -200,4 +174,75 @@ describe('matchBeer — slash-alias breweries', () => {
     );
     expect(m).toBeNull();
   });
+});
+
+describe('matchBeer — bare-slash (insert-time prevention)', () => {
+  test('ontap "Sady/Beer Bacon and Liberty Brewery Midnight Mass" hits canonical Untappd row "Browar Sady Midnight Mass"', () => {
+    const canon: CatalogBeer[] = [
+      c({ id: 100, brewery: 'Browar Sady', name: 'Midnight Mass', abv: 10.9 }),
+    ];
+    const m = matchBeer(
+      { brewery: 'Sady/Beer Bacon and Liberty Brewery', name: 'Midnight Mass', abv: 10.9 },
+      canon,
+    );
+    expect(m).toEqual({ id: 100, confidence: 1, source: 'exact' });
+  });
+});
+
+describe('vintage handling', () => {
+  const vintages: CatalogBeer[] = [
+    c({ id: 10, brewery: 'Harpagan', name: 'Buzdygan Rozkoszy 2024', abv: 8.0 }),
+    c({ id: 11, brewery: 'Harpagan', name: 'Buzdygan Rozkoszy 2025', abv: 8.5 }),
+    c({ id: 12, brewery: 'Harpagan', name: 'Buzdygan Rozkoszy 2026', abv: 9.5 }),
+  ];
+
+  test('picks the latest vintage when ABV not provided', () => {
+    const m = matchBeer({ brewery: 'Harpagan', name: 'Buzdygan Rozkoszy' }, vintages);
+    expect(m?.id).toBe(12); // highest id = newest
+    expect(m?.source).toBe('exact');
+  });
+
+  test('picks ABV-matching vintage when ABV provided', () => {
+    const m = matchBeer(
+      { brewery: 'Harpagan', name: 'Buzdygan Rozkoszy', abv: 8.5 },
+      vintages,
+    );
+    expect(m?.id).toBe(11); // 2025 matches ABV 8.5
+  });
+
+  test('falls back to latest when no ABV in catalog matches input', () => {
+    const m = matchBeer(
+      { brewery: 'Harpagan', name: 'Buzdygan Rozkoszy', abv: 12.0 },
+      vintages,
+    );
+    expect(m?.id).toBe(12); // none match — return latest anyway
+  });
+
+  test('ABV tolerance: 0.3 absolute', () => {
+    const m = matchBeer(
+      { brewery: 'Harpagan', name: 'Buzdygan Rozkoszy', abv: 8.7 },
+      vintages,
+    );
+    expect(m?.id).toBe(11); // 8.5 within 0.3 of 8.7
+  });
+
+  test('ignores catalog ABV nulls when picking by ABV', () => {
+    const mixed: CatalogBeer[] = [
+      c({ id: 20, brewery: 'X', name: 'Foo', abv: null }),
+      c({ id: 21, brewery: 'X', name: 'Foo', abv: 5.0 }),
+    ];
+    const m = matchBeer({ brewery: 'X', name: 'Foo', abv: 5.0 }, mixed);
+    expect(m?.id).toBe(21);
+  });
+});
+
+test('ontap-style raw beer_ref + ABV maps to clean Untappd entry', () => {
+  // Real-world scenario from issue #18: ontap parser used to leave
+  // "Buzdygan Rozkoszy 24°·8,5% — Caribbean Imperial Stout" in beer_ref,
+  // but with the fix beer_ref is clean.
+  const m = matchBeer(
+    { brewery: 'Harpagan Brewery', name: 'Buzdygan Rozkoszy', abv: 8.5 },
+    [c({ id: 99, brewery: 'Harpagan', name: 'Buzdygan Rozkoszy', abv: 8.5 })],
+  );
+  expect(m?.id).toBe(99);
 });

--- a/src/domain/matcher.test.ts
+++ b/src/domain/matcher.test.ts
@@ -78,9 +78,14 @@ describe('breweryAliases', () => {
   });
 
   test('multi-slash collab (A/B/C) splits into all parts', () => {
-    const out = breweryAliases('Nieczajna/Craftownia Brewery');
+    const out = breweryAliases('Nieczajna/Craftownia/Same Krafty Brewery');
     expect(new Set(out)).toEqual(
-      new Set(['nieczajna craftownia', 'nieczajna', 'craftownia']),
+      new Set([
+        'nieczajna craftownia same krafty',
+        'nieczajna',
+        'craftownia',
+        'same krafty',
+      ]),
     );
   });
 

--- a/src/domain/matcher.ts
+++ b/src/domain/matcher.ts
@@ -18,17 +18,20 @@ const FUZZY_THRESHOLD = 0.75;
 const ABV_TOLERANCE = 0.3;
 
 // Untappd records breweries either as a single name ("Piwne Podziemie Brewery"),
-// as an "X / Y" alias used for bilingual ("Piwne Podziemie / Beer Underground")
-// or collaboration ("AleBrowar / Poppels Bryggeri") pairs, or as an "X (Y)"
-// form for German aliases ("Kemker Kultuur (Brauerei J. Kemker)").
-// Ontap.pl renders only one of these. For matching purposes all three forms
-// collapse to: "any side of the separator is a valid brewery for this beer".
+// as a slash alias used for bilingual ("Piwne Podziemie / Beer Underground")
+// or collaboration ("Sady/Beer Bacon and Liberty Brewery") pairs, or as an
+// "X (Y)" form for German aliases ("Kemker Kultuur (Brauerei J. Kemker)").
+// The slash form appears with any spacing around "/" (with, without, or one
+// side only) — the regex absorbs all variants. Ontap.pl renders only one of
+// these. For matching purposes all forms collapse to: "any side of the
+// separator is a valid brewery for this beer".
 export function breweryAliases(brewery: string): string[] {
   const aliases = new Set<string>();
   const full = normalizeBrewery(brewery);
   if (full) aliases.add(full);
 
-  const slashParts = brewery.includes(' / ') ? brewery.split(' / ') : [brewery];
+  const slashRegex = /\s*\/\s*/;
+  const slashParts = slashRegex.test(brewery) ? brewery.split(slashRegex) : [brewery];
   for (const part of slashParts) {
     const parenMatch = part.match(/^(.+?)\s*\((.+)\)\s*$/);
     if (parenMatch) {

--- a/src/jobs/dedupe-brewery-aliases.test.ts
+++ b/src/jobs/dedupe-brewery-aliases.test.ts
@@ -220,4 +220,107 @@ describe('dedupeBreweryAliases', () => {
       .get('kemker-1') as { beer_id: number };
     expect(checkin.beer_id).toBe(aId);
   });
+
+  test('merges bare-slash collab orphan (Sady/Beer Bacon Midnight Mass case)', () => {
+    const db = fresh();
+    // Canonical Untappd-side row — simple brewery name.
+    const aId = upsertBeer(db, {
+      untappd_id: 6645648,
+      name: 'Midnight Mass',
+      brewery: 'Browar Sady',
+      style: null,
+      abv: 10.9,
+      rating_global: 3.92,
+      normalized_name: 'midnight mass',
+      normalized_brewery: 'sady',
+    });
+    // Orphan ontap-side row — brewery is compound bare-slash form.
+    const bId = upsertBeer(db, {
+      untappd_id: null,
+      name: 'Midnight Mass',
+      brewery: 'Sady/Beer Bacon and Liberty Brewery',
+      style: null,
+      abv: null,
+      rating_global: null,
+      normalized_name: 'midnight mass',
+      normalized_brewery: 'sady beer bacon and liberty',
+    });
+    upsertMatch(db, 'Midnight Mass', bId, 1.0);
+
+    const result = dedupeBreweryAliases(db, silentLog);
+    expect(result).toEqual({ pairsMerged: 1, beersDeleted: 1 });
+
+    // Orphan gone; canonical survives.
+    expect(db.prepare('SELECT id FROM beers WHERE id = ?').get(bId)).toBeUndefined();
+    expect(db.prepare('SELECT id FROM beers WHERE id = ?').get(aId)).toEqual({ id: aId });
+
+    // match_link transferred to canonical.
+    const link = db
+      .prepare('SELECT untappd_beer_id FROM match_links WHERE ontap_ref = ?')
+      .get('Midnight Mass') as { untappd_beer_id: number };
+    expect(link.untappd_beer_id).toBe(aId);
+  });
+
+  test('merges mixed-spacing slash orphan (Nieczajna/ Monsters style)', () => {
+    const db = fresh();
+    const aId = upsertBeer(db, {
+      untappd_id: 5712429,
+      name: 'Mexican',
+      brewery: 'Browar Monsters',
+      style: null,
+      abv: null,
+      rating_global: null,
+      normalized_name: 'mexican',
+      normalized_brewery: 'monsters',
+    });
+    const bId = upsertBeer(db, {
+      untappd_id: null,
+      name: 'Mexican',
+      brewery: 'Nieczajna/ Monsters Brewery',
+      style: null,
+      abv: null,
+      rating_global: null,
+      normalized_name: 'mexican',
+      normalized_brewery: 'nieczajna monsters',
+    });
+    upsertMatch(db, 'Mexican', bId, 1.0);
+
+    const result = dedupeBreweryAliases(db, silentLog);
+    expect(result).toEqual({ pairsMerged: 1, beersDeleted: 1 });
+    expect(db.prepare('SELECT id FROM beers WHERE id = ?').get(bId)).toBeUndefined();
+  });
+
+  test('does NOT merge slash orphan when no alias overlaps with canonical', () => {
+    const db = fresh();
+    // Canonical: "Genys Brewing Co.", normalized 'genys brewing co'.
+    const aId = upsertBeer(db, {
+      untappd_id: 5738553,
+      name: 'Grodziskie',
+      brewery: 'Genys Brewing Co.',
+      style: null,
+      abv: null,
+      rating_global: null,
+      normalized_name: 'grodziskie',
+      normalized_brewery: 'genys brewing co',
+    });
+    // Orphan: "Miejski Stargard/Nieczajna Brewery" — aliases include
+    // 'miejski stargard' and 'nieczajna' but NOT 'genys brewing co'.
+    const bId = upsertBeer(db, {
+      untappd_id: null,
+      name: 'Grodziskie',
+      brewery: 'Miejski Stargard/Nieczajna Brewery',
+      style: null,
+      abv: null,
+      rating_global: null,
+      normalized_name: 'grodziskie',
+      normalized_brewery: 'miejski stargard nieczajna',
+    });
+    upsertMatch(db, 'Grodziskie', bId, 1.0);
+
+    const result = dedupeBreweryAliases(db, silentLog);
+    expect(result).toEqual({ pairsMerged: 0, beersDeleted: 0 });
+    // Both rows still present.
+    expect(db.prepare('SELECT id FROM beers WHERE id = ?').get(aId)).toBeDefined();
+    expect(db.prepare('SELECT id FROM beers WHERE id = ?').get(bId)).toBeDefined();
+  });
 });

--- a/src/jobs/dedupe-brewery-aliases.test.ts
+++ b/src/jobs/dedupe-brewery-aliases.test.ts
@@ -288,6 +288,7 @@ describe('dedupeBreweryAliases', () => {
     const result = dedupeBreweryAliases(db, silentLog);
     expect(result).toEqual({ pairsMerged: 1, beersDeleted: 1 });
     expect(db.prepare('SELECT id FROM beers WHERE id = ?').get(bId)).toBeUndefined();
+    expect(db.prepare('SELECT id FROM beers WHERE id = ?').get(aId)).toEqual({ id: aId });
   });
 
   test('does NOT merge slash orphan when no alias overlaps with canonical', () => {

--- a/src/jobs/dedupe-brewery-aliases.ts
+++ b/src/jobs/dedupe-brewery-aliases.ts
@@ -6,6 +6,7 @@ interface PairCandidate {
   canonical_id: number;
   canonical_brewery: string;
   orphan_id: number;
+  orphan_brewery: string;
   orphan_norm_brewery: string;
 }
 
@@ -15,15 +16,19 @@ export interface DedupeResult {
 }
 
 export function dedupeBreweryAliases(db: DB, log: pino.Logger): DedupeResult {
-  // Find candidates: same normalized_name, A has untappd_id and a brewery
-  // in either "X / Y" slash form or "X (Y)" paren form, B has neither.
-  // Return brewery raw so we can compute aliases in JS (SQLite has no JS regex).
+  // Find candidates: same normalized_name, A has untappd_id and B doesn't.
+  // Compound brewery form ("X/Y" slash, any spacing, or "X (Y)" paren) may
+  // appear on EITHER side of the pair — PR-A had it on canonical (Kemker
+  // (Brauerei J. Kemker)), PR-C had it on orphan (Sady/Beer Bacon and
+  // Liberty Brewery). Match either; JS alias-overlap will decide whether
+  // the pair actually corresponds.
   const candidates = db
     .prepare(
       `SELECT
          a.id AS canonical_id,
          a.brewery AS canonical_brewery,
          b.id AS orphan_id,
+         b.brewery AS orphan_brewery,
          b.normalized_brewery AS orphan_norm_brewery
        FROM beers a
        JOIN beers b
@@ -31,18 +36,26 @@ export function dedupeBreweryAliases(db: DB, log: pino.Logger): DedupeResult {
         AND a.id <> b.id
        WHERE a.untappd_id IS NOT NULL
          AND b.untappd_id IS NULL
-         AND (a.brewery LIKE '% / %'
-              OR (a.brewery LIKE '%(%' AND a.brewery LIKE '%)%'))
+         AND (
+           a.brewery LIKE '%/%'
+           OR (a.brewery LIKE '%(%' AND a.brewery LIKE '%)%')
+           OR b.brewery LIKE '%/%'
+           OR (b.brewery LIKE '%(%' AND b.brewery LIKE '%)%')
+         )
        ORDER BY a.id, b.id`,
     )
     .all() as PairCandidate[];
 
-  // Filter to pairs where the orphan brewery actually overlaps an alias of canonical.
-  // Group by orphan_id to ensure each orphan is merged into its earliest canonical.
+  // Symmetric alias-overlap: pair merges only if breweryAliases(canonical)
+  // and breweryAliases(orphan) share at least one element. This filters out
+  // false-positives where the SQL pre-filter caught a pair that happens to
+  // share normalized_name but whose breweries are unrelated.
   const pairsByOrphan = new Map<number, PairCandidate>();
   for (const c of candidates) {
-    const aliases = new Set(breweryAliases(c.canonical_brewery));
-    if (!aliases.has(c.orphan_norm_brewery)) continue;
+    const canonicalAliases = new Set(breweryAliases(c.canonical_brewery));
+    const orphanAliases = breweryAliases(c.orphan_brewery);
+    const overlap = orphanAliases.some((x) => canonicalAliases.has(x));
+    if (!overlap) continue;
     if (!pairsByOrphan.has(c.orphan_id)) pairsByOrphan.set(c.orphan_id, c);
   }
 

--- a/src/jobs/dedupe-brewery-aliases.ts
+++ b/src/jobs/dedupe-brewery-aliases.ts
@@ -7,7 +7,6 @@ interface PairCandidate {
   canonical_brewery: string;
   orphan_id: number;
   orphan_brewery: string;
-  orphan_norm_brewery: string;
 }
 
 export interface DedupeResult {
@@ -28,8 +27,7 @@ export function dedupeBreweryAliases(db: DB, log: pino.Logger): DedupeResult {
          a.id AS canonical_id,
          a.brewery AS canonical_brewery,
          b.id AS orphan_id,
-         b.brewery AS orphan_brewery,
-         b.normalized_brewery AS orphan_norm_brewery
+         b.brewery AS orphan_brewery
        FROM beers a
        JOIN beers b
          ON a.normalized_name = b.normalized_name


### PR DESCRIPTION
## Summary
- `breweryAliases` now splits on `/\s*\/\s*/` — catches `X/Y`, `X / Y`, `X/ Y`, `X /Y`. Polish-collab slash-form breweries (Sady/Beer Bacon and Liberty Brewery, Nieczajna/Craftownia Brewery, etc.) now produce per-side aliases.
- `dedupeBreweryAliases` SQL widens to match compound form on EITHER pair side and to detect unspaced `/`. JS overlap check becomes symmetric (`breweryAliases(canonical) ∩ breweryAliases(orphan) ≠ ∅`).
- `matchBeer` is unchanged — it already uses `breweryAliases` symmetrically, so the matcher fix automatically prevents future ontap scrapes from creating these orphans.
- Master spec §10 gains a third footgun bullet.

Implements `docs/superpowers/specs/2026-05-25-slash-alias-bidirectional-design.md`. Extends PR-A (#39) and PR-B (#42).

## Test plan
- [x] `npm test` green locally (248 tests; +5 matcher, +3 dedupe vs main baseline 240)
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [ ] Post-deploy: startup log shows `dedupe-brewery-aliases: merged N orphan ontap rows into canonical Untappd rows` with N close to 17. Verified via prod query at spec-write time.
- [ ] Post-deploy: re-issue `/newbeers` against the *Midnight Mass* report. The duplicate entry should be gone.
- [ ] Post-deploy: confirm a fresh `/refresh` does not recreate any of the merged orphans (insert-time prevention from the matcher fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)