### PR TITLE
fix: PR-D2 perf hotfix — inline lookup for fresh orphans only

### DIFF
--- a/docs/superpowers/specs/2026-05-26-untappd-lookup.md
+++ b/docs/superpowers/specs/2026-05-26-untappd-lookup.md
@@ -212,33 +212,32 @@ export function listLookupCandidates(db: DB, limit: number, now: Date): Array<{
 
 ### Inline в `refreshOntap`
 
-`src/jobs/refresh-ontap.ts` зараз робить:
+Після `matchBeer`, **тільки якщо `matchBeer === null`** (тобто `upsertBeer` створив новий рядок у цьому sweep-і), викликаємо `enrichOneOrphan(beerId)`. Існуючі orphan-и (matchBeer повернув existing рядок без `untappd_id`) інлайн НЕ обробляє — вони чекають cron. Це критично, бо інакше один sweep пробує всі on-tap orphan-и (287 у проді), кожен з HTTP+sleep ≈2.5s → sweep уповільнюється на +12 хв.
 
 ```ts
 const m = matchBeer({ brewery, name: t.beer_ref, abv: t.abv }, catalog);
-const beerId = m ? m.id : upsertBeer(db, {...});
-// (далі match_links upsert тощо)
-```
+let beerId: number;
+let isFreshOrphan = false;
+if (m) {
+  upsertMatch(db, t.beer_ref, m.id, m.confidence);
+  beerId = m.id;
+} else {
+  beerId = upsertBeer(db, {...});
+  upsertMatch(db, t.beer_ref, beerId, 1.0);
+  isFreshOrphan = true;
+}
 
-Стає:
-
-```ts
-const m = matchBeer({ brewery, name: t.beer_ref, abv: t.abv }, catalog);
-const beerId = m ? m.id : upsertBeer(db, {...});
-
-const beer = getBeer(db, beerId);    // small helper, returns full row
-if (beer.untappd_id === null && isEligible(now, beer.untappd_lookup_at, beer.untappd_lookup_count)) {
-  const outcome = await lookupBeer({ brewery, name: t.beer_ref, fetch: http.get });
-  await new Promise((r) => setTimeout(r, 500));   // polite spacing
-  switch (outcome.kind) {
-    case 'matched':       recordLookupSuccess(db, beerId, outcome.result); break;
-    case 'not_found':     recordLookupNotFound(db, beerId, now.toISOString()); break;
-    case 'transient':     recordLookupTransient(db, beerId, now.toISOString()); break;
+if (lookupEnabled && isFreshOrphan) {
+  const outcome = await enrichOneOrphan({ db, log, http, now }, beerId);
+  // sleep тільки якщо HTTP реально був (defense in depth: outcome може
+  // повернутись 'skipped' через backoff або race condition)
+  if (lookupSleepMs > 0 && outcome !== 'skipped') {
+    await new Promise<void>((r) => setTimeout(r, lookupSleepMs));
   }
 }
 ```
 
-**Overhead в типовому sweep-і:** 0–3 нових orphan-ів за день — 1.5s оверхеду max. Backlog-сценарій керується cron-ом.
+**Overhead в типовому sweep-і:** 0–3 нових orphan-ів за день — 1.5s оверхеду max. Backlog (287 рядків у проді) обробляється cron-ом, по 20×2/добу = ~7 днів до 0.
 
 ### Cron `enrich-orphans` — backfill
 
@@ -420,3 +419,4 @@ Beers, що PR-D2 знайшов з `untappd_id` але `rating_global=NULL` (б
 - **Catalog growth.** PR-D2 знаходить нові untappd_id-и → нові варіанти стилів і ABV у `beers`. Це normal. Якщо BR-побори через дуже шумний search → false-positives ростуть → PR-A/B/C dedupe може видалити неправильні мерджі. Це тестується в `enrich-orphans.test.ts` на дуплікат-сценарії.
 - **`rating_refresh_*` колонки на існуючих рядках.** Default 0 → з'являються в пулі PR-D3 одразу. Усі beers з `untappd_id` set + `rating_global=NULL` (зараз 0 таких в проді — всі мають rating якщо мають bid) на момент деплою PR-D3 пройдуть один lookup кожен. Реал-кейс це невелика кількість (≤10), не вибух.
 - **Curl-first на dev-стороні.** PR-D1 і PR-D3 включають кроки в плані «curl URL, save fixture». CI цього НЕ робить. Це разова дія перед написанням parser-у — план фіксує конкретні URL і fixture-шляхи.
+- **Inline must NOT process backlog.** PR-D2.1 hotfix (2026-05-26): початковий PR-D2 inline-шлях не розрізняв fresh orphan-ів від існуючого backlog-у. На першому post-deploy sweep-і inline проходив всі 287 on-tap orphan-ів з HTTP+sleep ≈2.5s кожен → sweep уповільнився з ~5 хв до 10+ хв на 28 пабах. Fix: `isFreshOrphan` guard (`matchBeer === null` → upsertBeer create) + conditional sleep on `outcome !== 'skipped'`. Урок: "harmless guard skipped 95% of the time" у hot loop-і — не harmless, коли N=350 тапів × 500ms = 3 хв пустого sleep-у, плюс backlog-multiplier.

--- a/src/jobs/refresh-ontap.ts
+++ b/src/jobs/refresh-ontap.ts
@@ -71,6 +71,7 @@ export async function refreshOntap(deps: Deps): Promise<void> {
         const brewery = t.brewery_ref ?? t.beer_ref.split(/[—-]\s|:\s/)[0] ?? '';
         const m = matchBeer({ brewery, name: t.beer_ref, abv: t.abv }, catalog);
         let beerId: number;
+        let isFreshOrphan = false;
         if (m) {
           upsertMatch(db, t.beer_ref, m.id, m.confidence);
           beerId = m.id;
@@ -85,15 +86,19 @@ export async function refreshOntap(deps: Deps): Promise<void> {
             normalized_brewery: normalizeBrewery(brewery),
           });
           upsertMatch(db, t.beer_ref, beerId, 1.0);
+          isFreshOrphan = true;
         }
 
-        // Inline Untappd enrichment for orphans (untappd_id NULL) that
-        // pass the backoff gate. enrichOneOrphan itself short-circuits
-        // for non-orphans and ineligible ones, so the check here only
-        // saves the function-call + sleep overhead.
-        if (lookupEnabled) {
-          await enrichOneOrphan({ db, log, http, now }, beerId);
-          if (lookupSleepMs > 0) {
+        // Inline Untappd enrichment ONLY for beers we just created
+        // (matchBeer returned null). Existing orphans (matched to a row
+        // that has untappd_id NULL) are handled by the enrich-orphans
+        // cron — letting inline try them every 12h multiplies HTTP +
+        // sleep across the full backlog. PR-D2.1 perf fix (2026-05-26).
+        // Sleep only when HTTP actually fired (outcome !== 'skipped')
+        // as a defense in depth.
+        if (lookupEnabled && isFreshOrphan) {
+          const outcome = await enrichOneOrphan({ db, log, http, now }, beerId);
+          if (lookupSleepMs > 0 && outcome !== 'skipped') {
             await new Promise<void>((r) => setTimeout(r, lookupSleepMs));
           }
         }


### PR DESCRIPTION
## Summary
Regression introduced by PR-D2 (#47): \`/refresh\` slowed from ~5 min to 10+ min on 28 pubs at first post-deploy. Two compounding causes:

1. Inline path processed **every** on-tap orphan (287 in prod) every sweep, not just newly-upserted ones. Each lookup ≈ 2.5s (HTTP + sleep) → +12 min.
2. The 500ms post-call sleep ran on every tap iteration regardless of whether \`enrichOneOrphan\` actually made an HTTP request. ~350 taps × 500ms = +3 min pure sleep.

The PR-D2 plan flagged the unconditional sleep as "harmless because most taps are non-orphan in steady state" — true once the backlog is cleared, catastrophically wrong on day one with 287 backlog orphans on tap.

## Fix
- \`isFreshOrphan\` flag, set only inside the \`else\` (matchBeer returned null) branch of the tap loop. Inline \`enrichOneOrphan\` only fires when \`isFreshOrphan\`. Backlog stays the responsibility of the \`enrich-orphans\` cron (20×2/day → ~7 days to clear).
- Sleep gated by \`outcome !== 'skipped'\` as defense in depth (no HTTP → no sleep).

Master spec PR-D2 section and Footguns updated to record the lesson.

Implements \`docs/superpowers/specs/2026-05-26-untappd-enrich-perf-hotfix.md\`.

## Test plan
- [x] \`npm test\` green locally (307/41 — no test files changed)
- [x] \`npm run typecheck\` clean
- [x] \`npm run build\` clean
- [ ] After deploy: \`sudo journalctl -u warsaw-beer-bot --since today | grep \"ontap.*пабів\"\` — first sweep wall-time ≈ 5 min, not 10+.
- [ ] After 24h: \`sudo journalctl ... | grep \"enrich-orphans done\"\` — cron still processing ~20/run.
- [ ] After 1 week: prod on-tap orphan count keeps falling toward 0 minus Untappd-uncatalogued cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)