### PR TITLE
feat: Untappd lookup wire-up (PR-D2 of 3)

### DIFF
--- a/src/config/env.test.ts
+++ b/src/config/env.test.ts
@@ -1,12 +1,16 @@
 import { loadEnv } from './env';
 
 describe('loadEnv', () => {
+  const baseEnv = {
+    TELEGRAM_BOT_TOKEN: 'abc:1234567',
+    DATABASE_PATH: '/tmp/bot.db',
+    OSRM_BASE_URL: 'https://osrm.example',
+    NOMINATIM_USER_AGENT: 'ua',
+  };
+
   it('parses a complete env map', () => {
     const env = loadEnv({
-      TELEGRAM_BOT_TOKEN: 'abc:1234567',
-      DATABASE_PATH: '/tmp/bot.db',
-      OSRM_BASE_URL: 'https://osrm.example',
-      NOMINATIM_USER_AGENT: 'ua',
+      ...baseEnv,
       LOG_LEVEL: 'debug',
       DEFAULT_ROUTE_N: '7',
     });
@@ -16,5 +20,20 @@ describe('loadEnv', () => {
 
   it('rejects missing token', () => {
     expect(() => loadEnv({ DATABASE_PATH: '/tmp/x.db' } as any)).toThrow(/TELEGRAM_BOT_TOKEN/);
+  });
+
+  it('UNTAPPD_LOOKUP_ENABLED defaults to true when unset', () => {
+    const env = loadEnv(baseEnv);
+    expect(env.UNTAPPD_LOOKUP_ENABLED).toBe(true);
+  });
+
+  it('UNTAPPD_LOOKUP_ENABLED="false" parses to false', () => {
+    const env = loadEnv({ ...baseEnv, UNTAPPD_LOOKUP_ENABLED: 'false' });
+    expect(env.UNTAPPD_LOOKUP_ENABLED).toBe(false);
+  });
+
+  it('UNTAPPD_LOOKUP_ENABLED="true" parses to true', () => {
+    const env = loadEnv({ ...baseEnv, UNTAPPD_LOOKUP_ENABLED: 'true' });
+    expect(env.UNTAPPD_LOOKUP_ENABLED).toBe(true);
   });
 });

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -7,6 +7,10 @@ const Schema = z.object({
   NOMINATIM_USER_AGENT: z.string().min(1),
   LOG_LEVEL: z.enum(['trace', 'debug', 'info', 'warn', 'error']).default('info'),
   DEFAULT_ROUTE_N: z.coerce.number().int().positive().default(5),
+  UNTAPPD_LOOKUP_ENABLED: z
+    .union([z.literal('true'), z.literal('false')])
+    .default('true')
+    .transform((v) => v === 'true'),
 });
 
 export type Env = z.infer<typeof Schema>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { refreshOntap } from './jobs/refresh-ontap';
 import { refreshAllUntappd } from './jobs/refresh-untappd';
 import { dedupeBreweryAliases } from './jobs/dedupe-brewery-aliases';
 import { cleanupPollutedOntap } from './jobs/cleanup-polluted-ontap';
+import { enrichOrphans } from './jobs/enrich-orphans';
 import { createShutdown } from './shutdown';
 
 async function main(): Promise<void> {
@@ -46,7 +47,10 @@ async function main(): Promise<void> {
     langCommand,
     createRefreshCommand(
       async (notify) => {
-        await refreshOntap({ db, log, http, geocoder, onProgress: notify });
+        await refreshOntap({
+          db, log, http, geocoder, onProgress: notify,
+          lookupEnabled: env.UNTAPPD_LOOKUP_ENABLED,
+        });
         await refreshAllUntappd({ db, log, http, onProgress: notify });
       },
       buildNewbeersMessage,
@@ -55,10 +59,19 @@ async function main(): Promise<void> {
 
   const cronJobs = [
     cron.schedule('0 */12 * * *', () => {
-      refreshOntap({ db, log, http, geocoder }).catch((e) => log.error({ err: e }, 'ontap cron'));
+      refreshOntap({
+        db, log, http, geocoder,
+        lookupEnabled: env.UNTAPPD_LOOKUP_ENABLED,
+      }).catch((e) => log.error({ err: e }, 'ontap cron'));
     }),
     cron.schedule('0 3 * * *', () => {
       refreshAllUntappd({ db, log, http }).catch((e) => log.error({ err: e }, 'untappd cron'));
+    }),
+    cron.schedule('0 6,18 * * *', () => {
+      enrichOrphans({
+        db, log, http,
+        lookupEnabled: env.UNTAPPD_LOOKUP_ENABLED,
+      }).catch((e) => log.error({ err: e }, 'enrich-orphans cron'));
     }),
   ];
 

--- a/src/jobs/enrich-orphans.test.ts
+++ b/src/jobs/enrich-orphans.test.ts
@@ -1,0 +1,152 @@
+import pino from 'pino';
+import { openDb } from '../storage/db';
+import { migrate } from '../storage/schema';
+import { upsertBeer, getBeer } from '../storage/beers';
+import { upsertPub } from '../storage/pubs';
+import { createSnapshot, insertTaps } from '../storage/snapshots';
+import { upsertMatch } from '../storage/match_links';
+import type { Http } from '../sources/http';
+import { enrichOrphans } from './enrich-orphans';
+
+const silentLog = pino({ level: 'silent' });
+
+function fresh() {
+  const db = openDb(':memory:');
+  migrate(db);
+  return db;
+}
+
+function searchHtml(items: Array<{ bid: number; name: string; brewery: string }>): string {
+  const cards = items
+    .map((it) => `
+      <div class="beer-item">
+        <div class="beer-details">
+          <p class="name"><a href="/b/x/${it.bid}">${it.name}</a></p>
+          <p class="brewery"><a>${it.brewery}</a></p>
+          <p class="style">IPA</p>
+        </div>
+        <div class="details beer">
+          <p class="abv">5% ABV</p>
+          <div class="rating"><div class="caps" data-rating="3.5"></div></div>
+        </div>
+      </div>`)
+    .join('');
+  return `<html><body>${cards}</body></html>`;
+}
+
+function seedOrphanOnTap(
+  db: ReturnType<typeof fresh>,
+  brewery: string,
+  name: string,
+): number {
+  const beerId = upsertBeer(db, {
+    name, brewery, style: null, abv: null, rating_global: null,
+    normalized_name: name.toLowerCase(), normalized_brewery: brewery.toLowerCase(),
+  });
+  const pubId = upsertPub(db, {
+    slug: `pub-${beerId}`, name: `Pub ${beerId}`,
+    address: null, lat: null, lon: null,
+  });
+  const snapId = createSnapshot(db, pubId, '2026-05-26T12:00:00Z');
+  const ref = `${brewery} ${name}`;
+  upsertMatch(db, ref, beerId, 1.0);
+  insertTaps(db, snapId, [{
+    tap_number: 1, beer_ref: ref, brewery_ref: brewery,
+    abv: null, ibu: null, style: null, u_rating: null,
+  }]);
+  return beerId;
+}
+
+describe('enrichOrphans', () => {
+  test('processes orphans on current taps, returns stats', async () => {
+    const db = fresh();
+    const a = seedOrphanOnTap(db, 'Magic Road', 'Fifty Fifty Clementine');
+    const b = seedOrphanOnTap(db, 'Magic Road', 'Buty Skejta');
+    let calls = 0;
+    const http: Http = {
+      async get(): Promise<string> {
+        calls++;
+        if (calls === 1) {
+          return searchHtml([
+            { bid: 100, name: 'Fifty Fifty Clementine', brewery: 'Magic Road' },
+          ]);
+        }
+        return searchHtml([
+          { bid: 200, name: 'Buty Skejta', brewery: 'Some Other Brewery' },
+        ]);
+      },
+    };
+    const fixedNow = new Date('2026-05-26T12:00:00Z');
+
+    const result = await enrichOrphans({
+      db, log: silentLog, http, sleepMs: 0, now: () => fixedNow,
+    });
+
+    expect(result.processed).toBe(2);
+    expect(result.matched).toBe(1);
+    expect(result.not_found).toBe(1);
+    expect(result.transient).toBe(0);
+    expect(result.skipped).toBe(0);
+
+    expect(getBeer(db, a)?.untappd_id).toBe(100);
+    expect(getBeer(db, b)?.untappd_id).toBeNull();
+    expect(getBeer(db, b)?.untappd_lookup_count).toBe(1);
+  });
+
+  test('respects limit', async () => {
+    const db = fresh();
+    for (let i = 0; i < 5; i++) {
+      seedOrphanOnTap(db, `Brew${i}`, `Beer${i}`);
+    }
+    let calls = 0;
+    const http: Http = {
+      async get(): Promise<string> {
+        calls++;
+        return '<html><body></body></html>';
+      },
+    };
+
+    const result = await enrichOrphans({
+      db, log: silentLog, http, limit: 2, sleepMs: 0,
+      now: () => new Date('2026-05-26T12:00:00Z'),
+    });
+
+    expect(result.processed).toBe(2);
+    expect(calls).toBe(2);
+  });
+
+  test('lookupEnabled=false: no candidates touched, no HTTP', async () => {
+    const db = fresh();
+    seedOrphanOnTap(db, 'Brew', 'Beer');
+    let calls = 0;
+    const http: Http = {
+      async get(): Promise<string> { calls++; return ''; },
+    };
+
+    const result = await enrichOrphans({
+      db, log: silentLog, http, lookupEnabled: false, sleepMs: 0,
+      now: () => new Date('2026-05-26T12:00:00Z'),
+    });
+
+    expect(result).toEqual({ processed: 0, matched: 0, not_found: 0, transient: 0, skipped: 0 });
+    expect(calls).toBe(0);
+  });
+
+  test('sleeps between HTTP calls when sleepMs > 0', async () => {
+    const db = fresh();
+    seedOrphanOnTap(db, 'A', 'B');
+    seedOrphanOnTap(db, 'C', 'D');
+    const sleeps: number[] = [];
+    const http: Http = {
+      async get(): Promise<string> { return '<html></html>'; },
+    };
+    const sleep = async (ms: number) => { sleeps.push(ms); };
+
+    await enrichOrphans({
+      db, log: silentLog, http, sleepMs: 500, sleep,
+      now: () => new Date('2026-05-26T12:00:00Z'),
+    });
+
+    expect(sleeps).toEqual([500]);
+  });
+});

--- a/src/jobs/enrich-orphans.ts
+++ b/src/jobs/enrich-orphans.ts
@@ -1,0 +1,63 @@
+import type pino from 'pino';
+import type { DB } from '../storage/db';
+import type { Http } from '../sources/http';
+import { listLookupCandidates } from '../storage/beers';
+import { enrichOneOrphan } from './untappd-enrich';
+
+export interface EnrichOrphansResult {
+  processed: number;
+  matched: number;
+  not_found: number;
+  transient: number;
+  skipped: number;
+}
+
+export interface EnrichOrphansDeps {
+  db: DB;
+  log: pino.Logger;
+  http: Http;
+  lookupEnabled?: boolean;     // default true
+  limit?: number;               // default 20
+  sleepMs?: number;             // default 500
+  sleep?: (ms: number) => Promise<void>;   // for tests
+  now?: () => Date;             // for tests
+}
+
+const ZERO_RESULT: EnrichOrphansResult = {
+  processed: 0, matched: 0, not_found: 0, transient: 0, skipped: 0,
+};
+
+export async function enrichOrphans(
+  deps: EnrichOrphansDeps,
+): Promise<EnrichOrphansResult> {
+  if (deps.lookupEnabled === false) {
+    deps.log.info('untappd-lookup disabled (UNTAPPD_LOOKUP_ENABLED=false), skipping enrich-orphans');
+    return ZERO_RESULT;
+  }
+
+  const limit = deps.limit ?? 20;
+  const sleepMs = deps.sleepMs ?? 500;
+  const sleep = deps.sleep ?? ((ms: number) =>
+    new Promise<void>((r) => setTimeout(r, ms)));
+  const now = deps.now ?? (() => new Date());
+
+  const candidates = listLookupCandidates(deps.db, limit, now());
+  const result: EnrichOrphansResult = { ...ZERO_RESULT };
+
+  for (let i = 0; i < candidates.length; i++) {
+    const c = candidates[i];
+    const kind = await enrichOneOrphan(
+      { db: deps.db, log: deps.log, http: deps.http, now },
+      c.id,
+    );
+    result.processed++;
+    result[kind]++;
+
+    if (sleepMs > 0 && i < candidates.length - 1) {
+      await sleep(sleepMs);
+    }
+  }
+
+  deps.log.info(result, 'enrich-orphans done');
+  return result;
+}

--- a/src/jobs/refresh-ontap.ts
+++ b/src/jobs/refresh-ontap.ts
@@ -11,6 +11,7 @@ import { upsertBeer } from '../storage/beers';
 import { matchBeer } from '../domain/matcher';
 import { normalizeBrewery, normalizeName } from '../domain/normalize';
 import { noopProgress, type ProgressFn } from './progress';
+import { enrichOneOrphan } from './untappd-enrich';
 
 interface Deps {
   db: DB;
@@ -18,10 +19,19 @@ interface Deps {
   http: Http;
   geocoder: Geocoder;
   onProgress?: ProgressFn;
+  lookupEnabled?: boolean;     // default true
+  lookupSleepMs?: number;       // default 500
+  now?: () => Date;             // for tests
 }
 
 export async function refreshOntap(deps: Deps): Promise<void> {
-  const { db, log, http, geocoder, onProgress = noopProgress } = deps;
+  const {
+    db, log, http, geocoder,
+    onProgress = noopProgress,
+    lookupEnabled = true,
+    lookupSleepMs = 500,
+    now = () => new Date(),
+  } = deps;
   await onProgress('🍻 ontap: парсю індекс…', { force: true });
   const indexHtml = await http.get('https://ontap.pl/warszawa');
   const indexPubs = parseWarsawIndex(indexHtml);
@@ -60,10 +70,12 @@ export async function refreshOntap(deps: Deps): Promise<void> {
       for (const t of taps) {
         const brewery = t.brewery_ref ?? t.beer_ref.split(/[—-]\s|:\s/)[0] ?? '';
         const m = matchBeer({ brewery, name: t.beer_ref, abv: t.abv }, catalog);
+        let beerId: number;
         if (m) {
           upsertMatch(db, t.beer_ref, m.id, m.confidence);
+          beerId = m.id;
         } else {
-          const beerId = upsertBeer(db, {
+          beerId = upsertBeer(db, {
             name: t.beer_ref,
             brewery,
             style: t.style,
@@ -73,6 +85,17 @@ export async function refreshOntap(deps: Deps): Promise<void> {
             normalized_brewery: normalizeBrewery(brewery),
           });
           upsertMatch(db, t.beer_ref, beerId, 1.0);
+        }
+
+        // Inline Untappd enrichment for orphans (untappd_id NULL) that
+        // pass the backoff gate. enrichOneOrphan itself short-circuits
+        // for non-orphans and ineligible ones, so the check here only
+        // saves the function-call + sleep overhead.
+        if (lookupEnabled) {
+          await enrichOneOrphan({ db, log, http, now }, beerId);
+          if (lookupSleepMs > 0) {
+            await new Promise<void>((r) => setTimeout(r, lookupSleepMs));
+          }
         }
       }
       ok++;

--- a/src/jobs/untappd-enrich.test.ts
+++ b/src/jobs/untappd-enrich.test.ts
@@ -1,0 +1,159 @@
+import pino from 'pino';
+import { openDb } from '../storage/db';
+import { migrate } from '../storage/schema';
+import { upsertBeer, getBeer } from '../storage/beers';
+import type { Http } from '../sources/http';
+import { enrichOneOrphan } from './untappd-enrich';
+
+const silentLog = pino({ level: 'silent' });
+
+function fresh() {
+  const db = openDb(':memory:');
+  migrate(db);
+  return db;
+}
+
+function fakeHttp(html: string): Http {
+  return { async get(): Promise<string> { return html; } };
+}
+
+function throwingHttp(err: Error): Http {
+  return {
+    async get(): Promise<string> { throw err; },
+  };
+}
+
+function searchHtml(items: Array<{ bid: number; name: string; brewery: string; rating?: string }>): string {
+  const cards = items
+    .map((it) => `
+      <div class="beer-item">
+        <div class="beer-details">
+          <p class="name"><a href="/b/x/${it.bid}">${it.name}</a></p>
+          <p class="brewery"><a>${it.brewery}</a></p>
+          <p class="style">IPA</p>
+        </div>
+        <div class="details beer">
+          <p class="abv">5% ABV</p>
+          <div class="rating">
+            <div class="caps" data-rating="${it.rating ?? '3.5'}"></div>
+          </div>
+        </div>
+      </div>`)
+    .join('');
+  return `<html><body>${cards}</body></html>`;
+}
+
+describe('enrichOneOrphan', () => {
+  test('matched: fills untappd_id + rating, returns "matched"', async () => {
+    const db = fresh();
+    const beerId = upsertBeer(db, {
+      name: 'Fifty/Fifty Clementine & Passionfruit', brewery: 'Magic Road Brewery',
+      style: null, abv: 4.6, rating_global: null,
+      normalized_name: 'fifty fifty clementine passionfruit',
+      normalized_brewery: 'magic road',
+    });
+    const http = fakeHttp(searchHtml([
+      { bid: 6645513, name: 'Fifty Fifty - Clementine & Passionfruit', brewery: 'Magic Road', rating: '3.98' },
+    ]));
+
+    const out = await enrichOneOrphan({ db, log: silentLog, http }, beerId);
+
+    expect(out).toBe('matched');
+    const row = getBeer(db, beerId);
+    expect(row?.untappd_id).toBe(6645513);
+    expect(row?.rating_global).toBeCloseTo(3.98);
+    expect(row?.untappd_lookup_count).toBe(0); // success doesn't increment
+  });
+
+  test('not_found: increments count + records lookup_at, returns "not_found"', async () => {
+    const db = fresh();
+    const beerId = upsertBeer(db, {
+      name: 'Something Obscure', brewery: 'Unknown Brewery',
+      style: null, abv: null, rating_global: null,
+      normalized_name: 'something obscure', normalized_brewery: 'unknown',
+    });
+    const http = fakeHttp('<html><body></body></html>');
+    const fixedNow = new Date('2026-05-26T12:00:00Z');
+
+    const out = await enrichOneOrphan(
+      { db, log: silentLog, http, now: () => fixedNow }, beerId,
+    );
+
+    expect(out).toBe('not_found');
+    const row = getBeer(db, beerId);
+    expect(row?.untappd_id).toBeNull();
+    expect(row?.untappd_lookup_count).toBe(1);
+    expect(row?.untappd_lookup_at).toBe('2026-05-26T12:00:00.000Z');
+  });
+
+  test('transient: HTTP error, records lookup_at without incrementing count', async () => {
+    const db = fresh();
+    const beerId = upsertBeer(db, {
+      name: 'X', brewery: 'Y', style: null, abv: null, rating_global: null,
+      normalized_name: 'x', normalized_brewery: 'y',
+    });
+    const http = throwingHttp(new Error('ETIMEDOUT'));
+    const fixedNow = new Date('2026-05-26T12:00:00Z');
+
+    const out = await enrichOneOrphan(
+      { db, log: silentLog, http, now: () => fixedNow }, beerId,
+    );
+
+    expect(out).toBe('transient');
+    const row = getBeer(db, beerId);
+    expect(row?.untappd_lookup_count).toBe(0);
+    expect(row?.untappd_lookup_at).toBe('2026-05-26T12:00:00.000Z');
+  });
+
+  test('skipped: beer already has untappd_id', async () => {
+    const db = fresh();
+    const beerId = upsertBeer(db, {
+      untappd_id: 42,
+      name: 'X', brewery: 'Y', style: null, abv: null, rating_global: null,
+      normalized_name: 'x', normalized_brewery: 'y',
+    });
+    let httpCalled = false;
+    const http: Http = {
+      async get(): Promise<string> { httpCalled = true; return ''; },
+    };
+
+    const out = await enrichOneOrphan({ db, log: silentLog, http }, beerId);
+
+    expect(out).toBe('skipped');
+    expect(httpCalled).toBe(false);
+  });
+
+  test('skipped: backoff not yet elapsed', async () => {
+    const db = fresh();
+    const beerId = upsertBeer(db, {
+      name: 'X', brewery: 'Y', style: null, abv: null, rating_global: null,
+      normalized_name: 'x', normalized_brewery: 'y',
+    });
+    db.prepare(
+      'UPDATE beers SET untappd_lookup_at = ?, untappd_lookup_count = ? WHERE id = ?',
+    ).run('2026-05-26T11:00:00Z', 1, beerId);
+    let httpCalled = false;
+    const http: Http = {
+      async get(): Promise<string> { httpCalled = true; return ''; },
+    };
+    const fixedNow = new Date('2026-05-26T12:00:00Z');
+
+    const out = await enrichOneOrphan(
+      { db, log: silentLog, http, now: () => fixedNow }, beerId,
+    );
+
+    expect(out).toBe('skipped');
+    expect(httpCalled).toBe(false);
+  });
+
+  test('skipped: beer does not exist (defensive)', async () => {
+    const db = fresh();
+    let httpCalled = false;
+    const http: Http = {
+      async get(): Promise<string> { httpCalled = true; return ''; },
+    };
+    const out = await enrichOneOrphan({ db, log: silentLog, http }, 9999);
+    expect(out).toBe('skipped');
+    expect(httpCalled).toBe(false);
+  });
+});

--- a/src/jobs/untappd-enrich.ts
+++ b/src/jobs/untappd-enrich.ts
@@ -1,0 +1,56 @@
+import type pino from 'pino';
+import type { DB } from '../storage/db';
+import type { Http } from '../sources/http';
+import { isEligible } from '../domain/lookup-backoff';
+import { lookupBeer } from '../domain/untappd-lookup';
+import {
+  getBeer,
+  recordLookupSuccess,
+  recordLookupNotFound,
+  recordLookupTransient,
+} from '../storage/beers';
+
+export type EnrichOutcomeKind = 'matched' | 'not_found' | 'transient' | 'skipped';
+
+export interface EnrichDeps {
+  db: DB;
+  log: pino.Logger;
+  http: Http;
+  now?: () => Date;
+}
+
+export async function enrichOneOrphan(
+  deps: EnrichDeps,
+  beerId: number,
+): Promise<EnrichOutcomeKind> {
+  const beer = getBeer(deps.db, beerId);
+  if (!beer || beer.untappd_id !== null) return 'skipped';
+
+  const now = (deps.now ?? (() => new Date()))();
+  if (!isEligible(now, beer.untappd_lookup_at, beer.untappd_lookup_count)) {
+    return 'skipped';
+  }
+
+  const outcome = await lookupBeer({
+    brewery: beer.brewery,
+    name: beer.name,
+    fetch: (url) => deps.http.get(url),
+  });
+
+  const nowIso = now.toISOString();
+  switch (outcome.kind) {
+    case 'matched':
+      recordLookupSuccess(deps.db, beerId, outcome.result);
+      return 'matched';
+    case 'not_found':
+      recordLookupNotFound(deps.db, beerId, nowIso);
+      return 'not_found';
+    case 'transient':
+      deps.log.warn(
+        { err: outcome.error, beerId },
+        'untappd-lookup transient failure',
+      );
+      recordLookupTransient(deps.db, beerId, nowIso);
+      return 'transient';
+  }
+}


### PR DESCRIPTION
## Summary
- Light up the PR-D1 \`lookupBeer\` capability in two places:
  - **refresh-ontap inline**: after each upsert/match in the tap loop, call \`enrichOneOrphan(beerId)\` if the beer is an orphan and backoff-eligible. 500ms polite spacing per tap.
  - **enrich-orphans cron** (06:00 / 18:00 UTC): backfill up to 20 on-tap orphans per run.
- Shared helper \`src/jobs/untappd-enrich.ts:enrichOneOrphan\` so both call sites use the same eligibility + record-outcome logic.
- New env var \`UNTAPPD_LOOKUP_ENABLED\` (default \`true\`) — strict \`"true"\`/\`"false"\` zod literal so typos in \`.env\` are rejected. Set to \`false\` if Untappd blocks the bot's IP; both paths no-op until re-enabled.

Implements \`docs/superpowers/specs/2026-05-26-untappd-lookup.md\` PR-D2 section. PR-D3 (rating refresh via \`/beer/{id}\`) is next.

## Behavior change
Beers that were orphans before this PR (287 on current taps in prod, audited 2026-05-26) start filling \`untappd_id\` + \`style\` + \`abv\` + \`rating_global\` over the next week of cron runs. New on-tap beers get filled at \`/refresh\` time, in time for the PR-B autorun-\`/newbeers\` reply.

## Test plan
- [x] \`npm test\` green locally (307/41 — baseline 294 + 13 new)
- [x] \`npm run typecheck\` clean
- [x] \`npm run build\` clean
- [ ] After deploy + first \`/refresh\`: \`/newbeers\` shows ratings on previously-orphan entries (e.g. *Magic Road Fifty/Fifty Clementine & Passionfruit* should show \`⭐ 3.98\` instead of \`⭐ —\`).
- [ ] After 24h: \`sudo journalctl -u warsaw-beer-bot | grep enrich-orphans\` shows \`{processed,matched,not_found,transient,skipped}\` stats twice.
- [ ] After 1 week: prod on-tap-orphan count falls from ~287 toward 0 minus ambiguity-style orphans Untappd doesn't catalog.
- [ ] To kill: \`UNTAPPD_LOOKUP_ENABLED=false\` in \`/etc/warsaw-beer-bot/.env\` + restart; \`enrich-orphans done\` log line should disappear and \`/refresh\` HTTP volume drops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)