### PR TITLE
feat: Untappd rating refresh (PR-D3 of 3)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import { refreshAllUntappd } from './jobs/refresh-untappd';
 import { dedupeBreweryAliases } from './jobs/dedupe-brewery-aliases';
 import { cleanupPollutedOntap } from './jobs/cleanup-polluted-ontap';
 import { enrichOrphans } from './jobs/enrich-orphans';
+import { refreshTapRatings } from './jobs/refresh-tap-ratings';
 import { createShutdown } from './shutdown';
 
 async function main(): Promise<void> {
@@ -72,6 +73,12 @@ async function main(): Promise<void> {
         db, log, http,
         lookupEnabled: env.UNTAPPD_LOOKUP_ENABLED,
       }).catch((e) => log.error({ err: e }, 'enrich-orphans cron'));
+    }),
+    cron.schedule('0 9,21 * * *', () => {
+      refreshTapRatings({
+        db, log, http,
+        lookupEnabled: env.UNTAPPD_LOOKUP_ENABLED,
+      }).catch((e) => log.error({ err: e }, 'refresh-tap-ratings cron'));
     }),
   ];
 

--- a/src/jobs/refresh-tap-ratings.test.ts
+++ b/src/jobs/refresh-tap-ratings.test.ts
@@ -1,0 +1,165 @@
+import pino from 'pino';
+import { openDb } from '../storage/db';
+import { migrate } from '../storage/schema';
+import { upsertBeer, getBeer } from '../storage/beers';
+import { upsertPub } from '../storage/pubs';
+import { createSnapshot, insertTaps } from '../storage/snapshots';
+import { upsertMatch } from '../storage/match_links';
+import type { Http } from '../sources/http';
+import { refreshTapRatings } from './refresh-tap-ratings';
+
+const silentLog = pino({ level: 'silent' });
+
+function fresh() {
+  const db = openDb(':memory:');
+  migrate(db);
+  return db;
+}
+
+function beerPageHtml(rating: string): string {
+  return `<html><body>
+    <div class="basic">
+      <div class="rating">
+        <div class="caps" data-rating="${rating}"></div>
+      </div>
+    </div>
+  </body></html>`;
+}
+
+function seedIdBeerOnTap(
+  db: ReturnType<typeof fresh>,
+  brewery: string, name: string, untappdId: number,
+): number {
+  const beerId = upsertBeer(db, {
+    untappd_id: untappdId,
+    name, brewery, style: null, abv: null, rating_global: null,
+    normalized_name: name.toLowerCase(), normalized_brewery: brewery.toLowerCase(),
+  });
+  const pubId = upsertPub(db, {
+    slug: `pub-${beerId}`, name: `Pub ${beerId}`,
+    address: null, lat: null, lon: null,
+  });
+  const snapId = createSnapshot(db, pubId, '2026-05-27T12:00:00Z');
+  const ref = `${brewery} ${name}`;
+  upsertMatch(db, ref, beerId, 1.0);
+  insertTaps(db, snapId, [{
+    tap_number: 1, beer_ref: ref, brewery_ref: brewery,
+    abv: null, ibu: null, style: null, u_rating: null,
+  }]);
+  return beerId;
+}
+
+describe('refreshTapRatings', () => {
+  test('matched: fills rating_global and stats it as matched', async () => {
+    const db = fresh();
+    const beerId = seedIdBeerOnTap(db, 'Magic Road', 'Clementine', 6645513);
+    const calls: string[] = [];
+    const http: Http = {
+      async get(url: string): Promise<string> {
+        calls.push(url);
+        return beerPageHtml('3.98');
+      },
+    };
+    const fixedNow = new Date('2026-05-27T12:00:00Z');
+
+    const result = await refreshTapRatings({
+      db, log: silentLog, http, sleepMs: 0, now: () => fixedNow,
+    });
+
+    expect(result).toEqual({
+      processed: 1, matched: 1, not_found: 0, transient: 0,
+    });
+    expect(calls).toEqual(['https://untappd.com/beer/6645513']);
+    expect(getBeer(db, beerId)?.rating_global).toBeCloseTo(3.98);
+  });
+
+  test('not_found: NULL rating bumps count + records refresh_at', async () => {
+    const db = fresh();
+    const beerId = seedIdBeerOnTap(db, 'Brand', 'New', 999);
+    const http: Http = {
+      async get(): Promise<string> { return beerPageHtml('N/A'); },
+    };
+    const fixedNow = new Date('2026-05-27T12:00:00Z');
+
+    const result = await refreshTapRatings({
+      db, log: silentLog, http, sleepMs: 0, now: () => fixedNow,
+    });
+
+    expect(result).toEqual({
+      processed: 1, matched: 0, not_found: 1, transient: 0,
+    });
+    const row = getBeer(db, beerId);
+    expect(row?.rating_global).toBeNull();
+    expect(row?.rating_refresh_count).toBe(1);
+    expect(row?.rating_refresh_at).toBe('2026-05-27T12:00:00.000Z');
+  });
+
+  test('transient: HTTP error records refresh_at without incrementing count', async () => {
+    const db = fresh();
+    const beerId = seedIdBeerOnTap(db, 'X', 'Y', 100);
+    const http: Http = {
+      async get(): Promise<string> { throw new Error('ETIMEDOUT'); },
+    };
+    const fixedNow = new Date('2026-05-27T12:00:00Z');
+
+    const result = await refreshTapRatings({
+      db, log: silentLog, http, sleepMs: 0, now: () => fixedNow,
+    });
+
+    expect(result).toEqual({
+      processed: 1, matched: 0, not_found: 0, transient: 1,
+    });
+    const row = getBeer(db, beerId);
+    expect(row?.rating_refresh_count).toBe(0);
+    expect(row?.rating_refresh_at).toBe('2026-05-27T12:00:00.000Z');
+  });
+
+  test('respects limit', async () => {
+    const db = fresh();
+    for (let i = 0; i < 5; i++) {
+      seedIdBeerOnTap(db, `Brew${i}`, `Beer${i}`, 100 + i);
+    }
+    let calls = 0;
+    const http: Http = {
+      async get(): Promise<string> { calls++; return beerPageHtml('N/A'); },
+    };
+    const result = await refreshTapRatings({
+      db, log: silentLog, http, limit: 2, sleepMs: 0,
+      now: () => new Date('2026-05-27T12:00:00Z'),
+    });
+    expect(result.processed).toBe(2);
+    expect(calls).toBe(2);
+  });
+
+  test('lookupEnabled=false: no candidates touched, no HTTP', async () => {
+    const db = fresh();
+    seedIdBeerOnTap(db, 'X', 'Y', 100);
+    let calls = 0;
+    const http: Http = {
+      async get(): Promise<string> { calls++; return ''; },
+    };
+    const result = await refreshTapRatings({
+      db, log: silentLog, http, lookupEnabled: false, sleepMs: 0,
+      now: () => new Date('2026-05-27T12:00:00Z'),
+    });
+    expect(result).toEqual({ processed: 0, matched: 0, not_found: 0, transient: 0 });
+    expect(calls).toBe(0);
+  });
+
+  test('sleeps between HTTP calls when sleepMs > 0', async () => {
+    const db = fresh();
+    seedIdBeerOnTap(db, 'A', 'B', 100);
+    seedIdBeerOnTap(db, 'C', 'D', 200);
+    const sleeps: number[] = [];
+    const http: Http = {
+      async get(): Promise<string> { return beerPageHtml('N/A'); },
+    };
+    const sleep = async (ms: number) => { sleeps.push(ms); };
+
+    await refreshTapRatings({
+      db, log: silentLog, http, sleepMs: 500, sleep,
+      now: () => new Date('2026-05-27T12:00:00Z'),
+    });
+    expect(sleeps).toEqual([500]);
+  });
+});

--- a/src/jobs/refresh-tap-ratings.ts
+++ b/src/jobs/refresh-tap-ratings.ts
@@ -1,0 +1,82 @@
+import type pino from 'pino';
+import type { DB } from '../storage/db';
+import type { Http } from '../sources/http';
+import {
+  listRatingRefreshCandidates,
+  recordRatingSuccess,
+  recordRatingNotFound,
+  recordRatingTransient,
+} from '../storage/beers';
+import { buildBeerPageUrl, parseBeerPage } from '../sources/untappd/beer-page';
+
+export interface RefreshTapRatingsResult {
+  processed: number;
+  matched: number;
+  not_found: number;
+  transient: number;
+}
+
+export interface RefreshTapRatingsDeps {
+  db: DB;
+  log: pino.Logger;
+  http: Http;
+  lookupEnabled?: boolean;     // default true
+  limit?: number;               // default 20
+  sleepMs?: number;             // default 500
+  sleep?: (ms: number) => Promise<void>;   // for tests
+  now?: () => Date;             // for tests
+}
+
+const ZERO_RESULT: RefreshTapRatingsResult = {
+  processed: 0, matched: 0, not_found: 0, transient: 0,
+};
+
+export async function refreshTapRatings(
+  deps: RefreshTapRatingsDeps,
+): Promise<RefreshTapRatingsResult> {
+  if (deps.lookupEnabled === false) {
+    deps.log.info(
+      'untappd-lookup disabled (UNTAPPD_LOOKUP_ENABLED=false), skipping refresh-tap-ratings',
+    );
+    return ZERO_RESULT;
+  }
+
+  const limit = deps.limit ?? 20;
+  const sleepMs = deps.sleepMs ?? 500;
+  const sleep = deps.sleep ?? ((ms: number) =>
+    new Promise<void>((r) => setTimeout(r, ms)));
+  const now = deps.now ?? (() => new Date());
+
+  const candidates = listRatingRefreshCandidates(deps.db, limit, now());
+  const result: RefreshTapRatingsResult = { ...ZERO_RESULT };
+
+  for (let i = 0; i < candidates.length; i++) {
+    const c = candidates[i];
+    const tickNow = now();
+    const nowIso = tickNow.toISOString();
+    try {
+      const html = await deps.http.get(buildBeerPageUrl(c.untappd_id));
+      const { global_rating } = parseBeerPage(html);
+      if (global_rating !== null) {
+        recordRatingSuccess(deps.db, c.id, global_rating);
+        result.matched++;
+      } else {
+        recordRatingNotFound(deps.db, c.id, nowIso);
+        result.not_found++;
+      }
+    } catch (err) {
+      deps.log.warn({ err, beerId: c.id, untappdId: c.untappd_id },
+        'rating-refresh transient failure');
+      recordRatingTransient(deps.db, c.id, nowIso);
+      result.transient++;
+    }
+    result.processed++;
+
+    if (sleepMs > 0 && i < candidates.length - 1) {
+      await sleep(sleepMs);
+    }
+  }
+
+  deps.log.info(result, 'refresh-tap-ratings done');
+  return result;
+}

--- a/src/sources/untappd/beer-page.test.ts
+++ b/src/sources/untappd/beer-page.test.ts
@@ -1,0 +1,74 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { buildBeerPageUrl, parseBeerPage } from './beer-page';
+
+const fixturePath = path.join(__dirname, '../../../tests/fixtures/untappd/beer-page-magic-road.html');
+const html = fs.readFileSync(fixturePath, 'utf8');
+
+describe('buildBeerPageUrl', () => {
+  test('formats /beer/{bid}', () => {
+    expect(buildBeerPageUrl(6645513)).toBe('https://untappd.com/beer/6645513');
+  });
+
+  test('integer-only — fractional bids are not Untappd-valid', () => {
+    expect(buildBeerPageUrl(1)).toBe('https://untappd.com/beer/1');
+  });
+});
+
+describe('parseBeerPage', () => {
+  test('extracts non-null global_rating from the captured fixture (bid 6645513 = 3.98471)', () => {
+    const out = parseBeerPage(html);
+    expect(out.global_rating).not.toBeNull();
+    expect(typeof out.global_rating).toBe('number');
+    // Fixture is Magic Road Fifty/Fifty Clementine & Passionfruit at
+    // capture-time rating 3.98471. Use loose tolerance — Untappd may
+    // recalculate but the order of magnitude won't change.
+    expect(out.global_rating).toBeGreaterThan(0);
+    expect(out.global_rating).toBeLessThanOrEqual(5);
+    expect(out.global_rating).toBeCloseTo(3.98, 1);
+  });
+
+  test('returns null global_rating when page has no .caps[data-rating]', () => {
+    const out = parseBeerPage('<html><body><p>nothing here</p></body></html>');
+    expect(out.global_rating).toBeNull();
+  });
+
+  test('returns null when data-rating is "N/A" (Untappd uses this before 10 check-ins)', () => {
+    const synthetic = `
+      <html><body>
+        <div class="basic">
+          <div class="rating">
+            <div class="caps" data-rating="N/A"></div>
+          </div>
+        </div>
+      </body></html>`;
+    const out = parseBeerPage(synthetic);
+    expect(out.global_rating).toBeNull();
+  });
+
+  test('returns the global rating when a numeric data-rating is present', () => {
+    const synthetic = `
+      <html><body>
+        <div class="basic">
+          <div class="rating">
+            <div class="caps" data-rating="3.78"></div>
+          </div>
+        </div>
+      </body></html>`;
+    const out = parseBeerPage(synthetic);
+    expect(out.global_rating).toBeCloseTo(3.78);
+  });
+
+  test('handles "0" data-rating as 0 (not null) — distinguishes "no rating" from "rated zero"', () => {
+    const synthetic = `
+      <html><body>
+        <div class="basic">
+          <div class="rating">
+            <div class="caps" data-rating="0"></div>
+          </div>
+        </div>
+      </body></html>`;
+    const out = parseBeerPage(synthetic);
+    expect(out.global_rating).toBe(0);
+  });
+});

--- a/src/sources/untappd/beer-page.ts
+++ b/src/sources/untappd/beer-page.ts
@@ -1,0 +1,31 @@
+import * as cheerio from 'cheerio';
+
+export interface BeerPageData {
+  global_rating: number | null;
+}
+
+function parseRating(raw: string | undefined): number | null {
+  if (!raw) return null;
+  const n = parseFloat(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+export function buildBeerPageUrl(bid: number): string {
+  return `https://untappd.com/beer/${bid}`;
+}
+
+export function parseBeerPage(html: string): BeerPageData {
+  const $ = cheerio.load(html);
+
+  // Untappd renders the global rating as <div class="caps" data-rating="X">
+  // at the top of the beer page. The fixture (bid 6645513) has the global
+  // rating as the FIRST occurrence in document order (class is exactly "caps"
+  // — no trailing space). Subsequent .caps[data-rating] elements are checkin
+  // sub-cards (class "caps " with trailing space). .first() correctly picks
+  // the canonical global one.
+  const global_rating = parseRating(
+    $('.caps[data-rating]').first().attr('data-rating'),
+  );
+
+  return { global_rating };
+}

--- a/src/storage/beers.test.ts
+++ b/src/storage/beers.test.ts
@@ -320,3 +320,206 @@ describe('listLookupCandidates', () => {
     expect(c.untappd_lookup_count).toBe(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// PR-D3 helpers — rating-refresh
+// ---------------------------------------------------------------------------
+
+import {
+  recordRatingSuccess,
+  recordRatingNotFound,
+  recordRatingTransient,
+  listRatingRefreshCandidates,
+} from './beers';
+
+describe('recordRatingSuccess', () => {
+  test('sets rating_global from the parsed beer-page rating', () => {
+    const db = fresh();
+    const id = upsertBeer(db, {
+      untappd_id: 6645513,
+      name: 'X', brewery: 'Y', style: null, abv: null, rating_global: null,
+      normalized_name: 'x', normalized_brewery: 'y',
+    });
+    recordRatingSuccess(db, id, 3.98);
+    const row = getBeer(db, id);
+    expect(row?.rating_global).toBeCloseTo(3.98);
+    expect(row?.rating_refresh_count).toBe(0);     // success doesn't increment
+  });
+
+  test('overwrites a stale existing rating', () => {
+    const db = fresh();
+    const id = upsertBeer(db, {
+      untappd_id: 100,
+      name: 'X', brewery: 'Y', style: null, abv: null, rating_global: 3.5,
+      normalized_name: 'x', normalized_brewery: 'y',
+    });
+    recordRatingSuccess(db, id, 3.9);
+    expect(getBeer(db, id)?.rating_global).toBeCloseTo(3.9);
+  });
+});
+
+describe('recordRatingNotFound', () => {
+  test('increments count + sets refresh_at', () => {
+    const db = fresh();
+    const id = upsertBeer(db, {
+      untappd_id: 100,
+      name: 'X', brewery: 'Y', style: null, abv: null, rating_global: null,
+      normalized_name: 'x', normalized_brewery: 'y',
+    });
+    recordRatingNotFound(db, id, '2026-05-27T12:00:00Z');
+    let row = getBeer(db, id);
+    expect(row?.rating_refresh_at).toBe('2026-05-27T12:00:00Z');
+    expect(row?.rating_refresh_count).toBe(1);
+
+    recordRatingNotFound(db, id, '2026-05-28T12:00:00Z');
+    row = getBeer(db, id);
+    expect(row?.rating_refresh_at).toBe('2026-05-28T12:00:00Z');
+    expect(row?.rating_refresh_count).toBe(2);
+  });
+});
+
+describe('recordRatingTransient', () => {
+  test('updates refresh_at but does NOT increment count', () => {
+    const db = fresh();
+    const id = upsertBeer(db, {
+      untappd_id: 100,
+      name: 'X', brewery: 'Y', style: null, abv: null, rating_global: null,
+      normalized_name: 'x', normalized_brewery: 'y',
+    });
+    recordRatingTransient(db, id, '2026-05-27T12:00:00Z');
+    expect(getBeer(db, id)?.rating_refresh_count).toBe(0);
+    expect(getBeer(db, id)?.rating_refresh_at).toBe('2026-05-27T12:00:00Z');
+  });
+});
+
+describe('listRatingRefreshCandidates', () => {
+  function seedBeerOnTap(
+    db: ReturnType<typeof fresh>,
+    opts: {
+      brewery: string; name: string;
+      untappdId: number;
+      ratingGlobal?: number | null;
+      refreshAt?: string | null;
+      refreshCount?: number;
+    },
+  ): number {
+    const beerId = upsertBeer(db, {
+      untappd_id: opts.untappdId,
+      name: opts.name, brewery: opts.brewery,
+      style: null, abv: null,
+      rating_global: opts.ratingGlobal ?? null,
+      normalized_name: opts.name.toLowerCase(),
+      normalized_brewery: opts.brewery.toLowerCase(),
+    });
+    if (opts.refreshAt !== undefined || opts.refreshCount !== undefined) {
+      db.prepare(
+        'UPDATE beers SET rating_refresh_at = ?, rating_refresh_count = ? WHERE id = ?',
+      ).run(opts.refreshAt ?? null, opts.refreshCount ?? 0, beerId);
+    }
+    const pubId = upsertPub(db, {
+      slug: `pub-${beerId}`, name: `Pub ${beerId}`,
+      address: null, lat: null, lon: null,
+    });
+    const snapId = createSnapshot(db, pubId, '2026-05-27T12:00:00Z');
+    const ref = `${opts.brewery} ${opts.name}`;
+    upsertMatch(db, ref, beerId, 1.0);
+    insertTaps(db, snapId, [{
+      tap_number: 1, beer_ref: ref, brewery_ref: opts.brewery,
+      abv: null, ibu: null, style: null, u_rating: null,
+    }]);
+    return beerId;
+  }
+
+  test('returns beers with untappd_id AND rating_global IS NULL on a current tap', () => {
+    const db = fresh();
+    const candidate = seedBeerOnTap(db, {
+      brewery: 'Magic Road', name: 'Clementine', untappdId: 6645513,
+    });
+    // Has rating already — must be excluded.
+    seedBeerOnTap(db, {
+      brewery: 'Pinta', name: 'Atak', untappdId: 12345, ratingGlobal: 3.9,
+    });
+    const now = new Date('2026-05-27T12:00:00Z');
+    const out = listRatingRefreshCandidates(db, 10, now);
+    expect(out.map((c) => c.id)).toEqual([candidate]);
+    expect(out[0].untappd_id).toBe(6645513);
+  });
+
+  test('omits orphan beers (untappd_id NULL — those are PR-D2 territory)', () => {
+    const db = fresh();
+    const beerId = upsertBeer(db, {
+      name: 'X', brewery: 'Y', style: null, abv: null, rating_global: null,
+      normalized_name: 'x', normalized_brewery: 'y',
+    });
+    const pubId = upsertPub(db, {
+      slug: 'p', name: 'P', address: null, lat: null, lon: null,
+    });
+    const snapId = createSnapshot(db, pubId, '2026-05-27T12:00:00Z');
+    upsertMatch(db, 'X', beerId, 1.0);
+    insertTaps(db, snapId, [{
+      tap_number: 1, beer_ref: 'X', brewery_ref: 'Y',
+      abv: null, ibu: null, style: null, u_rating: null,
+    }]);
+    const now = new Date('2026-05-27T12:00:00Z');
+    expect(listRatingRefreshCandidates(db, 10, now)).toEqual([]);
+  });
+
+  test('omits beers not on any current tap', () => {
+    const db = fresh();
+    upsertBeer(db, {
+      untappd_id: 100,
+      name: 'Ghost', brewery: 'Old', style: null, abv: null, rating_global: null,
+      normalized_name: 'ghost', normalized_brewery: 'old',
+    });
+    const now = new Date('2026-05-27T12:00:00Z');
+    expect(listRatingRefreshCandidates(db, 10, now)).toEqual([]);
+  });
+
+  test('respects backoff via shared lookup-backoff isEligible', () => {
+    const db = fresh();
+    // count=1 → 24h delay. Last refresh 1h ago → not eligible.
+    seedBeerOnTap(db, {
+      brewery: 'Magic Road', name: 'Clementine', untappdId: 6645513,
+      refreshAt: '2026-05-27T11:00:00Z', refreshCount: 1,
+    });
+    const now = new Date('2026-05-27T12:00:00Z');
+    expect(listRatingRefreshCandidates(db, 10, now)).toEqual([]);
+  });
+
+  test('returns backoff-eligible beer 25h after last refresh attempt', () => {
+    const db = fresh();
+    const id = seedBeerOnTap(db, {
+      brewery: 'Magic Road', name: 'Clementine', untappdId: 6645513,
+      refreshAt: '2026-05-26T11:00:00Z', refreshCount: 1,
+    });
+    const now = new Date('2026-05-27T12:00:00Z');
+    const out = listRatingRefreshCandidates(db, 10, now);
+    expect(out.map((c) => c.id)).toEqual([id]);
+  });
+
+  test('applies the limit', () => {
+    const db = fresh();
+    for (let i = 0; i < 5; i++) {
+      seedBeerOnTap(db, {
+        brewery: `Brew${i}`, name: `Beer${i}`, untappdId: 1000 + i,
+      });
+    }
+    const now = new Date('2026-05-27T12:00:00Z');
+    expect(listRatingRefreshCandidates(db, 2, now).length).toBe(2);
+  });
+
+  test('returned shape carries untappd_id for the cron to use as URL input', () => {
+    const db = fresh();
+    seedBeerOnTap(db, {
+      brewery: 'Magic Road', name: 'Clementine', untappdId: 6645513,
+    });
+    const now = new Date('2026-05-27T12:00:00Z');
+    const [c] = listRatingRefreshCandidates(db, 10, now);
+    expect(c).toEqual(expect.objectContaining({
+      id: expect.any(Number),
+      untappd_id: 6645513,
+      rating_refresh_at: null,
+      rating_refresh_count: 0,
+    }));
+  });
+});

--- a/src/storage/beers.ts
+++ b/src/storage/beers.ts
@@ -15,6 +15,8 @@ export interface BeerRow extends BeerInput {
   id: number;
   untappd_lookup_at: string | null;
   untappd_lookup_count: number;
+  rating_refresh_at: string | null;
+  rating_refresh_count: number;
 }
 
 export function upsertBeer(db: DB, b: BeerInput): number {
@@ -153,6 +155,85 @@ export function listLookupCandidates(
   // and drift over time).
   const eligible = rows.filter((r) =>
     isEligible(now, r.untappd_lookup_at, r.untappd_lookup_count),
+  );
+
+  return eligible.slice(0, limit);
+}
+
+export function recordRatingSuccess(
+  db: DB,
+  beerId: number,
+  rating: number,
+): void {
+  // Success overwrites whatever rating_global was there. Count not touched —
+  // the beer leaves the candidate pool naturally (rating_global IS NOT NULL).
+  db.prepare('UPDATE beers SET rating_global = ? WHERE id = ?')
+    .run(rating, beerId);
+}
+
+export function recordRatingNotFound(
+  db: DB,
+  beerId: number,
+  at: string,
+): void {
+  db.prepare(
+    `UPDATE beers SET
+       rating_refresh_at = ?,
+       rating_refresh_count = rating_refresh_count + 1
+     WHERE id = ?`,
+  ).run(at, beerId);
+}
+
+export function recordRatingTransient(
+  db: DB,
+  beerId: number,
+  at: string,
+): void {
+  db.prepare(
+    'UPDATE beers SET rating_refresh_at = ? WHERE id = ?',
+  ).run(at, beerId);
+}
+
+export interface RatingRefreshCandidate {
+  id: number;
+  untappd_id: number;
+  rating_refresh_at: string | null;
+  rating_refresh_count: number;
+}
+
+export function listRatingRefreshCandidates(
+  db: DB,
+  limit: number,
+  now: Date,
+): RatingRefreshCandidate[] {
+  // SQL pre-filter: beers WITH untappd_id but NO rating, currently on tap.
+  // Same on-tap join as listLookupCandidates.
+  const rows = db
+    .prepare(
+      `SELECT b.id, b.untappd_id,
+              b.rating_refresh_at, b.rating_refresh_count
+       FROM beers b
+       WHERE b.untappd_id IS NOT NULL
+         AND b.rating_global IS NULL
+         AND EXISTS (
+           SELECT 1 FROM match_links ml
+           JOIN taps t ON t.beer_ref = ml.ontap_ref
+           JOIN tap_snapshots ts ON ts.id = t.snapshot_id
+           JOIN (
+             SELECT pub_id, MAX(snapshot_at) AS m
+             FROM tap_snapshots
+             GROUP BY pub_id
+           ) latest ON latest.pub_id = ts.pub_id
+                  AND latest.m = ts.snapshot_at
+           WHERE ml.untappd_beer_id = b.id
+         )
+       ORDER BY b.rating_refresh_count ASC, b.id ASC`,
+    )
+    .all() as RatingRefreshCandidate[];
+
+  // JS-side backoff filter using the shared lookup-backoff module.
+  const eligible = rows.filter((r) =>
+    isEligible(now, r.rating_refresh_at, r.rating_refresh_count),
   );
 
   return eligible.slice(0, limit);

--- a/src/storage/schema.test.ts
+++ b/src/storage/schema.test.ts
@@ -71,4 +71,23 @@ describe('schema migrations', () => {
     expect(lookupCount?.notnull).toBe(1);
     expect(String(lookupCount?.dflt_value)).toBe('0');
   });
+
+  test('migration v6 adds beers.rating_refresh_at + rating_refresh_count columns', () => {
+    const db = openDb(':memory:');
+    migrate(db);
+    const cols = db
+      .prepare('PRAGMA table_info(beers)')
+      .all() as { name: string; type: string; notnull: number; dflt_value: unknown }[];
+
+    const refreshAt = cols.find((c) => c.name === 'rating_refresh_at');
+    expect(refreshAt).toBeDefined();
+    expect(refreshAt?.type).toBe('TEXT');
+    expect(refreshAt?.notnull).toBe(0);
+
+    const refreshCount = cols.find((c) => c.name === 'rating_refresh_count');
+    expect(refreshCount).toBeDefined();
+    expect(refreshCount?.type).toBe('INTEGER');
+    expect(refreshCount?.notnull).toBe(1);
+    expect(String(refreshCount?.dflt_value)).toBe('0');
+  });
 });

--- a/src/storage/schema.ts
+++ b/src/storage/schema.ts
@@ -121,6 +121,13 @@ const MIGRATIONS: ReadonlyArray<{ version: number; sql: string }> = [
       ALTER TABLE beers ADD COLUMN untappd_lookup_count INTEGER NOT NULL DEFAULT 0;
     `,
   },
+  {
+    version: 6,
+    sql: `
+      ALTER TABLE beers ADD COLUMN rating_refresh_at TEXT;
+      ALTER TABLE beers ADD COLUMN rating_refresh_count INTEGER NOT NULL DEFAULT 0;
+    `,
+  },
 ];
 
 export function migrate(db: DB): void {

--- a/tests/fixtures/untappd/beer-page-magic-road.html
+++ b/tests/fixtures/untappd/beer-page-magic-road.html
@@ -1,0 +1,2446 @@
+<!DOCTYPE html>
+
+<html lang="en">
+
+<head>
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+
+			<title>Fifty Fifty - Clementine & Passionfruit - Magic Road - Untappd</title>
+		
+	<meta property="og:site_name" content="Untappd" />
+
+	<!-- meta block -->
+			<meta name="description" content="Fifty Fifty - Clementine & Passionfruit by Magic Road is a Sour - Smoothie / Pastry which has a rating of 4 out of 5, with 121 ratings and reviews on Untappd." />
+				<meta name="keywords" content="Fifty Fifty - Clementine & Passionfruit, Magic Road, Sour - Smoothie / Pastry, Poland, Masovian Voivodeship" />
+		<meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width" />
+	<meta property="al:ios:url" content="untappd://beer/6645513" /><meta property="al:ios:app_store_id" content="449141888" /><meta property="al:ios:app_name" content="Untappd" /><meta property="al:android:url" content="untappd://beer/6645513" /><meta property="al:android:package" content="com.untappdllc.app" /><meta property="al:android:app_name" content="Untappd" />		<meta property="fb:app_id"                content="153339744679495" />
+ 		<meta property="og:url"                   content="https://untappd.com/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513" />
+  		<meta property="og:title"                 content="Fifty Fifty - Clementine & Passionfruit - Magic Road - Untappd" />
+ 		<meta property="og:image"                 content="https://next.untappd.com/og/beer/6645513.png" />
+				<meta property="og:image:width"           content="1200" />
+		<meta property="og:image:height"          content="630" />
+				<meta property="og:description" 		  content="Fifty Fifty - Clementine & Passionfruit by Magic Road is a Sour - Smoothie / Pastry which has a rating of 4 out of 5, with 121 ratings and reviews on Untappd." />
+				<meta name="twitter:card" content="summary_large_image">
+		<meta name="twitter:site" content="@untappd">
+		<meta name="twitter:title" content="Fifty Fifty - Clementine & Passionfruit - Magic Road - Untappd ">
+		<meta name="twitter:description" content="Fifty Fifty - Clementine & Passionfruit by Magic Road is a Sour - Smoothie / Pastry which has a rating of 4 out of 5, with 121 ratings and reviews on Untappd.">
+		<meta name="twitter:image" content="https://next.untappd.com/og/beer/6645513.png">
+		<meta name="twitter:domain" content="untappd.com">
+		<meta name="twitter:app:name:iphone" content="Untappd">
+        <meta name="twitter:app:name:android" content="Untappd">
+        <meta name="twitter:app:id:iphone" content="id449141888">
+        <meta name="twitter:app:id:googleplay" content="com.untappdllc.app">
+		<meta name="referrer" content="origin-when-crossorigin">		<script type="application/ld+json">
+			{"@context":"http:\/\/schema.org\/","@type":"Product","name":"Magic Road Fifty Fifty - Clementine & Passionfruit","description":"","brand":{"@type":"Thing","name":"Magic Road"},"image":{"@type":"ImageObject","contentUrl":"https:\/\/next.untappd.com\/og\/beer\/6645513.png"},"mpn":6645513,"sku":6645513,"review":"","offers":"","aggregateRating":{"@type":"AggregateRating","ratingValue":3.98471,"bestRating":"5","reviewCount":121},"reviews":[{"@type":"Review","reviewBody":"Mandarijntjes, klein bittertje, mooi zuurtje, fris doordrinkbaar, ietsjes aan de dunne kant","datePublished":"2026-05-25T18:51:43+00:00","author":{"@type":"Person","name":"GidoR"},"reviewRating":{"@type":"Rating","ratingValue":3.75,"bestRating":5,"worstRating":0.1}},{"@type":"Review","reviewBody":"Sappie voor het slapen gaan.","datePublished":"2026-05-24T21:17:31+00:00","author":{"@type":"Person","name":"Schippie96"},"reviewRating":{"@type":"Rating","ratingValue":3,"bestRating":5,"worstRating":0.1}},{"@type":"Review","reviewBody":"Lekker man deze!","datePublished":"2026-05-24T13:39:01+00:00","author":{"@type":"Person","name":"damian005_"},"reviewRating":{"@type":"Rating","ratingValue":4.25,"bestRating":5,"worstRating":0.1}}]}		</script>
+		
+	<meta name="author" content="The Untappd Team" />
+	<meta name="Copyright" content="Copyright Untappd 2026. All Rights Reserved." />
+	<meta name="DC.title" content="Untappd" />
+			<meta name="DC.subject" content="Fifty Fifty - Clementine & Passionfruit by Magic Road is a Sour - Smoothie / Pastry which has a rating of 4 out of 5, with 121 ratings and reviews on Untappd." />
+			<meta name="DC.creator" content="The Untappd Team" />
+
+	<meta name="google-site-verification" content="EnR7QavTgiLCzZCCOv_OARCHsHhFwkwnJdG0Sti9Amg" />
+	<meta name="bitly-verification" content="b3080898518a"/>
+
+	<!-- favicon -->
+	<link rel="apple-touch-icon" sizes="144x144" href="https://untappd.com/assets/apple-touch-icon.png">
+	<link rel="icon" type="image/png" href="https://untappd.com/assets/favicon-32x32-v2.png" sizes="32x32">
+	<link rel="icon" type="image/png" href="https://untappd.com/assets/favicon-16x16-v2.png" sizes="16x16">
+	<link rel="manifest" href="https://untappd.com/assets/manifest.json">
+	<link rel="mask-icon" href="https://untappd.com/assets/safari-pinned-tab.svg" color="#5bbad5">
+
+	<link rel="stylesheet"
+    	href="https://untappd.com/assets/css/tailwind.css?v=2.8.36">
+	</link>
+
+	<link id="canonical" rel="canonical" href="https://untappd.com/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513">		<link rel="stylesheet" href="https://untappd.com/assets/css/master.min.css?v=4.5.41" />
+		<link rel="stylesheet" href="https://untappd.com/assets/v3/css/style.css?v=4.5.41" />
+		<link rel="stylesheet" href="https://untappd.com/assets/design-system/css/styles.css?v=4.5.41" />
+		<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+		<link href="https://fonts.googleapis.com/css?family=Material+Icons|Material+Icons+Outlined|Material+Icons+Two+Tone|Material+Icons+Round|Material+Icons+Sharp" rel="stylesheet">
+			<script src="https://untappd.com/assets/v3/js/common/min/site_common_min.js?v=2.8.36"></script>
+				<link rel="stylesheet" href="https://untappd.com/assets/css/facybox.min.css?v=4.5.41" />
+			
+		<link rel="stylesheet" href="https://untappd.com/assets/css/jquery.notifyBar.min.css?v=4.5.41" />
+		<link rel="stylesheet" href="https://untappd.com/assets/css/tipsy.min.css?v=4.5.41" type="text/css" media="screen" title="no title" charset="utf-8">
+		
+		<script type="text/javascript" language="Javascript">
+			$(document).ready(function(){
+				$(".tip").tipsy({fade: true});
+				$('.badge_hint').tipsy({gravity: 's', fade: true});
+				$('.disabled').tipsy({gravity: 'n', fade: true});
+
+				refreshTime(".timezoner", "D MMM YY", true);
+
+				$(".tab").click(function(){
+					$(".tab-area li").removeClass('active');
+					$(this).parent().addClass('active');
+					$(".list").hide();
+					$($(this).attr("href")).show();
+					return false;
+				});
+			});
+
+			</script>
+			<!-- For IE -->
+	<script type="text/javascript" language="Javascript">
+	onChangeInterval = "";
+	if(!(window.console && console.log)) {
+	  console = {
+	    log: function(){},
+	    debug: function(){},
+	    info: function(){},
+	    warn: function(){},
+	    error: function(){}
+	  };
+	}
+	</script>
+	
+	<!-- algoliasearch -->
+	<script type="text/javascript" src="https://untappd.com/assets/libs/js/algoliasearch.min.js?v2.8.36"></script>
+	<script type="text/javascript" src="https://untappd.com/assets/libs/js/autocomplete.min.js?v2.8.36"></script>
+	<script type="text/javascript" src="https://untappd.com/assets/libs/js/lodash.min.js?v2.8.36"></script>
+	<script type="text/javascript" src="https://untappd.com/assets/js/global/autosearch_tracking.min.js?v2.8.36"></script>
+
+	<script>
+        !function(e,a,t,n,s,i,c){e.AlgoliaAnalyticsObject=s,e.aa=e.aa||function(){(e.aa.queue=e.aa.queue||[]).push(arguments)},i=a.createElement(t),c=a.getElementsByTagName(t)[0],i.async=1,i.src="https://cdn.jsdelivr.net/npm/search-insights@0.0.14",c.parentNode.insertBefore(i,c)}(window,document,"script",0,"aa");
+
+        // Initialize library
+        aa('init', {
+        applicationID: '9WBO4RQ3HO',
+        apiKey: '1d347324d67ec472bb7132c66aead485',
+        })
+    </script>
+
+
+			<!-- Google Tag Manager -->
+		<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+		new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+		j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+		'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+		})(window,document,'script','dataLayer','GTM-N4DVXTR');</script>
+		<!-- End Google Tag Manager -->
+	
+	<script src="https://untappd.com/assets/v3/js/venue-impression-tracker.js"></script>
+
+	<script type="text/javascript">
+		var clevertap = {event:[], profile:[], account:[], onUserLogin:[], region: 'us1', notifications:[], privacy:[]};
+        clevertap.account.push({"id": "865-K5R-W96Z"});
+        clevertap.privacy.push({optOut: false}); //set the flag to true, if the user of the device opts out of sharing their data
+        clevertap.privacy.push({useIP: true}); //set the flag to true, if the user agrees to share their IP data
+        (function () {
+                var wzrk = document.createElement('script');
+                wzrk.type = 'text/javascript';
+                wzrk.async = true;
+                wzrk.src = ('https:' == document.location.protocol ? 'https://d2r1yp2w7bby2u.cloudfront.net' : 'http://static.clevertap.com') + '/js/clevertap.min.js';
+                var s = document.getElementsByTagName('script')[0];
+                s.parentNode.insertBefore(wzrk, s);
+        })();
+	</script>
+
+    
+<!-- Freestar Ads -->
+<!-- Below is a recommended list of pre-connections, which allow the network to establish each connection quicker, speeding up response times and improving ad performance. -->
+<link rel="preconnect" href="https://a.pub.network/" crossorigin />
+<link rel="preconnect" href="https://b.pub.network/" crossorigin />
+<link rel="preconnect" href="https://c.pub.network/" crossorigin />
+<link rel="preconnect" href="https://d.pub.network/" crossorigin />
+<link rel="preconnect" href="https://c.amazon-adsystem.com" crossorigin />
+<link rel="preconnect" href="https://s.amazon-adsystem.com" crossorigin />
+<link rel="preconnect" href="https://btloader.com/" crossorigin />
+<link rel="preconnect" href="https://api.btloader.com/" crossorigin />
+<link rel="preconnect" href="https://cdn.confiant-integrations.net" crossorigin />
+<!-- Below is a link to a CSS file that accounts for Cumulative Layout Shift, a new Core Web Vitals subset that Google uses to help rank your site in search -->
+<!-- The file is intended to eliminate the layout shifts that are seen when ads load into the page. If you don't want to use this, simply remove this file -->
+<!-- To find out more about CLS, visit https://web.dev/vitals/ -->
+<link rel="stylesheet" href="https://a.pub.network/untappd-com/cls.css">
+<script data-cfasync="false" type="text/javascript">
+    var isLoggedIn = false;
+    console.log("freestar_init", `isLoggedIn: ${isLoggedIn}`);
+
+    var env = 'PROD';
+
+    var freestar = freestar || {};
+    freestar.queue = freestar.queue || [];
+    freestar.queue.push(function () {
+        if (env !== 'PROD') {   
+            googletag.pubads().set('page_url', 'https://untappd.com/'); // Makes ads fill in non-prod environments
+        }
+    });
+    freestar.config = freestar.config || {};
+    if (isLoggedIn) {
+        // https://freestarhelp.zendesk.com/hc/en-us/articles/34516941197460-Disabling-Products
+        freestar.config.disabledProducts = {
+            stickyFooter: true,
+            video: true,
+            stickyRail: true,
+            pushdown: true,
+            dynamicAds: true,
+            sideWall: true,
+            pageGrabber: true,
+            googleInterstitial: true,
+            videoAdhesion: true,
+            iai: true,
+        };  
+    }
+    freestar.config.enabled_slots = [];
+    freestar.initCallback = function () { (freestar.config.enabled_slots.length === 0) ? freestar.initCallbackCalled = false : freestar.newAdSlots(freestar.config.enabled_slots) };
+</script>
+
+<!-- Ad-blocking revenue recovery tool provided by Tyler (https://nextglass.slack.com/archives/C049TLGTPRR/p1770762270660589) -->
+<script data-cfasync="false" type="text/javascript">
+    (()=>{var h=(o,t,i)=>new Promise((e,n)=>{var s=u=>{try{l(i.next(u))}catch(v){n(v)}},d=u=>{try{l(i.throw(u))}catch(v){n(v)}},l=u=>u.done?e(u.value):Promise.resolve(u.value).then(s,d);l((i=i.apply(o,t)).next())});var D,kt=new Uint8Array(16);function G(){if(!D&&(D=typeof crypto!="undefined"&&crypto.getRandomValues&&crypto.getRandomValues.bind(crypto),!D))throw new Error("crypto.getRandomValues() not supported. See https://github.com/uuidjs/uuid#getrandomvalues-not-supported");return D(kt)}var c=[];for(let o=0;o<256;++o)c.push((o+256).toString(16).slice(1));function st(o,t=0){return c[o[t+0]]+c[o[t+1]]+c[o[t+2]]+c[o[t+3]]+"-"+c[o[t+4]]+c[o[t+5]]+"-"+c[o[t+6]]+c[o[t+7]]+"-"+c[o[t+8]]+c[o[t+9]]+"-"+c[o[t+10]]+c[o[t+11]]+c[o[t+12]]+c[o[t+13]]+c[o[t+14]]+c[o[t+15]]}var Et=typeof crypto!="undefined"&&crypto.randomUUID&&crypto.randomUUID.bind(crypto),W={randomUUID:Et};function Tt(o,t,i){if(W.randomUUID&&!t&&!o)return W.randomUUID();o=o||{};let e=o.random||(o.rng||G)();if(e[6]=e[6]&15|64,e[8]=e[8]&63|128,t){i=i||0;for(let n=0;n<16;++n)t[i+n]=e[n];return t}return st(e)}var B=Tt;typeof document!="undefined"&&(A=document.createElement("style"),A.setAttribute("type","text/css"),A.appendChild(document.createTextNode('div._1bm7ugs{position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.4);z-index:999999}div._1bm7ugs *{box-sizing:border-box}div._1bm7ugs div.ittm5a{position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);display:flex;flex-direction:column;justify-content:flex-start;min-height:25vh;width:50%;background-color:#fff;border:none;border-radius:1em;box-shadow:0 0 10px rgba(0,0,0,0.3);text-align:center;font-size:13px;font-family:Arial,Helvetica,sans-serif;font-weight:bold;line-height:2;color:#000000}div._1bm7ugs div.ittm5a *:before,div._1bm7ugs div.ittm5a *:after{content:"";display:none}@media screen and (max-width:479px){div._1bm7ugs div.ittm5a{font-size:13px;width:90%}}@media screen and (min-width:480px){div._1bm7ugs div.ittm5a{font-size:14px;width:80%}}@media screen and (min-width:608px){div._1bm7ugs div.ittm5a{font-size:14px;width:70%}}@media screen and (min-width:960px){div._1bm7ugs div.ittm5a{font-size:16px;width:70%}}@media screen and (min-width:1200px){div._1bm7ugs div.ittm5a{font-size:16px;width:840px}}div._1bm7ugs div.ittm5a div._1wmm6xd{width:100%;background-color:transparent;border:0;color:inherit;display:block;font-size:1em;font-family:inherit;letter-spacing:normal;margin:0;opacity:1;outline:none;padding:1em 2em;position:static;text-align:center}div._1bm7ugs div.ittm5a div._1wmm6xd img{display:inline;margin:0 0 16px 0;padding:0;max-width:240px;max-height:60px}div._1bm7ugs div.ittm5a div._1wmm6xd h2{display:block;line-height:1.3;padding:0;font-family:inherit;font-weight:normal;font-style:normal;text-decoration:initial;text-align:center;font-size:1.75em;margin:0;color:inherit}div._1bm7ugs div.ittm5a div._1wmm6xd h2:not(img+*){margin-top:30px}div._1bm7ugs div.ittm5a div._1wmm6xd span._10cqbyd{position:absolute;top:0;right:15px;font-size:2em;font-weight:normal;cursor:pointer;color:inherit}div._1bm7ugs div.ittm5a div._1wmm6xd span._10cqbyd:hover{filter:brightness(115%)}div._1bm7ugs div.ittm5a section{width:100%;margin:0;padding:1em 2em;text-align:center;font-family:inherit;color:inherit;background:transparent}div._1bm7ugs div.ittm5a section p{display:block;margin:0 0 1em 0;line-height:1.5;text-align:center;font-size:1em;font-family:inherit;color:inherit;overflow-wrap:break-word;font-weight:normal;font-style:normal;text-decoration:initial}div._1bm7ugs div.ittm5a section p:last-of-type{margin:0 0 1.5em 0}div._1bm7ugs div.ittm5a section.zgt4cb{display:block}div._1bm7ugs div.ittm5a section.zgt4cb._15yer7c{display:none}div._1bm7ugs div.ittm5a section.zgt4cb a.mhlzqc._1emtbbe{color:var(--_1emtbbe)}div._1bm7ugs div.ittm5a section.zgt4cb a.mhlzqc.g0b7gl{text-decoration:var(--g0b7gl)}div._1bm7ugs div.ittm5a section.zgt4cb a.mhlzqc._1h4vo4h:visited{color:var(--_1h4vo4h)}div._1bm7ugs div.ittm5a section.zgt4cb div.axqbiy{display:block;margin:0.75em;padding:0}div._1bm7ugs div.ittm5a section.zgt4cb div.axqbiy p._10lak7c{max-width:80%;margin:0 auto;padding:0;font-size:0.85em;color:inherit;font-style:normal;font-weight:normal;cursor:pointer}div._1bm7ugs div.ittm5a section.g3f52f{display:block}div._1bm7ugs div.ittm5a section.g3f52f._15yer7c{display:none}div._1bm7ugs div.ittm5a section.g3f52f h4._1e70kqd{color:inherit;text-align:initial;font-weight:normal;font-family:inherit;font-size:1.125em;margin:0 0 0.5em 0.5em}div._1bm7ugs div.ittm5a section.g3f52f div.i5jiss{display:flex;margin:1.5em 0}div._1bm7ugs div.ittm5a section.g3f52f div.i5jiss ul._19i18vc{max-height:300px;flex:2;list-style:none;overflow-y:auto;margin:0 1em 0 0;padding-inline-start:0}@media screen and (min-width:608px){div._1bm7ugs div.ittm5a section.g3f52f div.i5jiss ul._19i18vc{flex:1;margin:0 2em 0 0}}div._1bm7ugs div.ittm5a section.g3f52f div.i5jiss ul._19i18vc li{padding:0.75em;cursor:pointer;background:rgba(0,0,0,0.05);font-weight:bold}div._1bm7ugs div.ittm5a section.g3f52f div.i5jiss ul._19i18vc li:hover{background:rgba(0,0,0,0.075)}div._1bm7ugs div.ittm5a section.g3f52f div.i5jiss ul._19i18vc li._1lowx25{color:var(--_1lsu7q);background:var(--vot3fy)}div._1bm7ugs div.ittm5a section.g3f52f div.i5jiss div._1kebabo{max-height:300px;overflow-y:auto;flex:3;display:flex;flex-direction:column;justify-content:space-between;text-align:initial}div._1bm7ugs div.ittm5a section.g3f52f div.i5jiss div._1kebabo ol._130j852{display:none;list-style-type:decimal;text-align:initial;padding:0;margin:0 2em;font-weight:normal}div._1bm7ugs div.ittm5a section.g3f52f div.i5jiss div._1kebabo ol._130j852._1lowx25{display:block}div._1bm7ugs div.ittm5a section.g3f52f div.i5jiss div._1kebabo p{margin:1em 0 0;text-align:inherit;font-style:italic}div._1bm7ugs div.ittm5a section.g3f52f button.hrbmcw{font-size:1em;text-transform:initial}div._1bm7ugs div.ittm5a button._10jcka8{width:auto;height:auto;max-width:90%;cursor:pointer;display:inline-block;letter-spacing:normal;margin:0.75em;opacity:1;outline:none;overflow-wrap:break-word;font-family:inherit;font-weight:normal;font-style:normal;text-decoration:initial;text-transform:uppercase;text-align:center;color:#FFFFFF;font-size:1.15em;padding:0.75em 2em;padding-inline:2em;padding-block:0.75em;line-height:normal;background:#40C28A;border:none;border-radius:0.25em;box-shadow:none}div._1bm7ugs div.ittm5a button._10jcka8:hover{filter:brightness(115%);box-shadow:none}div._1bm7ugs div.ittm5a a._1ahf6lp{height:50px;width:50px;position:absolute;bottom:5px;right:5px}div._1bm7ugs div.ittm5a a._1ahf6lp img{position:initial;height:100%;width:100%;filter:drop-shadow(1px 1px 1px var(--_1n05zg8))}')),document.head.appendChild(A));var A;var at="aHR0cHM6Ly9hLnB1Yi5uZXR3b3JrL2NvcmUvcHJlYmlkLXVuaXZlcnNhbC1jcmVhdGl2ZS5qcw==",rt="aHR0cHM6Ly93d3cuZ29vZ2xldGFnc2VydmljZXMuY29tL3RhZy9qcy9ncHQuanM=",dt="aHR0cHM6Ly9hLnB1Yi5uZXR3b3JrL2NvcmUvaW1ncy8xLnBuZw==",lt="ZGF0YS1mcmVlc3Rhci1hZA==",ct="c2l0ZS1jb25maWcuY29t";var mt="aHR0cHM6Ly9mcmVlc3Rhci5jb20vYWQtcHJvZHVjdHMvZGVza3RvcC1tb2JpbGUvZnJlZXN0YXItcmVjb3ZlcmVk",ut=["Y29uZmlnLmNvbmZpZy1mYWN0b3J5LmNvbQ==","Y29uZmlnLmNvbnRlbnQtc2V0dGluZ3MuY29t","Y29uZmlnLnNpdGUtY29uZmlnLmNvbQ==","Y29uZmlnLmZyZmlndXJlcy5jb20="];var y="ZnMtYWRiLWVycg",gt=()=>h(void 0,null,function*(){document.body||(yield new Promise(n=>document.addEventListener("DOMContentLoaded",n)));let o=["YWQ=","YmFubmVyLWFk","YmFubmVyX2Fk","YmFubmVyLWFkLWNvbnRhaW5lcg==","YWQtc2lkZXJhaWw=","c3RpY2t5YWRz","aW1wcnRudC1jbnQ="],t=document.createElement("div");t.textContent=Math.random().toString(),t.setAttribute(atob(lt),Math.random().toString());for(let n=0;n<o.length;n++)t.classList.add(atob(o[n]));t.style.display="block",document.body.appendChild(t);let i=window.getComputedStyle(t),e=i==null?void 0:i.display;if(t.remove(),e==="none")throw new Error(y)}),H=(o,t=!1)=>h(void 0,null,function*(){return new Promise((i,e)=>{let n=document.createElement("script");try{n.src=o,n.addEventListener("load",()=>{t?ft(o,i,e):i()}),n.addEventListener("error",()=>{e(y)}),document.head.appendChild(n)}catch(s){e(s)}finally{n.remove()}})}),pt=(...t)=>h(void 0,[...t],function*(o=atob(dt)){return new Promise((i,e)=>{let n=encodeURIComponent(new Date().toISOString().split("Z")[0]),s=document.createElement("img");s.src=`${o}?x=${n}`,s.onload=()=>h(void 0,null,function*(){yield ft(o,i,e),i(),s.remove()}),s.onerror=()=>{e(y),s.remove()},document.body.appendChild(s)})}),ft=(o,t,i)=>h(void 0,null,function*(){try{let e=yield fetch(o),n=e==null?void 0:e.redirected,s=e==null?void 0:e.url;n||(s?s!==o:!1)?i(y):t()}catch(e){i(y)}});var ht="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEsAAABLCAMAAAAPkIrYAAACPVBMVEUAAAAdHRocHBoAwogKCgkcHBoOunUcHBoBw4kJxYwcHBocHBocHBocHBocHBocHBoMDAwcyZYMDAsLCwocHBocHBoJCQkcHBobGxocypYdHRsLCwscHBodHRocHBsdHRsdHRscHBsUFBMG4ocTExIWFhUcHBocHBocHBsdHRsXFxYAwogcHBocHBocHBocHBsdHRsSEhEPDw4QEA4RERAcHBodHRsGxIocHBoeHhwaGhkXFxUVFRQSEhEQEA8NDQwLCwoAwogcHBodHRseHhsUFBMUFBMTExESEhIODg0dHRsfHx0fHx0XFxYXFxUWFhUaGhgQEA4REREKCgkCw4kcHBodHRsaGhkcHBoODg0XFxYPDw4PDw4SEhAODg0J1ZkBw4kcHBocHBodHRoiIiAZGRcQxJIWFhQLy4gQEA8Bw4kBwokDw4oDw4kEw4oIxIsIxIsVFRQjIyIXFxUXFxYDroAVxJUWFhUPyZkMxZUZvpoKuakGxIoJxYwHxIsPxY4Kw4wRxZkEooYgIB4mJiUPxo4Iu4cUFBMKuJ0RupofhmchgGQHxIoLxY0LxY1RUU8cx5IVFRQFu40IwpcOzo0Nw4gW0ZARERAEt3AUzY8Ny6ESEhAJwYwH4pUQEA8PyKRK2LcWFhUIyqkClWcQkW8sdWERoXcNuoYWqn4Ps4IlyJgWyZFG06gG03MI04ofyZoEt3AEpoUGvqIXFxUIvaEPDw4I4GsAwogAw4kCv4YQonYdh2cNqXoZkW0ggGUR8h49AAAAt3RSTlMA/fz9Bf4m9fK++ujw6/PhEpcPB+7kCdCqmZQN+fjOwaecX11QTNjErph4+t3b07R/PzUrGdW+vIp1bVlHQxwUC/f3n5BoWykkIMiNhG5kVTQlIhfty6OHaFJPOzgvJw3pu7ayioB5cUMw9PDl39qvqoJ/fHRgQSocFxQK0caaioJpYmBKOTQoJyL08bampKCQjYhxcWhmZF9dW1dUNTMyMCspHRAG8Ne9qqCcjYJ7cmBSUTkqKRN/kiPNAAAHfElEQVRYw9WX9UPbUBDH716TZWvSllFdHdbRUtrCYDBjBszd3d3d3d3d3V3D9G/bvbXdyJKMbr/t8wO8V5rvu7ucPOA/RJjafahv/PguAL7aSn9Vp77wjwxcG1GQMUkSpwHYggpDlLwTBfhr+kzyIjbUNZUOhnniVNKaDX1iExMhsQb+krF+BRuik4uAM/SHVh0QfRUvwEF3YjoUStFqCdPJ4uzGOTD6Qyu8mD4YgVUAE0W0RsdAQcTcmBqQ1RngHyKJiNUAMorWTEm4YSwIKVt9HBuShRjlY0qSvy9PbI4dmTykMTmZdlOHl9e5rRgB6Ix+Os+B4wdCK4xKYYTbH+guM4xUaQPTu/8MgBKMcZOjWNaK1AApmOTfXOhGee0MMCIqSuVF4PTiCPgjC5mtnn5Ve1FOOsGEkWF0lVZiEy07mWfbOnQcpF9VQTxdBOYIIxTEubQoFyvNxIaz9GDK0jmYntZa/s2NF9P3URInmNiODpIaU4u+wspuitU9I4LdwIDpdtdtkkqx+VAQYxRpMRSHWU/QUVwW7ERv3YHDoTAG2aydAQbbQvoKbcTVJFhLUoXytsE+CmAfywigpROLUxL4xGEA9w8fatMKhw5vBYBeIUcfYZIdO4EGT0qiYHXHhAAXlqkFMG4B8BcZ96K9B2gglXkUfSlVBLstqtrcOqplJwAkWEN5n98LukH2gBCx1sPMtlolCz1mIEUHWjbRc00bee7ubdmB1iAZOgBPAlxXm9Vt7Tt06NCeoB/L1OYKWtE6B31IbFebLdfyoS7DyhZF4ZYDIDjsvbNaK27BT9o1N7cFPU9I6w1wNs5hQTf+6icjcChAjx8pPHMciS0534rWoQpV7bf5R1qGRN/Beno+z5wQTa2M8qOer1SoxImZf9RaRQfuzC7D1i7glF3OfIvDOCULlmR315aSFvfTXOsmnbd0S3ZdykdAFesEuS3rD1CO1bntXQos+bnbXIvMspzJrQOuDHVw1pjbJsRBILgcAuQ5ZSEfLKvumWgdoIxo++Fnn2U170dK+YYtOwCmsWHwi0XjyE3L8v3GWl3pjzzt804GRYZy1pIu1nIaehiDFmxqp5Jp/c4aaW0gs2bNhDx9w/HGhZ2Lc/MCuwNUBn/ryru4n+qxbapOqytFawEYM5EXelo3oRZla5zsMjBrq3YATM4bUoKDIRCs1J2xpWu2yvtd7tiCy2Spuhs0nGThsdnVXEmAGsouPS8quJiqhReZxqziOrRhehBwIjY+2IeCARuWq6pBu7mgmUlDxIQzyeRRQAxxUK3jGjBiy0Muxp//hbpD0/ZrsUSgkhaVXjmtfTgMDHn0icRI6tz6PXvWX7r0av2e9QegBYvduDo74ezSSIC4zKtxHhjS7vPXj1xs1iIwoloRFV/JDICYr0y09oTZCqU9+k20vnw78pinWsVzMGCvZLeH2EVyTpQkqRyi1mIYjFETrY+fj8LLfrw+u94FPR6nc4R1MoAjFPB4eIeYBvel8SZa6qejVM3LuZ/LjP1cw6pBsNcCpwonAdQqgomWeoS325U//DQsnYTYBYpCjdk3wFtEAqcbazWrD4Bzvp9KnAM9bhePd/ds3vL6WYN7zbSW5prpCrJsOejoY53A52vuiuJwCbCYDTXTytf2popmdRzomMTnoY/lRmSjWAOCzaYNmH52nCW7jhmEi40mP/Nt5ipbB9CEncGArj+1ZvJeu19/h7eHeTmX/PR4PN9G/6y1i8xaCTr6syTAMKzP731WMjNsH/snH7eQWRV6s5xpqQg88q8A9UQ/j6HfVMvcrJEiPbWv5a3V4aImm5YGm2tt7kdV9A501AbJpQjWtLzYJ7l1UXOtU2TWU9DRnTvTmSXgFwGbUgxCHZtiprVpCV1GDuvvv5KtGKCOVWveBtcfaHd3MdHaQWbtAB0RkdI9hgnQkAmO4vfPSsFQ644ld0fS0k30AXgclAUaOlvDHn6PHmqodZzMOqOT6snKinnLqoLf8ONpKvMMJg1ytU0FVbjOrHqrayCfOl7dIQGvlXp/75SY1GutpOrZqZOySxTy0YrB/x0w0CWNIrE0a3JqLw9L9FOfKA3Z66kaa6nZ6CFr5Y0k5hUri7S3SVV/GRGaRD5cA3HKeENKrY5BFDMfOnpBnivUm/lIu6f1YYjopUHWtw4bwYSLzMYn+UIJS34m2gkL2dV2kSa084M4wUP9JY5zeQ6ZWabw1K+Jo2tYALK8Pr792Z2WnaGHA92d+M3+x/Q3Z4rN2k3goim0N90APYPWysw1vy/PLsW6Gv7IwAyOr+GnTypDMdOtl+bg6qoIomt+Hz5wJohSDFoh4GfSPO6f0GuCDVHJRLv1L706oP+waNiFaJ89ktsklMoYHw2t0zmNth4e4PTqNlcWERljiKI90jQg+3HMi0p3KAjPQgXleb1zuy43esUmT66vHizkDO/hxRC950LpW+VGa11pb/3UiZVIaJ8wCP4Gz4DZImPh8nWLf0Z/dH9/XQNiWY+x8Nd06V/pRsSQzZ0qSztkidauyNoa+FdmjJhfPsebkh2Z2Y0Te1TDf8p3Lm4o6W/+QtYAAAAASUVORK5CYII=";var bt="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEsAAABLCAMAAAAPkIrYAAAC8VBMVEUAAAAAwoj+/v7+/v4Awoj+/v4AwYj+/v4Ss4K3t7f9/f38/Pz9/f0IuYT+/v78/Pz+/v79/f39/f39/f0IVT329vb8/Pz8/PwFnoP19fX19fX8/Pz9/f39/f36+vrz8/P19fX19fX39/f7+/sStIP29vYH1b0AwYf8/Pz19fX4+Pj4+Pj09PTx8fEAwoj6+vr6+vr5+fn39/f29vb29va4uLi4uLj9/f37+/sHuoT7+/v5+fn6+vr19fX6+vr39/f09PT6+vr09PS4uLi4uLj09PS4uLj9/f0BwYf9/f38/Pz7+/v29vb4+Pj19fX09PT6+vry8vL4+Pj19fX4+Pjz8/P29vb29vb4+Pjo6Oj4+Pj4+Pjd3d0IuX74+Pjz8/MDiWP8/Pz8/Pz6+vr29vb7+/v39/f4+Pj6+vrv7+/29vb19fXm5ubu7u739/cEXUL6+vr9/f36+vr5+fkHsIT6+vrw8PD09PT6+vr39/cBwIf9/f0BwIf6+voIuYQEvYUGuoQEvIX6+voHuIP39/fu7u7h4eEHsYLt7e37+/v19fXy8vLv7+/x8fHx8fEGvYrBwcHx8fEFr5UBwIcBwYcDvoYHu4UDvob39/cGuoP6+voJtIUJtIMKrYGEXULt7e3y8vLo6OgIVT0IlX3W1tYHtI8Kv2IehWYhgGQDv4cBwIcEv4YFvIYEvob+/v4KtIAFu4T39/cItoELqoAHuoUGvoPn5+fv7+8NrH7JyckIuXwGs4UDrpMItYTHx8f09PTk5OQGyXUJrJIEmYB8fHwHv5V8fHwJroUGxoHi4uIOoHgExIQIVT4Fsoi7u7v5+fkJsnL09PQGmHIGkXkHtGsRoXcJtIAUoXYIrHzg4ODw8PDp6ekFvYbu7u7Dw8MGxYMEnWIDnXIJx3sMpn7Ozs4Dwaa2trYGyYPX19e7u7sUoIQIVD0H14sH2H8Kums/qEe8vLwgpmLh4eEAw4kAwogQonYdh2cDvYUNqXoZkW0ggGSqNDsXAAAA83RSTlMA/vz+/Pf1+qkH8eX1zfjT++rv7i8I4dZiLR4L8+bGaCsVE8unki732I82LyUO+r64ops0FwkF487LyLWzrn9YVT08FA8KBPTv7N3DtaihmIyEfXt2dW5gW1VLQiwZEAYE3trBsKyll5SPiIaGe29tY11STkdGOighGfPo4dLOvLaxsI6Kh399cWtrZFxSQR4cEhLs6N7Jxr2tnJSDdW9kYE0wLiclEvb07OPWzsO0pqKdmoyFfXZzbm1sYlhNTElIRz8/Pj09Ojk1NTAvLCsmJBwaDQn14Mq0qqejo4t6c2xpaGBcWVhXPDsxMCsqKiIZDw1727kAAAAH5klEQVRYw9WXVYDTQBCG/8w2lAoVChQ93N3d3d3d3d3d3d3d3d3d3d2dFn1iQkvpNSkU3vjuIbud5L+d2dnJBP8hmfdVTJzT6YwJ5KzfMEOeUePxbxRJ2SqhmYhkWRwCIutj89iSLHlm/DWZhjXgR8OajYhRpLk4wloNEXNUuVyyyIi/JGaG2CQ3qpYJCh6tkmBSG61ASnup4wiV+IllilYhvmeSOmXuHz5aU7ByXGoJJBdka9QVIVE1DmUdCYUPcTNkswhBz4HifCmRvrclJgxxHPMTkr58KIEqRbHzxOJBoWppOfSObKVbPeJZ5zvrS8YhCuMRlUGRvCaypsQfKGCisFR8TdDaQSJHywLhjKm2nAHKUF4exmosouH3tJP1efgStYKdHC1iQIsBwlImEwpbqQ1+Sx5y1OBLfifZ8xQOlnfVrFQ0bjpqyuMOwbOtPJmUtQzSU7P4CE6WKrFJTIPibtpgYhWpfjcOflqqX+BP+ZcuYQKgEskid5BcECaOeq0GIldqhEIH6hmjJLuqQRezsRYQz0StiiAUUhnlFBhvFXHVpoIl9B2BRXFEJYRGvMhUgxUj69UHqjSVY8FkFKoU77YsdwHmkzNqgCEfJTSgSCnRAri0+HWShfyXJArzcsGCBVF+cuoU/6rwavElADUspvOGKrKojnCkjmbhbKhAObNg23IpBIoN/bHxYVYyV0Z4WlNyIIUcrSBm6yRXCEjSQHC1JUv67oFVRu+IBUMOWw0sSSq5JD9Y2C1pc45zsVlG5cSNrOWnNVg5XHHpJnCQpVYmYiJ6WO5y6ZSZPzxfxbft+hnqEpQWPqLa7YUQ1VQ0pkdr8gn4yO5yRYCatZJL59GKMY30Jkrhs8SlxEBlJWR434PFIuzwmSK5XEmh4nQaSUpTG0wCvUgXbw+V9ZnScrnMkiz2j/P8MA2L6aZP+K1Wf75ng+ecO23dYLBH/llVuokwThZK75k9LcY3+vzMrqV1VOeSetT2VjwaDLSk6j4Xqyj142dxeDtVYrWks+sF1erH9o3ecSFjMmAMNfFOc4quiGqMkwVe6g1UxHT9LwSJ/QFOiAi14aUxFUhZTf5ZsIubFOVBfnd3KiYxvQ4DUzS0VktuaZbfxpEg8gasG2UAklM++DF2qk7xc7OWViedW5o4wTet48xWekhnbx2eq9SGdPqAqrxJEdP1nazWmsq5tRnaJKfRQNYSCGD/JMnNG+oO1NqtLOsi/DG0L+gdpaeznHJpEUjtvrwFTNKd0f3YuZKXtSO81HXqHdMzTCdHRUbOLhX1hv6oGVIALqlXuGUVChPFqb7neOdwAPtEYmjQaQX7GIik2wY/uicUuaKWp+JdwPSOA1QXg6FF7Stut+d5P9bBj64NRBMDMFwY9/Is2w+tQdDk6scfYtKse20V5syZc/+wvz1jT2oFhWpmuRqQsDiwRySHJtk/ff2s7OekTprmFEZRdM0ALu9P1tQXVBVpYwP5qWkQrS/fll77caQ21oOauLJe1tN2dk5YZHkGH6gE6EqNoUkk6dMyDP1Rh1ZfgJpYsWINt7UHTPo6hWMBMyg/CsvWIFruj8uAY70kF/u5G1oM4eejxo7m7W5GAA2KGoJouZfyZUl/5Uil2aTlZy4xjnO9kbfHaME/UAptLZf7MhTuKn5Ks6EmTuy6HO+KYFgznbK4ucG0eoDx+CmtgIrutkaKn/O8wkYDUlBiaNHnV504x5W5GFRUocrAAIrnbUtEStR1OKJqr8unNZTX1VcjXJQS6Pmzro5SnC1LnX+vNaGH5NYdUPdaZitQ01cautOPaaPf+zhQe1nbqTzQgny9Tik9e2s1j/udVu1ivKyjKrshmqU7MheP7AvQPMqgxLDs77QGcuT7qe2jlEer+29cViNX+2hyquDxGstvfd1Jtb2BjV0Ko4z+7VcFoCrlDq61gaO1Vm1uTWWUUKfzbwuNRRMgS0PKF0xrcQRuRt6orGfNkdmhkjQmfMKx2ynNpnFBtG7xstapP2fCqKrS6uaEP3WT2djlypTToKl1mt/USceqtBJTKSCWScRDODpT78xAbpFYU2s6L2umxodKiQTAemoZaMhAzTiJnZRHQ+uFjvs71bI66o1cnEeTs26gpZBV+caMmVUoYgE9Zj/JrV5WDbP8DOhqtNSCilpG5TMiVTQq6x8zpTfppBSICQjPCIt5NBDfKdppfncJ+yJgkVOkix++bZP4rT8r4OiUFY4CnEslOTKajLCZznDMSpFpr++3B542YOIS+BMjm3Dy5sVqSKURhGHkYDdRwULpz8PLdJ3SBe4PF9pWNsodC3gXJqYZEIzhtthK6qdISJFvj/c2KI/7r5rpfxCjVjaRXbkrRjK6YUBw8hqpHNsNbeKQuWwBqIk3xE6xk6dWiktsKoffwv8sW0pwKNqYSCQrNz9c4R7TMocgcwvloCUoLeS8+AN10pPcvA4PMnccEJnInCxX4i3D27Xb2ryx1Ugkh41UfDfEtVPCePgzHaORo02sH6d0dOKGRiHIZrOREJaETePW8UTCSnJFhEShCmayN/d2jVm65e/Yvn37DjXjFfYufKuV9E3YGiIJkttJHzZSXWcz5W1iJjl3DPwNqedymIVzRuuaqeEhc4phTXPoiUyVY+KvSVUprYM4WJF7Zs0aLY6RZahowsEZs+AfyThsUJOSJexGe9YcuctVqlkX/yffAdbeMQWIuBUAAAAAAElFTkSuQmCC";var F=class{constructor(t){this.config=null,this.langCode=null,this.languages=this.getUserPreferredLanguages(t)}init(){return h(this,null,function*(){this.config=yield this.fetchConfig(),this.config!==null&&(this.langCode=this.getFirstSupportedLanguage(this.languages),this.observe())})}fetchConfig(){return h(this,null,function*(){let t=ut,i=t.length-1,e=Number.isNaN(Number(localStorage.getItem("fs.cdi")))?0:Number(localStorage.getItem("fs.cdi")),n=Number.isNaN(Number(localStorage.getItem("fs.cfc")))?0:Number(localStorage.getItem("fs.cfc")),d=`https://${atob(t[e])}/untappd-com.json`;try{return(yield fetch(d)).json()}catch(l){return n++,n>=3&&(n=0,e++),e>i&&(e=0),null}finally{localStorage.setItem("fs.cdi",e),localStorage.setItem("fs.cfc",n)}})}killScroll(t){if(t.isScrollDisabled){this.existingOverflow=document.body.style.overflow,document.body.style.overflow="hidden";let i=window.pageYOffset||document.documentElement.scrollTop,e=window.pageXOffset||document.documentElement.scrollLeft;document.body.style.top=`-${i}px`,document.body.style.left=`-${e}px`,window.onscroll=function(){window.scrollTo(e,i)}}}reviveScroll(){document.body.style.overflow=this.existingOverflow||"",window.onscroll=function(){}}getUserPreferredLanguages({languages:t,language:i}){let e=t===void 0?[i]:t;if(e)return e.map(n=>{let s=n.trim().toLowerCase();if(!s.includes("zh"))return s.split(/-|_/)[0];let d=s.split(/-|_/)[1],l=["hans","cn","sg"],u=["hant","hk","mo","tw"];if(s==="zh"||l.includes(d))return"zh";if(u.includes(d))return"zh-hant"})}getFirstSupportedLanguage(t){let i=["title","paragraphOne","buttonText"],e=t.find(n=>i.every(s=>!!this.config[s][n]));return e!==void 0?e:"en"}getLocalizedTextContent(t,i,e=!1){var s;let n=t[i];if(n===void 0)throw new Error(`Config text not found for text key ${i}`);return e?(s=n[this.langCode])!=null?s:n.en:n[this.langCode]}getPixelString(t){return typeof t=="number"?`${t}px`:null}pickContrastingColorValue(t,i,e){let n=t.substring(1,7),s=parseInt(n.substring(0,2),16),d=parseInt(n.substring(2,4),16),l=parseInt(n.substring(4,6),16);return s*.299+d*.587+l*.114>=128?i:e}generateOverlay(t){let{siteId:i,isCloseEnabled:e,dismissDuration:n,dismissDurationPv:s,logoUrl:d,font:l,paragraphTwo:u,paragraphThree:v,closeText:E,linkText:U,linkUrl:O,textColor:T,headerTextColor:S,buttonTextColor:w,headerBgColor:X,bgColor:I,buttonBgColor:L,borderColor:V,borderWidth:vt,borderRadius:xt,closeButtonColor:$,closeTextColor:Q,linkTextColor:Z,linkTextDecoration:j,linkVisitedTextColor:J,hasFsBranding:yt,disableInstructions:_t}=t,g=document.createElement("div");g.style.setProperty("--vot3fy",L||"#40C28A"),g.style.setProperty("--_1lsu7q",w||"#000000"),g.style.setProperty("--_1n05zg8",this.pickContrastingColorValue(I||"#FFFFFF","white","black")),Z&&g.style.setProperty("--_1emtbbe",Z),J&&g.style.setProperty("--_1h4vo4h",J),j&&g.style.setProperty("--g0b7gl",j),g.classList.add("_1bm7ugs"),g.id="ndeb5g",g.dir="auto",this.oid=g.id;let p=document.createElement("div");p.classList.add("ittm5a"),I&&(p.style.backgroundColor=I),l&&(p.style.fontFamily=l),T&&(p.style.color=T);let Y=this.getPixelString(xt),q=this.getPixelString(vt);Y&&(p.style.borderRadius=Y),(V||q)&&(p.style.borderStyle="solid"),V&&(p.style.borderColor=V),q&&(p.style.borderWidth=q);let b=document.createElement("div");if(b.classList.add("_1wmm6xd"),S&&(b.style.color=S),X){b.style.backgroundColor=X;let a=Y||"1em";b.style.borderTopLeftRadius=a,b.style.borderTopRightRadius=a}if(d){let a=document.createElement("img");a.src=d,a.alt="Logo",a.onerror=function(){this.style.display="none"},b.appendChild(a)}let K=document.createElement("h2");K.textContent=this.getLocalizedTextContent(t,"title"),b.appendChild(K);let x=document.createElement("section");x.classList.add("zgt4cb");let tt=document.createElement("p");if(tt.textContent=this.getLocalizedTextContent(t,"paragraphOne"),x.appendChild(tt),u&&Object.keys(u).length!==0){let a=document.createElement("p");a.textContent=this.getLocalizedTextContent(t,"paragraphTwo"),x.appendChild(a)}if(v&&Object.keys(v).length!==0){let a=document.createElement("p");a.textContent=this.getLocalizedTextContent(t,"paragraphThree"),x.appendChild(a)}let et=U&&this.getLocalizedTextContent(t,"linkText"),it=O&&this.getLocalizedTextContent(t,"linkUrl",!0);if(et&&it){let a=document.createElement("div");a.style.margin="0 0 1em";let r=document.createElement("a");r.classList.add("mhlzqc"),Z&&r.classList.add("_1emtbbe"),J&&r.classList.add("_1h4vo4h"),j&&r.classList.add("g0b7gl"),r.textContent=et,r.href=it,r.target="_blank",a.appendChild(r),x.appendChild(a)}let _=document.createElement("button");if(_.classList.add("_10jcka8"),_.tabIndex=0,_.textContent=this.getLocalizedTextContent(t,"buttonText"),L&&(_.style.backgroundColor=L),w&&(_.style.color=w),_.onclick=function(){document.querySelector("section.zgt4cb").classList.add("_15yer7c"),document.querySelector("section.g3f52f").classList.remove("_15yer7c")},x.appendChild(_),e){let a=()=>{if(g.remove(),this.reviveScroll(),!n&&!s){sessionStorage.setItem(`fs.adb${i||""}.dis`,"1");return}sessionStorage.removeItem(`fs.adb${i||""}.dis`),s?this.updateValues("p"):n&&this.updateValues("dt")},r=document.createElement("span");if(r.classList.add("_10cqbyd"),r.innerHTML="&times;",r.tabIndex=0,$&&(r.style.color=$),r.addEventListener("click",a),b.appendChild(r),E&&Object.keys(E).length!==0){let f=document.createElement("div");f.classList.add("axqbiy");let m=document.createElement("p");m.classList.add("_10lak7c"),m.textContent=this.getLocalizedTextContent(t,"closeText"),Q&&(m.style.color=Q),m.addEventListener("click",a),f.appendChild(m),x.appendChild(f)}}let Ct=a=>{let r=document.querySelectorAll("._19i18vc > li"),f=document.getElementsByClassName("_130j852");for(let m=0;m<f.length;m++)r[m].classList.remove("_1lowx25"),f[m].classList.remove("_1lowx25");r[a].classList.add("_1lowx25"),f[a].classList.add("_1lowx25")},k=document.createElement("section");k.classList.add("g3f52f","_15yer7c");let M=document.createElement("h4");M.classList.add("_1e70kqd"),M.textContent=this.getLocalizedTextContent(t,"instructionsTitle");let R=document.createElement("div");R.classList.add("i5jiss");let P=document.createElement("ul");P.classList.add("_19i18vc");let z=document.createElement("div");z.classList.add("_1kebabo"),_t.forEach((a,r)=>{let f=document.createElement("li");f.onclick=()=>Ct(r),f.textContent=this.getLocalizedTextContent(a,"name",!0),P.appendChild(f);let m=document.createElement("ol");m.classList.add("_130j852"),r===0&&(f.classList.add("_1lowx25"),m.classList.add("_1lowx25")),this.getLocalizedTextContent(a,"steps").forEach(Lt=>{let ot=document.createElement("li");ot.textContent=Lt,m.appendChild(ot)}),z.appendChild(m)});let wt=this.getLocalizedTextContent(t,"disclaimerText"),nt=document.createElement("p");nt.textContent=wt,z.appendChild(nt),R.appendChild(P),R.appendChild(z);let C=document.createElement("button");if(C.classList.add("_10jcka8","hrbmcw"),C.textContent=this.getLocalizedTextContent(t,"backButtonText"),L&&(C.style.backgroundColor=L),w&&(C.style.color=w),C.onclick=function(){document.querySelector("section.g3f52f").classList.add("_15yer7c"),document.querySelector("section.zgt4cb").classList.remove("_15yer7c")},k.appendChild(M),k.appendChild(R),k.appendChild(C),p.appendChild(b),p.appendChild(x),p.appendChild(k),yt){let a=document.createElement("a");a.classList.add("_1ahf6lp"),a.href=atob(mt),a.target="_blank";let r=document.createElement("img");r.alt="Logo",r.src=this.pickContrastingColorValue(I||"#FFFFFF",ht,bt),a.appendChild(r),p.appendChild(a)}return g.appendChild(p),g}getAndSetOverlay(t){return h(this,null,function*(){if(this.post(!0,t),!t.dismissDuration&&!t.dismissDurationPv&&sessionStorage.getItem(`fs.adb${t.siteId||""}.dis`)==="1")return;let i=localStorage.getItem("fs.adb"),e=i&&JSON.parse(i);if(t.dismissDurationPv&&e.p&&typeof e.p=="number")if(t.dismissDurationPv<=e.p+1)this.clearValue("p");else{this.updateValues("p");return}else this.clearValue("p");let n=parseInt(e.dt,10);if(t.dismissDuration&&n){if(Math.abs((Date.now()-n)/36e5)<t.dismissDuration)return;this.clearValue("dt")}else this.clearValue("dt");if(document.body||(yield new Promise(d=>document.addEventListener("DOMContentLoaded",d))),this.killScroll(t),document.querySelector(`#${this.oid}`)!==null)return;let s=this.generateOverlay(t);document.body.appendChild(s)})}getStatus(t,i){return i===!0?1:t===2||t===1?2:0}getAndSetData(t){let i=localStorage.getItem("fs.adb"),e=i&&JSON.parse(i),n=Date.now(),s,d,l;return e?(s=e.i,d=e.ot,l=this.getStatus(e.s,t)):(e={},s=B(),d=n,l=t?1:0),e.i=s,e.s=l,e.ot=d,e.lt=n,localStorage.setItem("fs.adb",JSON.stringify(e)),e}updateValues(t){let i=localStorage.getItem("fs.adb"),e=i&&JSON.parse(i);t==="p"?(e.p=e.p?e.p+1:1,e.dt&&delete e.dt):t==="dt"&&(e.dt=Date.now(),e.p&&delete e.p),localStorage.setItem("fs.adb",JSON.stringify(e))}clearValue(t){let i=localStorage.getItem("fs.adb"),e=i&&JSON.parse(i);e[t]&&(delete e[t],localStorage.setItem("fs.adb",JSON.stringify(e)))}post(t,i){let e=atob(ct),s=`https://${i.cDomain||e}/v2/abr`,d=this.getAndSetData(t),{accountId:l,siteId:u}=i,v=navigator.userAgent||window.navigator.userAgent,E=document.referrer,U=window.location,O=S=>{switch(S){case 0:return"not detected";case 1:return"detected";case 2:return"recovered";default:return}},T={accountId:l,siteId:u,userId:d.i,url:U.href,referalURL:E,userAgent:v,status:O(d.s),returning:d.ot!==d.lt,version:"1.4.2"};fetch(s,{method:"POST",headers:{"Content-Type":"application/json","X-Client-Geo-Location":"{client_region},{client_region_subdivision},{client_city}"},body:JSON.stringify(T)}).catch(()=>{})}observe(){let t="",i=new MutationObserver(()=>{location.pathname!==t&&(t=location.pathname,this.run())}),e={subtree:!0,childList:!0};i.observe(document,e)}run(){let t=this.config;setTimeout(()=>h(this,null,function*(){try{yield gt(),yield pt(),yield H(atob(at),!0),yield H(atob(rt),!1),this.post(!1,t)}catch(i){(i===y||(i==null?void 0:i.message)===y)&&(yield this.getAndSetOverlay(t))}}),500)}};var Rt=["googlebot","mediapartners-google","adsbot-google","bingbot","slurp","duckduckbot","baiduspider","yandexbot","konqueror/3.5","Exabot/3.0","facebot","facebookexternalhit/1.0","facebookexternalhit/1.1","ia_archiver"],N=class{constructor(t){this.globalNavigator=t}checkForBot(){let t=this.globalNavigator.userAgent;t&&Rt.forEach(i=>{if(RegExp(i.toLowerCase()).test(t.toLowerCase()))throw new Error("bot detected")})}};var zt=new N(window.navigator);zt.checkForBot();var Dt=new F(window.navigator);Dt.init();})();
+</script>
+
+<script src="https://a.pub.network/untappd-com/pubfig.min.js" data-cfasync="false" async></script>
+<script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js?network-code=15184186" ></script>
+<!-- End Freestar Ads -->
+    <!-- Freestar Ad Sticky Styling: https://resources.freestar.com/docs/sticky-ads-1 -->
+    <style>
+    div.sticky {
+        position: -webkit-sticky; /* Safari */
+        position: sticky;
+        top: 84px; /* Navbar height */
+    }
+    </style>
+
+</head>
+<style type="text/css">
+	.hidden {display: none;}
+	.main {
+       margin-top: 0px !important;
+   }
+</style>
+<script src="https://untappd.com/assets/libs/js/feather-icons@4.29.2.min.js"></script>
+<body onunload="">
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-N4DVXTR" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+
+
+<script type="text/javascript">
+    $(document).ready(function() {
+        $('a[data-href=":logout"]').on('click', function(event) {
+            clevertap.event.push("logout");
+        });
+        $('a[data-href=":external/help"]').on('click', function(event) {
+            clevertap.event.push("pageview_help");
+        });
+        $('a[data-href=":store"]').on('click', function(event) {
+            clevertap.event.push("pageview_store");
+        });
+        $('a[href="/admin"]').on('click', function(event) {
+          clevertap.event.push("pageview_admin");
+        });
+
+            });
+</script>
+<div id="mobile_nav_user">
+
+   </div>
+
+<div id="mobile_nav_site">
+  <form class="search_box" method="get" action="/search">
+    <input type="text" class="track-focus search-input-desktop" autocomplete="off" data-track="desktop_search" placeholder="Find a drink, brewery or bar..." name="q" aria-label="Find a drink, brewery or bar search" />
+    <input type="submit" value="Submit the form!" style="position: absolute; top: 0; left: 0; z-index: 0; width: 1px; height: 1px; visibility: hidden;" />
+    <div class="autocomplete">
+    </div>
+  </form>
+  <ul>
+    <li><a class="track-click" data-track="mobile_menu" data-href=":blog" href="/blog">Blog</a></li>
+    <li><a class="track-click" data-track="mobile_menu" data-href=":beer/top_rated" href="/beer/top_rated">Top Rated</a></li>
+    <li><a class="track-click" data-track="mobile_menu" data-href=":supporter" href="/supporter">Insiders</a></li>
+    <li><a class="track-click" data-track="mobile_menu" data-href=":external/help" target="_blank" href="http://help.untappd.com">Help</a></li>
+    <li><a class="track-click" data-track="mobile_menu" data-href=":shop" target="_blank" href="https://untappd.com/shop">Shop</a></li>
+          <li><a class="track-click" data-track="mobile_menu" data-href=":sidebar/login" href="/login">Login</a></li>
+      <li><a class="track-click" data-track="mobile_menu" data-href=":sidebar/create" href="/create?source=mobilemenu">Sign Up</a></li>
+        </ul>
+</div>
+<header>
+
+  <div class="inner mt-2">
+
+		<a class="track-click logo" style="margin-top: 2px;" data-track="desktop_header" data-href=":root" href="/">
+			<img src="https://untappd.com/assets/design-system/ut-brand-dark.svg" class="" alt="Untappd"/>
+		</a>
+
+    
+      <div class="get_user_desktop">
+        <a class="sign_in track-click" data-track="mobile_header" data-href=":login" href="/login?go_to=https://untappd.com/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513">Sign In</a>
+        <a href="/create" class="join track_click" data-track="mobile_header" data-href=":create">Join Now</a>
+      </div>
+
+    
+    <div class="mobile_menu_btn">Menu</div>
+
+    <div id="nav_site">
+      <ul>
+        <li><a class="track-click" data-track="desktop_menu" data-href=":blog" href="/blog">Blog</a></li>
+        <li><a class="track-click" data-track="desktop_menu" data-href=":beer/top_rated" href="/beer/top_rated">Top Rated</a></li>
+        <li><a class="track-click" data-track="desktop_menu" data-href=":supporter" href="/supporter">Insiders</a></li>
+        <li><a class="track-click" data-track="desktop_menu" data-href=":external/help" target="_blank" href="http://help.untappd.com">Help</a></li>
+        <li><a class="track-click" data-track="desktop_menu" data-href=":shop" target="_blank" href="https://untappd.com/shop">Shop</a></li>
+      </ul>
+      <form class="search_box" method="get" action="/search">
+        <input type="text" class="track-focus search-input-desktop" autocomplete="off" data-track="desktop_search" placeholder="Find a drink, brewery or bar..." name="q" aria-label="Find a drink, brewery or bar search" />
+        <input type="submit" value="Submit the form!" style="position: absolute; top: 0; left: 0; z-index: 0; width: 1px; height: 1px; visibility: hidden;" />
+        <div class="autocomplete">
+        </div>
+      </form>
+    </div>
+    </div>
+</header>
+<style type="text/css">
+    .ac-selected {
+        background-color: #f8f8f8;
+    }
+</style>
+
+<div class="nav_open_overlay"></div>
+<div id="slide">
+
+<script>
+$(document).ready(() => {
+	$(".hide-notice-banner").on("click", function(e) {
+		e.preventDefault();
+		$(this).parent().parent().slideUp();
+		$.post(`/account/hide_notice_wildcard`, {cookie: $(this).attr('data-cookie-name')}, (data) => {
+			console.log(data);
+		}).fail((err) => {
+			console.error(err);
+		})
+	})
+
+	$(".hide-notice-simple").on("click", function(e) {
+		e.preventDefault();
+		$(this).parent().parent().slideUp();
+	})
+
+	feather.replace()
+})
+</script>
+	<div class="leaderboard-ad">
+		<div style="text-align: center;" data-freestar-ad="__336x280 __728x90" id="untappd-com_leaderboard-atf">
+			<script data-cfasync="false" type="text/javascript">
+				freestar.config.enabled_slots.push({ placementName: "untappd-com_leaderboard-atf", slotId: "untappd-com_leaderboard-atf" });
+			</script>
+		</div>
+	</div>
+	<div class="cont beer-page" data-logged-supporter="0" data-logged-rating-bump="0">
+
+<link rel="stylesheet"
+    href="https://untappd.com/assets/css/tailwind.css?v=2.8.36">
+</link>
+
+<style>
+
+.mobile-only {
+        display: none;
+    }
+
+    @media (max-width: 768px) {
+        .mobile-only {
+            display: block;
+        }
+    }
+</style>
+    <div class="main">
+      
+<div class="box b_info">
+
+    
+    <div class="content">
+        <div class="top">
+            <div class="basic">
+                <a class="label image-big" data-image="https://assets.untappd.com/site/beer_logos_hd/beer-6645513_bce50_hd.jpeg">                
+                    <img src="https://assets.untappd.com/site/beer_logos/beer-6645513_22c0d_sm.jpeg" alt="Fifty Fifty - Clementine & Passionfruit label">                </a>
+                <div class="name">
+                    <h1>Fifty Fifty - Clementine & Passionfruit</h1>                    <p class="brewery">
+                                                    <a href="/MagicRoad">Magic Road</a>
+                            
+                    </p>
+                                        <p class="style">Sour - Smoothie / Pastry</p>
+                </div>
+                <div class="actions mobile">
+                                            <a class="check open-checkin-btn" href="/login?go_to=https://untappd.com/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513">Check-in</a>
+                        <a class="add" href="/login?go_to=https://untappd.com/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513">Add</a>
+                        
+                </div>
+            </div>
+            
+            <div class="stats">
+                <p>
+                    <span class="stat">Total (<a class="tip" title="Total Check-ins All Time" href="javascript:void(0)">?</a>)</span>
+                    <span class="count">132</span>
+                </p><p>
+                    <span class="stat">Unique (<a class="tip" title="Number of Users All Time" href="javascript:void(0)">?</a>)</span>
+                    <span class="count">127</span>
+                </p><p>
+                    <span class="stat">Monthly (<a class="tip" title="Number for Checkins the last 4 weeks" href="javascript:void(0)">?</a>)</span>
+                    <span class="count">24</span>
+                </p><p>
+                    <span class="stat">You</span>
+                    <span class="count"><a href="/login?go_to=https%3A%2F%2Funtappd.com%2F%2Fb%2Fmagic-road-fifty-fifty-clementine-and-passionfruit%2F6645513%3Ffilter%3Dyou" class="track-click" data-track="beer" data-href=":feed/filteryou/header">0</a></span>
+                </p>
+            </div>
+        </div>
+
+        <div class="details">
+            <p class="abv">
+                4.6% ABV            </p><p class="ibu">
+                N/A IBU            </p>
+                <div class="caps" data-rating="3.98471">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap"></div>
+	</div><span class="num">(3.98)</span>            <p class="raters">
+                121 Ratings            </p>
+        </div>
+
+        
+        <div class="bottom">
+                            <div class="actions desktop">
+                                            <a class="add tip" title="Add to Wishlist" href="/login?go_to=https://untappd.com/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513">Add</a>
+                        <a class="check open-checkin-btn tip" title="Check-in" href="/login?go_to=https://untappd.com/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513">Check-in</a>
+                                        </div>
+                
+            <div class="desc">
+                <div class="beer-descrption-read-more">
+                                    </div>
+                <div class="beer-descrption-read-less" style="display: none;">
+                     <a href="#" class="read-less track-click" data-track="beer" data-href=":info/readless">Show Less</a>
+                </div>
+            </div>
+            <div class="clearfix"></div>
+        </div>
+    </div>
+</div>
+
+     <div class="mobile-only">
+        
+     </div>
+
+             <div class="photo-boxes">
+            <p><a href="/user/serhane/checkin/1573436878"><img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_05_27/1a1c79808577705da1d4878df28528fb_c_1573436878_raw.jpg" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_05_27/1a1c79808577705da1d4878df28528fb_c_1573436878_raw.jpg" alt="Recent check-in photo 1"></a></p><p><a href="/user/juliearch/checkin/1573313103"><img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_05_26/31119bf4562a85859b176fd63377777c_c_1573313103_raw.jpg" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_05_26/31119bf4562a85859b176fd63377777c_c_1573313103_raw.jpg" alt="Recent check-in photo 2"></a></p><p><a href="/user/GidoR/checkin/1573137342"><img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_05_25/4076b0781163d7ba8320a5dda1b01fa5_c_1573137342_raw.jpg" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_05_25/4076b0781163d7ba8320a5dda1b01fa5_c_1573137342_raw.jpg" alt="Recent check-in photo 3"></a></p><p><a href="/user/Schippie96/checkin/1572921296"><img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_05_24/4de87027585a4e18cec3333c32b79a43_c_1572921296_raw.jpg" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_05_24/4de87027585a4e18cec3333c32b79a43_c_1572921296_raw.jpg" alt="Recent check-in photo 4"></a></p><p><a href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513/photos" class="track-click" data-track="beer" data-href=":photos/seemore"><span class="all">See All</span><img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_05_24/839325bd7094272d429d6e53d65422b1_c_1572920951_raw.jpg" alt="See all photos"></a></p>        </div>
+        
+    <div class="box activity">
+        <div class="content">
+            <div class="filters">
+                <span>Filter by:</span>
+                                    <span class="current">
+                    Global
+                    </span><span>
+                        <a href="/login?go_to=https%3A%2F%2Funtappd.com%2F%2Fb%2Fmagic-road-fifty-fifty-clementine-and-passionfruit%2F6645513%3Ffilter%3Dfriends" class="track-click" data-track="beer" data-href=":feed/filterfriends">Friends</a>
+                    </span><span>
+                        <a href="/login?go_to=https%3A%2F%2Funtappd.com%2F%2Fb%2Fmagic-road-fifty-fifty-clementine-and-passionfruit%2F6645513%3Ffilter%3Dyou" class="track-click" data-track="beer" data-href=":feed/filteryou">You</a>
+                    </span>
+                                </div>
+            <h3>Global Recent Activity</h3>
+
+                            <div id="main-stream">
+                
+			<div class="item " id="checkin_1573436878" data-checkin-id="1573436878">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/serhane">
+							<img loading="lazy" src="https://assets.untappd.com/profile/0e42e542aff46efe4476377d78f500fa_100x100.jpg" alt="Beer Floyd">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6645513_22c0d_sm.jpeg" alt="Fifty Fifty - Clementine & Passionfruit by Magic Road">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-2903749-type-checkin_feed">
+								<a href="/user/serhane" class="user">Beer Floyd</a>  is drinking a <a href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513">Fifty Fifty - Clementine & Passionfruit</a> by <a  href="/MagicRoad">Magic Road</a> at <a href="/v/jabeerwocky/2903749">Jabeerwocky</a>
+							</p>
+														<div class="checkin-comment">
+								
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/draft@3x.png" alt="Draft">
+										          <span>Draft</span>
+										        </p>
+												<div class="caps " data-rating="4.1">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-10"></div>
+	</div>								    </div>
+																			<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/badges/bdg_DessertTime_v2_Core_sm.jpg" alt="Dessert Time! (Level 23)">
+											<span>Earned the Dessert Time! (Level 23) badge!</span>
+										</span>
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/serhane/checkin/1573436878" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_05_27/1a1c79808577705da1d4878df28528fb_c_1573436878_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+							
+						</div>
+
+						<div class="bottom">
+							<a href="/user/serhane/checkin/1573436878" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Wed, 27 May 2026 18:05:22 +0000</a>
+							<a href="/user/serhane/checkin/1573436878" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+													</div>
+
+						<div class="cheers" style="display: none;">								<span class="count"><span>0</span></span>
+								<span class="toast-list"></span>
+														</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+							
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1573313103" data-checkin-id="1573313103">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+												<a href="/user/juliearch">
+							<img loading="lazy" src="https://assets.untappd.com/profile/5b4826bb826133e322d922aed84d8387_100x100.jpg" alt="Julie">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6645513_22c0d_sm.jpeg" alt="Fifty Fifty - Clementine & Passionfruit by Magic Road">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-9917985-type-checkin_feed">
+								<a href="/user/juliearch" class="user">Julie</a>  is drinking a <a href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513">Fifty Fifty - Clementine & Passionfruit</a> by <a  href="/MagicRoad">Magic Road</a> at <a href="/v/at-home/9917985">Untappd at Home</a>
+							</p>
+														<div class="checkin-comment">
+								
+								<p class="purchased" data-track-venue-impression="venue_id-11142155-type-checkin_feed">Purchased at <a href="/v/warsaw-beer-festival-warszawski-festiwal-piwa/11142155">Warszawski Festiwal Piwa</a></p>									<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/can@3x.png" alt="Can">
+										          <span>Can</span>
+										        </p>
+												<div class="caps " data-rating="4.25">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-25"></div>
+	</div>								    </div>
+																			<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/badges/c3b54a07633c542b460f45849f99bef4_sm.jpeg" alt="WFP: Hit the Beat! (Level 5)">
+											<span>Earned the WFP: Hit the Beat! (Level 5) badge!</span>
+										</span>
+																				<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/badges/bdg_FruitsOfYourLabor_sm.jpg" alt="Fruits of Your Labor (Level 12)">
+											<span>Earned the Fruits of Your Labor (Level 12) badge!</span>
+										</span>
+																				<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/badges/bdg_PolePosition_sm.jpg" alt="Pole Position (Level 25)">
+											<span>Earned the Pole Position (Level 25) badge!</span>
+										</span>
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/juliearch/checkin/1573313103" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_05_26/31119bf4562a85859b176fd63377777c_c_1573313103_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+							
+						</div>
+
+						<div class="bottom">
+							<a href="/user/juliearch/checkin/1573313103" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Tue, 26 May 2026 19:36:15 +0000</a>
+							<a href="/user/juliearch/checkin/1573313103" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+													</div>
+
+						<div class="cheers" style="display: none;">								<span class="count"><span>0</span></span>
+								<span class="toast-list"></span>
+														</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+							
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1573137342" data-checkin-id="1573137342">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+												<a href="/user/GidoR">
+							<img loading="lazy" src="https://assets.untappd.com/profile/316f0a649f2b1176279d5cb8cef718bd_100x100.jpg" alt="Gido Riphagen">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6645513_22c0d_sm.jpeg" alt="Fifty Fifty - Clementine & Passionfruit by Magic Road">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-9917985-type-checkin_feed">
+								<a href="/user/GidoR" class="user">Gido Riphagen</a>  is drinking a <a href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513">Fifty Fifty - Clementine & Passionfruit</a> by <a  href="/MagicRoad">Magic Road</a> at <a href="/v/at-home/9917985">Untappd at Home</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1573137342">
+									Mandarijntjes, klein bittertje, mooi zuurtje, fris doordrinkbaar, ietsjes aan de dunne kant									</p>
+
+																					<div class="translate"><a href="/login?go_to=https://untappd.com/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513" data-checkin-id="1573137342">Translate</a></div>
+												
+								<p class="purchased" data-track-venue-impression="venue_id-2221398-type-checkin_feed">Purchased at <a href="/v/mitra-driessen-apeldoorn/2221398">Mitra Driessen Apeldoorn</a></p>									<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/can@3x.png" alt="Can">
+										          <span>Can</span>
+										        </p>
+												<div class="caps " data-rating="3.75">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-75"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+									
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/GidoR/checkin/1573137342" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_05_25/4076b0781163d7ba8320a5dda1b01fa5_c_1573137342_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+							
+						</div>
+
+						<div class="bottom">
+							<a href="/user/GidoR/checkin/1573137342" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Mon, 25 May 2026 18:51:43 +0000</a>
+							<a href="/user/GidoR/checkin/1573137342" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+													</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>6</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="dmeuleman" href="/user/dmeuleman" title="Dennis Meuleman" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/fa1757288ffa557642a2180f856a2f99_100x100.jpg" alt="Dennis Meuleman avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="Dj_arno88" href="/user/Dj_arno88" title="Djarno Albers" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/e392d2ec0997ad10edb0ea4275c8b65f_100x100.jpg" alt="Djarno Albers avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="Makkakker_1498" href="/user/Makkakker_1498" title="Mark van Otten" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/f642b62e2ef04f0a56c97008bc37b9db_100x100.jpg" alt="Mark van Otten avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="nlvalinl" href="/user/nlvalinl" title="Michaël de Wit" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/e9246176dc67417252a0f8b40b4fed46_100x100.jpg" alt="Michaël de Wit avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="Fieldchicken" href="/user/Fieldchicken" title="Martin Velthoen" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/fdfe28c9f1d1051d21523bd2dad1e457_100x100.jpg" alt="Martin Velthoen avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="bladluis" href="/user/bladluis" title="Thijs Mensink" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/a8d5d230f87e268efeadb04371fac6fb_100x100.jpg" alt="Thijs Mensink avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+							
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1572921296" data-checkin-id="1572921296">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+												<a href="/user/Schippie96">
+							<img loading="lazy" src="https://assets.untappd.com/profile/c14642f83a53af11824a354754e712d4_100x100.jpg" alt="Marc Schipaanboord">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6645513_22c0d_sm.jpeg" alt="Fifty Fifty - Clementine & Passionfruit by Magic Road">
+							</a>
+														<p class="text">
+								<a href="/user/Schippie96" class="user">Marc Schipaanboord</a>  is drinking a <a  href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513">Fifty Fifty - Clementine & Passionfruit</a> by <a href="/MagicRoad">Magic Road</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1572921296">
+									Sappie voor het slapen gaan.									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/can@3x.png" alt="Can">
+										          <span>Can</span>
+										        </p>
+												<div class="caps " data-rating="3">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+																			<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/badges/bdg_brewery_prioneer_sm.jpg" alt="Brewery Pioneer (Level 78)">
+											<span>Earned the Brewery Pioneer (Level 78) badge!</span>
+										</span>
+										
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/vvanwesterop">
+																	<img src="https://assets.untappd.com/profile/78fbbb6dd69cb275abe11d095778fe60_100x100.jpg" alt="Vincent van Westerop avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Mitchell321123">
+																	<img src="https://assets.untappd.com/profile/89a71e12ebfb46acb73cc24aae0daf82_100x100.jpg" alt="Mitchell De Boer avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Senzh94">
+																	<img src="https://assets.untappd.com/profile/5ca6aac23445faf7f233957fab869031_100x100.jpg" alt="Sander Schipaanboord avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/Schippie96/checkin/1572921296" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_05_24/4de87027585a4e18cec3333c32b79a43_c_1572921296_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+							
+						</div>
+
+						<div class="bottom">
+							<a href="/user/Schippie96/checkin/1572921296" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Sun, 24 May 2026 21:17:31 +0000</a>
+							<a href="/user/Schippie96/checkin/1572921296" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+													</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>2</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="lautje_b" href="/user/lautje_b" title="Laurens Boudewijn" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/0b532a5ceeca9793de3a20b2a558e308_100x100.jpg" alt="Laurens Boudewijn avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="Viktor1983" href="/user/Viktor1983" title="Viktor Langerak" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://gravatar.com/avatar/4d2a0493591ec56c75f23ec707a2bc14?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Viktor Langerak avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+							
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1572920951" data-checkin-id="1572920951">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+												<a href="/user/vvanwesterop">
+							<img loading="lazy" src="https://assets.untappd.com/profile/78fbbb6dd69cb275abe11d095778fe60_100x100.jpg" alt="Vincent van Westerop">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6645513_22c0d_sm.jpeg" alt="Fifty Fifty - Clementine & Passionfruit by Magic Road">
+							</a>
+														<p class="text">
+								<a href="/user/vvanwesterop" class="user">Vincent van Westerop</a>  is drinking a <a  href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513">Fifty Fifty - Clementine & Passionfruit</a> by <a href="/MagicRoad">Magic Road</a>
+							</p>
+														<div class="checkin-comment">
+								
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/can@3x.png" alt="Can">
+										          <span>Can</span>
+										        </p>
+												<div class="caps " data-rating="3.5">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-50"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+									
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Schippie96">
+																	<img src="https://assets.untappd.com/profile/c14642f83a53af11824a354754e712d4_100x100.jpg" alt="Marc Schipaanboord avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Senzh94">
+																	<img src="https://assets.untappd.com/profile/5ca6aac23445faf7f233957fab869031_100x100.jpg" alt="Sander Schipaanboord avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Mitchell321123">
+																	<img src="https://assets.untappd.com/profile/89a71e12ebfb46acb73cc24aae0daf82_100x100.jpg" alt="Mitchell De Boer avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/vvanwesterop/checkin/1572920951" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_05_24/839325bd7094272d429d6e53d65422b1_c_1572920951_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+							
+						</div>
+
+						<div class="bottom">
+							<a href="/user/vvanwesterop/checkin/1572920951" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Sun, 24 May 2026 21:16:40 +0000</a>
+							<a href="/user/vvanwesterop/checkin/1572920951" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+													</div>
+
+						<div class="cheers" style="display: none;">								<span class="count"><span>0</span></span>
+								<span class="toast-list"></span>
+														</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+							
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1572725169" data-checkin-id="1572725169">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+												<a href="/user/Kreijne">
+							<img loading="lazy" src="https://assets.untappd.com/profile/c04d69c99cb9b7bf35bb6472aeda6b6f_100x100.jpg" alt="Mark Kreijne">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6645513_22c0d_sm.jpeg" alt="Fifty Fifty - Clementine & Passionfruit by Magic Road">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-9917985-type-checkin_feed">
+								<a href="/user/Kreijne" class="user">Mark Kreijne</a>  is drinking a <a href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513">Fifty Fifty - Clementine & Passionfruit</a> by <a  href="/MagicRoad">Magic Road</a> at <a href="/v/at-home/9917985">Untappd at Home</a>
+							</p>
+														<div class="checkin-comment">
+								
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/can@3x.png" alt="Can">
+										          <span>Can</span>
+										        </p>
+												<div class="caps " data-rating="4">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+																			<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/badges/bdg_SourBrew_sm.jpg" alt="Pucker Up (Level 8)">
+											<span>Earned the Pucker Up (Level 8) badge!</span>
+										</span>
+																				<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/badges/bdg_FruitsOfYourLabor_sm.jpg" alt="Fruits of Your Labor (Level 7)">
+											<span>Earned the Fruits of Your Labor (Level 7) badge!</span>
+										</span>
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+							
+						</div>
+
+						<div class="bottom">
+							<a href="/user/Kreijne/checkin/1572725169" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Sun, 24 May 2026 14:30:26 +0000</a>
+							<a href="/user/Kreijne/checkin/1572725169" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+													</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>1</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="HansvanLankveld" href="/user/HansvanLankveld" title="Hans Van Lankveld" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/7bbce9ba54ec155b6fc2715ff6b643bb_100x100.jpg" alt="Hans Van Lankveld avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+							
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1572708937" data-checkin-id="1572708937">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+												<a href="/user/damian005_">
+							<img loading="lazy" src="https://assets.untappd.com/profile/fdba37c15307ce221a0fc4c32c2ea3cc_100x100.jpg" alt="Damian">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6645513_22c0d_sm.jpeg" alt="Fifty Fifty - Clementine & Passionfruit by Magic Road">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-9917985-type-checkin_feed">
+								<a href="/user/damian005_" class="user">Damian</a>  is drinking a <a href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513">Fifty Fifty - Clementine & Passionfruit</a> by <a  href="/MagicRoad">Magic Road</a> at <a href="/v/at-home/9917985">Untappd at Home</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1572708937">
+									Lekker man deze!									</p>
+
+									
+								<p class="purchased" data-track-venue-impression="venue_id-10748051-type-checkin_feed">Purchased at <a href="/v/house-of-beers/10748051">House of Beers</a></p>									<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/can@3x.png" alt="Can">
+										          <span>Can</span>
+										        </p>
+												<div class="caps " data-rating="4.25">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-25"></div>
+	</div>								    </div>
+																			<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/badges/bdg_brewery_prioneer_sm.jpg" alt="Brewery Pioneer (Level 24)">
+											<span>Earned the Brewery Pioneer (Level 24) badge!</span>
+										</span>
+																				<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/badges/bdg_SourBrew_sm.jpg" alt="Pucker Up (Level 4)">
+											<span>Earned the Pucker Up (Level 4) badge!</span>
+										</span>
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/damian005_/checkin/1572708937" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_05_24/14e9d96a4cc5778ad90b4005690de523_c_1572708937_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+							
+						</div>
+
+						<div class="bottom">
+							<a href="/user/damian005_/checkin/1572708937" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Sun, 24 May 2026 13:39:01 +0000</a>
+							<a href="/user/damian005_/checkin/1572708937" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+													</div>
+
+						<div class="cheers" style="display: none;">								<span class="count"><span>0</span></span>
+								<span class="toast-list"></span>
+														</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+							
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1572377005" data-checkin-id="1572377005">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+												<a href="/user/JelleHopman">
+							<img loading="lazy" src="https://gravatar.com/avatar/8dc085943df2980a53b6e7c927bd3f22?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Jelle Hopman">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6645513_22c0d_sm.jpeg" alt="Fifty Fifty - Clementine & Passionfruit by Magic Road">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-9917985-type-checkin_feed">
+								<a href="/user/JelleHopman" class="user">Jelle Hopman</a>  is drinking a <a href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513">Fifty Fifty - Clementine & Passionfruit</a> by <a  href="/MagicRoad">Magic Road</a> at <a href="/v/at-home/9917985">Untappd at Home</a>
+							</p>
+														<div class="checkin-comment">
+								
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/can@3x.png" alt="Can">
+										          <span>Can</span>
+										        </p>
+												<div class="caps " data-rating="4.5">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-50"></div>
+	</div>								    </div>
+									
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/berylhopman">
+																	<img src="https://gravatar.com/avatar/6c1ce1f20be3eb293533a92e752727d6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Beryl Hopman avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Dreamkarp">
+																	<img src="https://gravatar.com/avatar/66b225cdb4736fcca01d8da2d25517aa?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Wouter Van Geert avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+							
+						</div>
+
+						<div class="bottom">
+							<a href="/user/JelleHopman/checkin/1572377005" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Sat, 23 May 2026 17:55:25 +0000</a>
+							<a href="/user/JelleHopman/checkin/1572377005" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+													</div>
+
+						<div class="cheers" style="display: none;">								<span class="count"><span>0</span></span>
+								<span class="toast-list"></span>
+														</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+							
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1572374605" data-checkin-id="1572374605">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+												<a href="/user/Dreamkarp">
+							<img loading="lazy" src="https://gravatar.com/avatar/66b225cdb4736fcca01d8da2d25517aa?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Wouter Van Geert">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6645513_22c0d_sm.jpeg" alt="Fifty Fifty - Clementine & Passionfruit by Magic Road">
+							</a>
+														<p class="text">
+								<a href="/user/Dreamkarp" class="user">Wouter Van Geert</a>  is drinking a <a  href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513">Fifty Fifty - Clementine & Passionfruit</a> by <a href="/MagicRoad">Magic Road</a>
+							</p>
+														<div class="checkin-comment">
+								
+																	<div class="rating-serving">
+										<div class="caps " data-rating="4">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+																			<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/badges/bdg_RidingSteady_sm.jpg" alt="Riding Steady (Level 69)">
+											<span>Earned the Riding Steady (Level 69) badge!</span>
+										</span>
+										
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/JelleHopman">
+																	<img src="https://gravatar.com/avatar/8dc085943df2980a53b6e7c927bd3f22?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Jelle Hopman avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+							
+						</div>
+
+						<div class="bottom">
+							<a href="/user/Dreamkarp/checkin/1572374605" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Sat, 23 May 2026 17:52:04 +0000</a>
+							<a href="/user/Dreamkarp/checkin/1572374605" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+													</div>
+
+						<div class="cheers" style="display: none;">								<span class="count"><span>0</span></span>
+								<span class="toast-list"></span>
+														</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+							
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1571220087" data-checkin-id="1571220087">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+												<a href="/user/Jonrasm">
+							<img loading="lazy" src="https://assets.untappd.com/profile/0d2b7b6475f35a9db0cd462503147b3e_100x100.jpg" alt="Jonas Rasmusson">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6645513_22c0d_sm.jpeg" alt="Fifty Fifty - Clementine & Passionfruit by Magic Road">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-1439400-type-checkin_feed">
+								<a href="/user/Jonrasm" class="user">Jonas Rasmusson</a>  is drinking a <a href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513">Fifty Fifty - Clementine & Passionfruit</a> by <a  href="/MagicRoad">Magic Road</a> at <a href="/v/kirseberg/1439400">Kirseberg</a>
+							</p>
+														<div class="checkin-comment">
+								
+								<p class="purchased" data-track-venue-impression="venue_id-10044353-type-checkin_feed">Purchased at <a href="/v/piwnemosty-pl-craft-beer-marketplace/10044353">PiwneMosty.pl - Craft Beer Marketplace</a></p>									<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/can@3x.png" alt="Can">
+										          <span>Can</span>
+										        </p>
+												<div class="caps " data-rating="4">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+									
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/Jonrasm/checkin/1571220087" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_05_19/1d807e5d6fb7f31580bd33079f29f5a3_c_1571220087_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+							
+						</div>
+
+						<div class="bottom">
+							<a href="/user/Jonrasm/checkin/1571220087" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Tue, 19 May 2026 19:22:00 +0000</a>
+							<a href="/user/Jonrasm/checkin/1571220087" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+													</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>1</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="larsofagony" href="/user/larsofagony" title="Lars lundin" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/b6e894e7b0fd014465ffd68be5f71ab6_100x100.jpg" alt="Lars lundin avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+							
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1571089550" data-checkin-id="1571089550">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+												<a href="/user/Lollkoll">
+							<img loading="lazy" src="https://gravatar.com/avatar/ff40458fd29c430924dc90e5821d648c?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Kristi Koll">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6645513_22c0d_sm.jpeg" alt="Fifty Fifty - Clementine & Passionfruit by Magic Road">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-9917985-type-checkin_feed">
+								<a href="/user/Lollkoll" class="user">Kristi Koll</a>  is drinking a <a href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513">Fifty Fifty - Clementine & Passionfruit</a> by <a  href="/MagicRoad">Magic Road</a> at <a href="/v/at-home/9917985">Untappd at Home</a>
+							</p>
+														<div class="checkin-comment">
+								
+								<p class="purchased" data-track-venue-impression="venue_id-669673-type-checkin_feed">Purchased at <a href="/v/koht/669673">Koht</a></p>									<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/can@3x.png" alt="Can">
+										          <span>Can</span>
+										        </p>
+												<div class="caps " data-rating="4">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+									
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/kjeasr">
+																	<img src="https://assets.untappd.com/profile/47449299fbb08fe02dd8a20654f2e804_100x100.jpg" alt="Sten  avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+							
+						</div>
+
+						<div class="bottom">
+							<a href="/user/Lollkoll/checkin/1571089550" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Mon, 18 May 2026 19:22:32 +0000</a>
+							<a href="/user/Lollkoll/checkin/1571089550" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+													</div>
+
+						<div class="cheers" style="display: none;">								<span class="count"><span>0</span></span>
+								<span class="toast-list"></span>
+														</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+							
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1571088931" data-checkin-id="1571088931">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+												<a href="/user/kjeasr">
+							<img loading="lazy" src="https://assets.untappd.com/profile/47449299fbb08fe02dd8a20654f2e804_100x100.jpg" alt="Sten">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6645513_22c0d_sm.jpeg" alt="Fifty Fifty - Clementine & Passionfruit by Magic Road">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-9917985-type-checkin_feed">
+								<a href="/user/kjeasr" class="user">Sten</a>  is drinking a <a href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513">Fifty Fifty - Clementine & Passionfruit</a> by <a  href="/MagicRoad">Magic Road</a> at <a href="/v/at-home/9917985">Untappd at Home</a>
+							</p>
+														<div class="checkin-comment">
+								
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/can@3x.png" alt="Can">
+										          <span>Can</span>
+										        </p>
+												<div class="caps " data-rating="3.75">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-75"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+																			<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/badges/bdg_PolePosition_sm.jpg" alt="Pole Position (Level 36)">
+											<span>Earned the Pole Position (Level 36) badge!</span>
+										</span>
+										
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Lollkoll">
+																	<img src="https://gravatar.com/avatar/ff40458fd29c430924dc90e5821d648c?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Kristi Koll avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+							
+						</div>
+
+						<div class="bottom">
+							<a href="/user/kjeasr/checkin/1571088931" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Mon, 18 May 2026 19:19:11 +0000</a>
+							<a href="/user/kjeasr/checkin/1571088931" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+													</div>
+
+						<div class="cheers" style="display: none;">								<span class="count"><span>0</span></span>
+								<span class="toast-list"></span>
+														</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+							
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1570883182" data-checkin-id="1570883182">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+												<a href="/user/Tierchen76">
+							<img loading="lazy" src="https://assets.untappd.com/profile/9c3dfcc5d1fa05a223f1c1911fc7ca00_100x100.jpg" alt="Tierchen Animal">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6645513_22c0d_sm.jpeg" alt="Fifty Fifty - Clementine & Passionfruit by Magic Road">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-13400864-type-checkin_feed">
+								<a href="/user/Tierchen76" class="user">Tierchen Animal</a>  is drinking a <a href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513">Fifty Fifty - Clementine & Passionfruit</a> by <a  href="/MagicRoad">Magic Road</a> at <a href="/v/crafter-s/13400864">Crafter's</a>
+							</p>
+														<div class="checkin-comment">
+								
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/draft@3x.png" alt="Draft">
+										          <span>Draft</span>
+										        </p>
+												<div class="caps " data-rating="4">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+									
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Hoppelhasi">
+																	<img src="https://assets.untappd.com/profile/26a10ac3f41dc29ceaf96cf2bc4ce896_100x100.jpg" alt="Christian Ernesto avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/Tierchen76/checkin/1570883182" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_05_17/c3c1ee4cea694acd645bb65a1c735a00_c_1570883182_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+							
+						</div>
+
+						<div class="bottom">
+							<a href="/user/Tierchen76/checkin/1570883182" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Sun, 17 May 2026 17:05:52 +0000</a>
+							<a href="/user/Tierchen76/checkin/1570883182" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+													</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>1</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="Jebusomat" href="/user/Jebusomat" title="Jebus Omat" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://gravatar.com/avatar/8e41440ec12cdf443462ac8fcf2ab2e1?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Jebus Omat avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+							
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1570112320" data-checkin-id="1570112320">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+												<a href="/user/Martek85">
+							<img loading="lazy" src="https://assets.untappd.com/profile/270eda6d7146babfdf1fe36fedc45982_100x100.jpg" alt="Marta B">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6645513_22c0d_sm.jpeg" alt="Fifty Fifty - Clementine & Passionfruit by Magic Road">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-9023142-type-checkin_feed">
+								<a href="/user/Martek85" class="user">Marta B</a>  is drinking a <a href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513">Fifty Fifty - Clementine & Passionfruit</a> by <a  href="/MagicRoad">Magic Road</a> at <a href="/v/klubokawiarnia-cynamon/9023142">Klubokawiarnia Cynamon</a>
+							</p>
+														<div class="checkin-comment">
+								
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/can@3x.png" alt="Can">
+										          <span>Can</span>
+										        </p>
+												<div class="caps " data-rating="3.75">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-75"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+																			<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/badges/bdg_FruitsOfYourLabor_sm.jpg" alt="Fruits of Your Labor (Level 91)">
+											<span>Earned the Fruits of Your Labor (Level 91) badge!</span>
+										</span>
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+							
+						</div>
+
+						<div class="bottom">
+							<a href="/user/Martek85/checkin/1570112320" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Fri, 15 May 2026 18:02:02 +0000</a>
+							<a href="/user/Martek85/checkin/1570112320" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+													</div>
+
+						<div class="cheers" style="display: none;">								<span class="count"><span>0</span></span>
+								<span class="toast-list"></span>
+														</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+							
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1570111930" data-checkin-id="1570111930">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+												<a href="/user/rhager">
+							<img loading="lazy" src="https://assets.untappd.com/profile/64248d8b7b9ae2e03a2efb215e7de817_100x100.jpg" alt="Ronald Hager">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6645513_22c0d_sm.jpeg" alt="Fifty Fifty - Clementine & Passionfruit by Magic Road">
+							</a>
+														<p class="text">
+								<a href="/user/rhager" class="user">Ronald Hager</a>  is drinking a <a  href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513">Fifty Fifty - Clementine & Passionfruit</a> by <a href="/MagicRoad">Magic Road</a>
+							</p>
+														<div class="checkin-comment">
+								
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/can@3x.png" alt="Can">
+										          <span>Can</span>
+										        </p>
+												<div class="caps " data-rating="3.75">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-75"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+									
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/rhager/checkin/1570111930" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_05_15/d2eeffe2c6ae1285a3cda205968d895e_c_1570111930_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+							
+						</div>
+
+						<div class="bottom">
+							<a href="/user/rhager/checkin/1570111930" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Fri, 15 May 2026 18:01:15 +0000</a>
+							<a href="/user/rhager/checkin/1570111930" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+													</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>7</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="adomascepavicius" href="/user/adomascepavicius" title="Adomas Cepavicius" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://gravatar.com/avatar/45ce901301d14ee53b8db6a0bd86cbf1?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Adomas Cepavicius avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="Marcello197676" href="/user/Marcello197676" title="Marcel van Bokhoven" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/5b52781b720d605749988f433082a6bd_100x100.jpg" alt="Marcel van Bokhoven avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="THE-GRUMP" href="/user/THE-GRUMP" title="Grumpy" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/2965d1baf779c3910f10669f18fd91c0_100x100.jpg" alt="Grumpy avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="Aldgisl" href="/user/Aldgisl" title="Jan Koning" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/0c2a6d99ca8c233ad37be9eb6559ae69_100x100.jpg" alt="Jan Koning avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="Keesursem1977" href="/user/Keesursem1977" title="Kees Ursem" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/b5c3cbc3be14eb17fc796c1943210de2_100x100.jpg" alt="Kees Ursem avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="Kainn" href="/user/Kainn" title="Kain Dekker" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/249d4e5320afb5503229bcf5d7a4189f_100x100.jpg" alt="Kain Dekker avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="Edamboy" href="/user/Edamboy" title="Bert Zijlstra" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/f5cf11515752c57b1aad73bcaeed1847_100x100.jpg" alt="Bert Zijlstra avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+							
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1570109839" data-checkin-id="1570109839">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+												<a href="/user/Edytka">
+							<img loading="lazy" src="https://assets.untappd.com/profile/3a2ab8fbb737999609e9a98743396572_100x100.jpg" alt="Edytka">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6645513_22c0d_sm.jpeg" alt="Fifty Fifty - Clementine & Passionfruit by Magic Road">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-9023142-type-checkin_feed">
+								<a href="/user/Edytka" class="user">Edytka</a>  is drinking a <a href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513">Fifty Fifty - Clementine & Passionfruit</a> by <a  href="/MagicRoad">Magic Road</a> at <a href="/v/klubokawiarnia-cynamon/9023142">Klubokawiarnia Cynamon</a>
+							</p>
+														<div class="checkin-comment">
+								
+																	<div class="rating-serving">
+										<div class="caps " data-rating="4.25">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-25"></div>
+	</div>								    </div>
+																			<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/badges/bdg_DessertTime_v2_Core_sm.jpg" alt="Dessert Time! (Level 8)">
+											<span>Earned the Dessert Time! (Level 8) badge!</span>
+										</span>
+										
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Arsival">
+																	<img src="https://assets.untappd.com/profile/db9ff7997183ab59d4202615d633f495_100x100.jpg" alt="Arkadiusz  avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Martek85">
+																	<img src="https://assets.untappd.com/profile/270eda6d7146babfdf1fe36fedc45982_100x100.jpg" alt="Marta B avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+							
+						</div>
+
+						<div class="bottom">
+							<a href="/user/Edytka/checkin/1570109839" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Fri, 15 May 2026 17:57:19 +0000</a>
+							<a href="/user/Edytka/checkin/1570109839" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+													</div>
+
+						<div class="cheers" style="display: none;">								<span class="count"><span>0</span></span>
+								<span class="toast-list"></span>
+														</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+							
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1570109721" data-checkin-id="1570109721">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+												<a href="/user/Arsival">
+							<img loading="lazy" src="https://assets.untappd.com/profile/db9ff7997183ab59d4202615d633f495_100x100.jpg" alt="Arkadiusz">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6645513_22c0d_sm.jpeg" alt="Fifty Fifty - Clementine & Passionfruit by Magic Road">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-9023142-type-checkin_feed">
+								<a href="/user/Arsival" class="user">Arkadiusz</a>  is drinking a <a href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513">Fifty Fifty - Clementine & Passionfruit</a> by <a  href="/MagicRoad">Magic Road</a> at <a href="/v/klubokawiarnia-cynamon/9023142">Klubokawiarnia Cynamon</a>
+							</p>
+														<div class="checkin-comment">
+								
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/can@3x.png" alt="Can">
+										          <span>Can</span>
+										        </p>
+												<div class="caps " data-rating="4.75">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-75"></div>
+	</div>								    </div>
+																			<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/badges/bdg_GloryCan_sm.jpg" alt="For the Can (Level 41)">
+											<span>Earned the For the Can (Level 41) badge!</span>
+										</span>
+																				<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/badges/bdg_SourBrew_sm.jpg" alt="Pucker Up (Level 26)">
+											<span>Earned the Pucker Up (Level 26) badge!</span>
+										</span>
+										
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Martek85">
+																	<img src="https://assets.untappd.com/profile/270eda6d7146babfdf1fe36fedc45982_100x100.jpg" alt="Marta B avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Edytka">
+																	<img src="https://assets.untappd.com/profile/3a2ab8fbb737999609e9a98743396572_100x100.jpg" alt="Edytka  avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/Arsival/checkin/1570109721" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_05_15/6260969fefbef4c9beb4ac442f6ff6f2_c_1570109721_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+							
+						</div>
+
+						<div class="bottom">
+							<a href="/user/Arsival/checkin/1570109721" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Fri, 15 May 2026 17:57:06 +0000</a>
+							<a href="/user/Arsival/checkin/1570109721" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+													</div>
+
+						<div class="cheers" style="display: none;">								<span class="count"><span>0</span></span>
+								<span class="toast-list"></span>
+														</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+							
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1568105748" data-checkin-id="1568105748">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+												<a href="/user/Papysh">
+							<img loading="lazy" src="https://gravatar.com/avatar/7f790c88728bbdd4acf1da1d394bb99c?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Krzysztof Kotkowski">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6645513_22c0d_sm.jpeg" alt="Fifty Fifty - Clementine & Passionfruit by Magic Road">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-9917985-type-checkin_feed">
+								<a href="/user/Papysh" class="user">Krzysztof Kotkowski</a>  is drinking a <a href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513">Fifty Fifty - Clementine & Passionfruit</a> by <a  href="/MagicRoad">Magic Road</a> at <a href="/v/at-home/9917985">Untappd at Home</a>
+							</p>
+														<div class="checkin-comment">
+								
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/can@3x.png" alt="Can">
+										          <span>Can</span>
+										        </p>
+												<div class="caps " data-rating="3.75">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-75"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+																			<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/badges/bdg_DessertTime_v2_Core_sm.jpg" alt="Dessert Time! (Level 87)">
+											<span>Earned the Dessert Time! (Level 87) badge!</span>
+										</span>
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+							
+						</div>
+
+						<div class="bottom">
+							<a href="/user/Papysh/checkin/1568105748" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Thu, 07 May 2026 17:33:37 +0000</a>
+							<a href="/user/Papysh/checkin/1568105748" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+													</div>
+
+						<div class="cheers" style="display: none;">								<span class="count"><span>0</span></span>
+								<span class="toast-list"></span>
+														</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+							
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1567993960" data-checkin-id="1567993960">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/Malyna">
+							<img loading="lazy" src="https://assets.untappd.com/profile/041fd819920f12bd13d92170cf00c3c3_100x100.jpg" alt="Algis Mantas">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6645513_22c0d_sm.jpeg" alt="Fifty Fifty - Clementine & Passionfruit by Magic Road">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-13452133-type-checkin_feed">
+								<a href="/user/Malyna" class="user">Algis Mantas</a>  is drinking a <a href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513">Fifty Fifty - Clementine & Passionfruit</a> by <a  href="/MagicRoad">Magic Road</a> at <a href="/v/uwaga-piwo/13452133">Uwaga Piwo</a>
+							</p>
+														<div class="checkin-comment">
+								
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/draft@3x.png" alt="Draft">
+										          <span>Draft</span>
+										        </p>
+												<div class="caps " data-rating="4">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+																			<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/badges/bdg_PolePosition_sm.jpg" alt="Pole Position (Level 21)">
+											<span>Earned the Pole Position (Level 21) badge!</span>
+										</span>
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/Malyna/checkin/1567993960" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_05_06/09b365e014755016fcc5b59e19298526_c_1567993960_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+							
+						</div>
+
+						<div class="bottom">
+							<a href="/user/Malyna/checkin/1567993960" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Wed, 06 May 2026 20:52:03 +0000</a>
+							<a href="/user/Malyna/checkin/1567993960" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+													</div>
+
+						<div class="cheers" style="display: none;">								<span class="count"><span>0</span></span>
+								<span class="toast-list"></span>
+														</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+							
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1567992297" data-checkin-id="1567992297">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+												<a href="/user/chichicoco">
+							<img loading="lazy" src="https://assets.untappd.com/profile/f10571106df77bff03c8d8d2aa276261_100x100.jpg" alt="Chichicoco">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6645513_22c0d_sm.jpeg" alt="Fifty Fifty - Clementine & Passionfruit by Magic Road">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-13452133-type-checkin_feed">
+								<a href="/user/chichicoco" class="user">Chichicoco</a>  is drinking a <a href="/b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513">Fifty Fifty - Clementine & Passionfruit</a> by <a  href="/MagicRoad">Magic Road</a> at <a href="/v/uwaga-piwo/13452133">Uwaga Piwo</a>
+							</p>
+														<div class="checkin-comment">
+								
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/draft@3x.png" alt="Draft">
+										          <span>Draft</span>
+										        </p>
+												<div class="caps " data-rating="4.5">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-50"></div>
+	</div>								    </div>
+									
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/chichicoco/checkin/1567992297" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_05_06/d1043626e1ccc19a6b9a44a454bbdcd0_c_1567992297_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+							
+						</div>
+
+						<div class="bottom">
+							<a href="/user/chichicoco/checkin/1567992297" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Wed, 06 May 2026 20:43:11 +0000</a>
+							<a href="/user/chichicoco/checkin/1567992297" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+													</div>
+
+						<div class="cheers" style="display: none;">								<span class="count"><span>0</span></span>
+								<span class="toast-list"></span>
+														</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+							
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+						<script type="text/javascript" src="https://untappd.com/assets/v3/js/common/min/feed_scripts_min.js?v=2.8.36"></script>
+			<style type="text/css">
+				.translate {
+					color: #000;
+				    font-weight: 600;
+				    font-size: 12px;
+				    text-transform: uppercase;
+				    margin-bottom: 0px;
+				    margin-top: 15px;
+				    margin-bottom: 10px;
+				}
+			</style>
+			
+			<script id="delete-checkin-container" type="text/x-handlebars-template">
+				<div class="delete-confirm-checkin"></div>
+			</script>
+			<script id="delete-checkin-template" type="text/x-handlebars-template">
+				<div class="modal delete-confirm"><div class="inner"><div class="top"><a class="close" href="#"></a><h3 style="margin-bottom: 0px; padding-bottom: 0px; border-bottom: none;">Confirm Check-in Deletion</h3></div><div class="error" id="delete-checkin-error" style="display: none;"></div><div class="delete-confirm-message" style="padding: 24px; text-align: center; -moz-box-sizing: border-box; box-sizing: border-box;"><p><strong>Warning</strong> - Are you sure you want to delete this check-in? This cannot be undone. All badges that are associated with this check-in will be removed.</p><div class="inner-container" style="width: 80%; margin: 15px auto;"><a href="#" class="check-confirm-deletion" data-checkin-id="{{checkin_id}}" style="margin-top: 15px;">Confirm Deletion</a><p id="checkin-delete-loader" class="stream-loading"><span></span></p></div></div></div></div>
+			</script>
+			<script id="comment-template" type="text/x-handlebars-template">
+				{{#each items}}<div class="comment" id="comment_{{this.comment_id}}"><div class="avatar"><div class="avatar-holder">{{#if this.user.supporter}} <span class="supporter"></span>{{/if}}<a href="/user/{{this.user.user_name}}"><img src="{{this.user.user_avatar}}" alt="Your Avatar"></a></div></div><div class="text"><p><a href="/user/{{this.user.user_name}}">{{this.user.first_name}} {{this.user.last_name}}</a>: <abbr id="checkincomment_{{this.comment_id}}">{{{this.comment}}}</abbr></p><p class="meta"><span class="time timezoner">{{this.created_at}}</span>{{#if this.comment_editor}}<a href="#" class="comment-edit" data-comment-id="{{this.comment_id}}">Edit</a>{{/if}}{{#if this.comment_owner}}<a href="#" class="comment-delete" data-comment-id="{{this.comment_id}}">Delete</a>{{/if}}</p></div></div>{{#if this.comment_editor}}<div class="comment" id="commentedit_{{this.comment_id}}" style="display: none;"><div class="avatar"><div class="avatar-holder">{{#if this.user.supporter}} <span class="supporter"></span>{{/if}}<a href="/user/{{this.user.user_name}}"><img src="{{this.user.user_avatar}}" alt="Your Avatar"></a></div></div><div class="text"><form class="editing"><p class="editerror_{{this.comment_id}} post-error" style="display: none;">There was a problem posting your comment, please try again.</p><textarea name="comment" id="commentBox_{{this.comment_id}}" onkeydown="limitTextReverse($('#commentBox_{{this.comment_id}}'),$('#commentedit_{{this.comment_id}} .myCount'), 140);">{{{this.comment}}}</textarea><span class="comment-loading" style="display: none;"></span><span class="counter"><abbr class="myCount">0</abbr>/140</span><span class="actions"><a href="#" class="submit comment-update-save" data-comment-id="{{this.comment_id}}">Update</a><a href="#" data-comment-id="{{this.comment_id}}" class="cancel comment-update-cancel">Cancel</a></span></form></div></div>{{/if}}{{/each}}
+			</script>
+			<script type="text/javascript">
+				$(document).ready(function() {
+					createImpressionTracker();
+				});
+			</script>
+			                </div>
+                <a href="/login?go_to=https://untappd.com//b/magic-road-fifty-fifty-clementine-and-passionfruit/6645513" data-filter="none" data-bid="6645513" class="more_checkins button yellow track-click" data-track="beer" data-href=":feed/showmoreloggedout">Show More</a>
+                <p class="stream-loading"><span></span></p>
+                
+        </div>
+    </div>
+
+    </div>
+
+    <div class="sidebar">
+      
+                    <p class="edit" style="text-align: center;">
+                            <a href="/login?go_to=https://untappd.com/beer/propose_edit/6645513">Propose Edit</a>
+                <a href="/login?go_to=https://untappd.com/beer/propose_dupe/6645513">Propose Duplicate</a>
+                            </p>
+            	<div class="box">
+		<div style="text-align: center;" data-freestar-ad="__336x280" id="untappd-com_untappd_siderail_right_atf">
+			<script data-cfasync="false" type="text/javascript">
+				freestar.config.enabled_slots.push({ placementName: "untappd-com_untappd_siderail_right_atf", slotId: "untappd-com_untappd_siderail_right_atf" });
+			</script>
+		</div>
+	</div>
+	    <div class="box">
+        <div class="content">
+            <h3>Loyal Drinkers (<a href="#" title="This data is refreshed every 48 hours." class="tip">?</a>)</h3>
+            <div class="drinkers">
+                                    <a class="tip track-click" data-track="sidebar" data-href=":loyal/drinkers" href="/user/starydziad" title="CześćSerduszko  (2 check-ins)" ><span><img src="https://assets.untappd.com/profile/c5811712d4282417630dc0986e7c980b_100x100.jpg" alt="CześćSerduszko  avatar"></span></a>
+                                        <a class="tip track-click" data-track="sidebar" data-href=":loyal/drinkers" href="/user/lepszyzbiks" title="Łukasz  (2 check-ins)" ><span><img src="https://assets.untappd.com/profile/3d4ac9c65427b8601ad97b18ce24051a_100x100.jpg" alt="Łukasz  avatar"></span></a>
+                                        <a class="tip track-click" data-track="sidebar" data-href=":loyal/drinkers" href="/user/Skylaer" title="Heidi Nykanen (2 check-ins)" ><span><img src="https://assets.untappd.com/profile/08d2a3997d5b3350994bc5aecb4a8341_100x100.jpg" alt="Heidi Nykanen avatar"></span></a>
+                                        <a class="tip track-click" data-track="sidebar" data-href=":loyal/drinkers" href="/user/Sanderka" title="Sanderka  (2 check-ins)" ><span><img src="https://gravatar.com/avatar/545696ad113ce30322a4441c3e3a3e2e?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Sanderka  avatar"></span></a>
+                                        <a class="tip track-click" data-track="sidebar" data-href=":loyal/drinkers" href="/user/esodin" title="Eugene Sodin (1 check-in)" ><span><img src="https://assets.untappd.com/profile/e05c5d9aa3ed082e8354ab144e716a96_100x100.jpg" alt="Eugene Sodin avatar"></span></a>
+                                        <a class="tip track-click" data-track="sidebar" data-href=":loyal/drinkers" href="/user/Papysh" title="Krzysztof Kotkowski (1 check-in)" ><span><img src="https://gravatar.com/avatar/7f790c88728bbdd4acf1da1d394bb99c?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Krzysztof Kotkowski avatar"></span></a>
+                                        <a class="tip track-click" data-track="sidebar" data-href=":loyal/drinkers" href="/user/Vran" title="Domagoj Vran (1 check-in)" ><span><img src="https://assets.untappd.com/profile/a2da6835a5cb370c81ff2c556b1cc959_100x100.jpg" alt="Domagoj Vran avatar"></span></a>
+                                        <a class="tip track-click" data-track="sidebar" data-href=":loyal/drinkers" href="/user/ghbacellar" title="Gonçalo Bacellar (1 check-in)" ><span><img src="https://assets.untappd.com/profile/a0b89417e589df1db2fa37b943940bb9_100x100.jpg" alt="Gonçalo Bacellar avatar"></span></a>
+                                        <a class="tip track-click" data-track="sidebar" data-href=":loyal/drinkers" href="/user/Estebanik" title="Paweł Om (1 check-in)" ><span><img src="https://assets.untappd.com/profile/9b37f3e356a79a715bd73cad45b60331_100x100.jpg" alt="Paweł Om avatar"></span></a>
+                                        <a class="tip track-click" data-track="sidebar" data-href=":loyal/drinkers" href="/user/KostiantynMartyniuk" title="Kostiantyn Martyniuk (1 check-in)" ><span><img src="https://assets.untappd.com/profile/1dc99eb5dec51a11924efcfc633ec8d3_100x100.jpg" alt="Kostiantyn Martyniuk avatar"></span></a>
+                                        <a class="tip track-click" data-track="sidebar" data-href=":loyal/drinkers" href="/user/GidoR" title="Gido Riphagen (1 check-in)" ><span><img src="https://assets.untappd.com/profile/316f0a649f2b1176279d5cb8cef718bd_100x100.jpg" alt="Gido Riphagen avatar"></span></a>
+                                        <a class="tip track-click" data-track="sidebar" data-href=":loyal/drinkers" href="/user/Zanik81" title="Žánik Žánik (1 check-in)" ><span><img src="https://assets.untappd.com/profile/94649ba32ee7331e14586d081ad98ca9_100x100.jpg" alt="Žánik Žánik avatar"></span></a>
+                                </div>
+        </div>
+    </div>
+    
+    <div class="box">
+        <div class="content">
+            <h3>Similar Beers</h3>
+
+                            <div class="item">
+                    <p class="logo">
+                        <a href="/b/ill-will-brewing-fear-the-turtle/6438918" class="track-click" data-track="sidebar" data-href=":beer/similar">
+                            <img src="https://assets.untappd.com/site/beer_logos/beer-6438918_c758b_sm.jpeg" alt="Fear the Turtle label">
+                        </a>
+                    </p><p class="text">
+                        <a href="/b/ill-will-brewing-fear-the-turtle/6438918" class="track-click" data-track="sidebar" data-href=":beer/similar">
+                            <span class="name">Fear the Turtle</span>
+                        </a>
+                        <span class="brewery">ill will brewing</span>
+                    </p>
+                </div>
+                                <div class="item">
+                    <p class="logo">
+                        <a href="/b/mortalis-brewing-company-myths-of-mortalis-strawberry-chocolate-crepe/6560808" class="track-click" data-track="sidebar" data-href=":beer/similar">
+                            <img src="https://assets.untappd.com/site/beer_logos/beer-6560808_ed735_sm.jpeg" alt="Myths of Mortalis | Strawberry + Chocolate + Crepe label">
+                        </a>
+                    </p><p class="text">
+                        <a href="/b/mortalis-brewing-company-myths-of-mortalis-strawberry-chocolate-crepe/6560808" class="track-click" data-track="sidebar" data-href=":beer/similar">
+                            <span class="name">Myths of Mortalis | Strawberry + Chocolate + Crepe</span>
+                        </a>
+                        <span class="brewery">Mortalis Brewing Company</span>
+                    </p>
+                </div>
+                                <div class="item">
+                    <p class="logo">
+                        <a href="/b/servaes-brewing-co-ever-after-honeydew-pineapple-kiwi/6220725" class="track-click" data-track="sidebar" data-href=":beer/similar">
+                            <img src="https://assets.untappd.com/site/beer_logos/beer-6220725_32843_sm.jpeg" alt="Ever After - Honeydew Pineapple Kiwi label">
+                        </a>
+                    </p><p class="text">
+                        <a href="/b/servaes-brewing-co-ever-after-honeydew-pineapple-kiwi/6220725" class="track-click" data-track="sidebar" data-href=":beer/similar">
+                            <span class="name">Ever After - Honeydew Pineapple Kiwi</span>
+                        </a>
+                        <span class="brewery">Servaes Brewing Co.</span>
+                    </p>
+                </div>
+                                <div class="item">
+                    <p class="logo">
+                        <a href="/b/mortalis-brewing-company-myths-of-mortalis-thumb-print-cookie/6583463" class="track-click" data-track="sidebar" data-href=":beer/similar">
+                            <img src="https://assets.untappd.com/site/beer_logos/beer-6583463_103c6_sm.jpeg" alt="Myths of Mortalis | Thumb Print Cookie label">
+                        </a>
+                    </p><p class="text">
+                        <a href="/b/mortalis-brewing-company-myths-of-mortalis-thumb-print-cookie/6583463" class="track-click" data-track="sidebar" data-href=":beer/similar">
+                            <span class="name">Myths of Mortalis | Thumb Print Cookie</span>
+                        </a>
+                        <span class="brewery">Mortalis Brewing Company</span>
+                    </p>
+                </div>
+                                <div class="item">
+                    <p class="logo">
+                        <a href="/b/mortalis-brewing-company-draco-constellation/5952305" class="track-click" data-track="sidebar" data-href=":beer/similar">
+                            <img src="https://assets.untappd.com/site/beer_logos/beer-5952305_497ed_sm.jpeg" alt="Draco Constellation label">
+                        </a>
+                    </p><p class="text">
+                        <a href="/b/mortalis-brewing-company-draco-constellation/5952305" class="track-click" data-track="sidebar" data-href=":beer/similar">
+                            <span class="name">Draco Constellation</span>
+                        </a>
+                        <span class="brewery">Mortalis Brewing Company</span>
+                    </p>
+                </div>
+                        </div>
+    </div>
+        	<div class="box">
+        	<div class="content">
+                <h3>Verified Locations</h3>                    <div class="item" data-track-venue-impression="venue_id-669673-type-verified_locations">
+                        <a href="/v/koht/669673" class="track-click" data-track="sidebar" data-href=":venue/toplist">
+                            <p class="logo">
+                                <span>Verified</span>                                <img src="https://images.untp.beer/resize?width=176&height=176&background=255,255,255&extend=white&stripmeta=true&url=https://utfb-images.untappd.com/logos/56297e2ca3e2ed046cdb6ae6ba82bda84b6d04bd.jpg?auto=compress" alt="Koht logo">
+                            </p><p class="text">
+                                <span class="name">Koht</span>
+
+                                <span class="location">Tallinn, Harju maakond                                        </span>                            </p>
+                        </a>
+                    </div>
+
+        			        	</div>
+    	</div>
+        <script type="text/javascript">
+            $(document).ready(function() {
+                createImpressionTracker();
+            });
+        </script>
+    	    	<div class="box">
+        	<div class="content">
+                <h3>Popular Locations</h3>                    <div class="item" data-track-venue-impression="venue_id-13400864-type-popular_locations">
+                        <a href="/v/crafter-s/13400864" class="track-click" data-track="sidebar" data-href=":venue/toplist">
+                            <p class="logo">
+                                                                <img src="https://ss3.4sqi.net/img/categories_v2/nightlife/pub_bg_512.png" alt="Crafter's logo">
+                            </p><p class="text">
+                                <span class="name">Crafter's</span>
+
+                                <span class="location">Angers, Pays de la Loire                                        </span>                            </p>
+                        </a>
+                    </div>
+
+        			                    <div class="item" data-track-venue-impression="venue_id-2903749-type-popular_locations">
+                        <a href="/v/jabeerwocky/2903749" class="track-click" data-track="sidebar" data-href=":venue/toplist">
+                            <p class="logo">
+                                                                <img src="https://ss3.4sqi.net/img/categories_v2/nightlife/pub_bg_512.png" alt="Jabeerwocky logo">
+                            </p><p class="text">
+                                <span class="name">Jabeerwocky</span>
+
+                                <span class="location">Warszawa, Województwo mazowieckie                                        </span>                            </p>
+                        </a>
+                    </div>
+
+        			        	</div>
+    	</div>
+        <script type="text/javascript">
+            $(document).ready(function() {
+                createImpressionTracker();
+            });
+        </script>
+    		<div class="sticky">
+		<div style="text-align: center;" data-freestar-ad="__300x600" id="untappd-com_untappd_siderail_right_sticky">
+			<script data-cfasync="false" type="text/javascript">
+				freestar.config.enabled_slots.push({ placementName: "untappd-com_untappd_siderail_right_sticky", slotId: "untappd-com_untappd_siderail_right_sticky" });
+			</script>
+		</div>
+	</div>
+	
+
+    </div>
+
+</div>
+
+    <script>
+    $(document).ready(function() {
+        $(".read-less").on("click", function() {
+            $(".beer-descrption-read-less").hide();
+            $(".beer-descrption-read-more").show();
+            return false;
+        });
+
+        $(".read-more").on("click", function() {
+            $(".beer-descrption-read-more").hide();
+            $(".beer-descrption-read-less").show();
+            return false;
+        });
+    })
+    </script>
+    
+<script>
+    $(".image-big").on("click", function(e) {
+        e.preventDefault();
+        var lightbox = lity($(this).attr("data-image"));
+    });
+</script>
+
+<script>
+    $(document).ready(function() {
+        if (location.hash === "#moderator_tools_open") {
+            $.facybox({ajax: '/beer/merge/6645513'});
+
+            if (window.history && window.history.replaceState) {
+                window.history.replaceState(null, null, window.location.pathname + window.location.search);
+            }
+        }
+    });
+</script>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/lity/2.4.1/lity.min.js" integrity="sha256-zxQassxI0mVHvbol+aWu+6yZE0RuRgssztENh+Nha9M=" crossorigin="anonymous"></script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/lity/2.4.1/lity.min.css" integrity="sha256-NAvhzrbNXUReroETt2Qx7bSamUy1a9ugWA7c7AVZwG8=" crossorigin="anonymous" />
+
+<iframe src="/profile/stats?id=6645513&type=beer&is_supporter=0&nomobile=true" width="0" height="0" tabindex="-1" title="empty" class="hidden"></iframe><style>
+#pmLink {
+	visibility: hidden;
+    color: #8a4500;
+    font: inherit;
+    line-height: inherit;
+    text-decoration: none;
+    cursor: pointer;
+    background: transparent;
+    border: none;
+    margin: 0;
+    padding: 0;
+}
+
+#pmLink:hover {
+	visibility: visible;
+    color: #c60;
+}
+</style>
+
+	<footer class="has-bottom-ad">
+		<div class="footer-nav">
+			<div class="footer-inner">
+				<ul>
+					<li>
+						<a class="track-click" data-track="footer" data-href=":footer/businesses" href="https://utfb.untappd.com/">Untappd for Business</a>
+					</li>
+					<li>
+						<a class="track-click" data-track="footer" data-href=":footer/businesses/blog" href="https://lounge.untappd.com/">Untappd for Business Blog</a>
+					</li>
+					<li>
+						<a class="track-click" data-track="footer" data-href=":footer/breweries" href="https://untappd.com/breweries">Breweries</a>
+					</li>
+					<li>
+						<a class="track-click" data-track="footer" data-href=":footer/shop" href="https://untappd.com/shop">Shop</a>
+					</li>
+					<li>
+						<a class="track-click" data-track="footer" data-href=":footer/support" href="http://help.untappd.com/">Support</a>
+					</li>
+					<li>
+						<a class="track-click" data-track="footer" data-href=":footer/careers" href="/careers">Careers</a>
+					</li>
+					<li>
+						<a class="track-click" data-track="footer" data-href=":footer/api" href="/api/">API</a>
+					</li>
+					<li>
+						<a class="track-click" data-track="footer" data-href=":footer/terms" href="/terms">Terms</a>
+					</li>
+					<li>
+						<a class="track-click" data-track="footer" data-href=":footer/privacy" href="/privacy">Privacy</a>
+					</li>
+					<li>
+						<a class="track-click" data-track="footer" data-href=":footer/cookie" href="/cookie">Cookie Policy</a>
+					</li>
+					<li>
+						<!-- https://freestarhelp.zendesk.com/hc/en-us/articles/34424330233364-Freestar-Sourcepoint-CMP-Implementation -->
+						<button id="pmLink">Privacy Manager</button>
+					</li>
+					<li>
+						<a class="track-click" data-track="footer" data-href=":footer/personal_data" href="/privacy/personal-data">Manage Personal Data</a>
+					</li>
+				</ul>
+			</div>
+		</div>
+		<ul class="social">
+    <li><a class="track-click" data-track="footer" data-href=":footer/social/twitter" href="https://bit.ly/3T6pKK6" target="_blank"><img src="https://untappd.com/assets/custom/homepage/images/icon-twitter.svg" alt="Icon twitter" /></a></li>
+    <li><a class="track-click" data-track="footer" data-href=":footer/social/facebook" href="https://bit.ly/3RVLffu" target="_blank"><img src="https://untappd.com/assets/custom/homepage/images/icon-facebook.svg" alt="Icon facebook" /></a></li>
+    <li><a class="track-click" data-track="home" data-href=":footer/social/instagram" href="https://bit.ly/3EyG9D5" target="_blank"><img src="https://untappd.com/assets/custom/homepage/images/icon-instagram.svg" alt="Icon instagram" /></a></li>
+</ul>	</footer>
+
+<script type="text/javascript">
+	// polyfill for ie11
+	function getUrlParameter(name) {
+		name = name.replace(/[\[]/, '\\[').replace(/[\]]/, '\\]');
+		var regex = new RegExp('[\\?&]' + name + '=([^&#]*)');
+		var results = regex.exec(location.search);
+		return results === null ? '' : decodeURIComponent(results[1].replace(/\+/g, ' '));
+	};
+
+	$(document).ready(function() {
+		// remove any access tokens, preserve other elements
+		if (history.replaceState) {
+			if (location.href.indexOf("access_token=") >= 0) {
+				const accessTokenURL = getUrlParameter("access_token");
+				let currentURL = location.href;
+				let finalURL = currentURL.replace(`access_token=${accessTokenURL}`, '');
+
+				// if the url has a "&" already in it, then remove the "?" and replace the first "&" with an "?"
+				if (finalURL.indexOf("&") >= 0) {
+					finalURL = finalURL.replace("?", "").replace("&", "?");
+				} else {
+					finalURL = finalURL.split("?")[0];
+				}
+
+				history.replaceState(null, "", finalURL);
+			}
+		}
+	})
+</script>
+
+<script type="text/javascript">
+	// Clear Text Feild
+	function clearText(thefield) {
+		if (thefield.defaultValue == thefield.value)
+			thefield.value = ""
+	}
+</script>
+
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
Closes the PR-D series:

- **Migration v6**: \`beers.rating_refresh_at\` + \`rating_refresh_count\` (separate from PR-D1's lookup_at/count so the two state machines don't interfere).
- **New \`src/sources/untappd/beer-page.ts\`**: cheerio parser for \`https://untappd.com/beer/<bid>\`, returning \`{ global_rating: number | null }\`. Fixture-tested against curl-captured snapshot of bid 6645513.
- **New storage helpers in \`src/storage/beers.ts\`**: \`recordRatingSuccess\`, \`recordRatingNotFound\`, \`recordRatingTransient\`, \`listRatingRefreshCandidates\`. Reuse \`isEligible\` + the 0/24/72/168/336/720 h backoff schedule from PR-D1's \`lookup-backoff\`.
- **New \`src/jobs/refresh-tap-ratings.ts\` cron**: 09:00 / 21:00 UTC, limit 20 per run, 500ms polite spacing, respects \`UNTAPPD_LOOKUP_ENABLED\`.

## Behavior change
Beers that PR-D2 found by bid but Untappd hadn't yet rated (≤9 check-ins) now get periodic re-checks via \`/beer/{id}\`. When Untappd's rating crosses the 10-checkin threshold, the next cron run picks it up and \`/newbeers\` starts showing ⭐ instead of \`⭐ —\`.

Current prod candidate count = **0** at PR-write time — all pre-existing PR-D2-found beers happen to have ratings. PR-D3 is preventive infra for the population that will accumulate going forward.

Implements \`docs/superpowers/specs/2026-05-26-untappd-lookup.md\` PR-D3 section.

Note: Untappd redirects \`/beer/<bid>\` → \`/b/<slug>/<bid>\` via 302. Node's fetch (via the bot's http.get) follows redirects automatically; no code change needed for the runtime path. The curl-first capture in Task 3 used \`-L\`.

## Test plan
- [x] \`npm test\` green locally (332/43 — baseline 307 + 25 new)
- [x] \`npm run typecheck\` clean
- [x] \`npm run build\` clean
- [ ] After deploy: \`sudo journalctl -u warsaw-beer-bot --since today | grep \"refresh-tap-ratings done\"\` shows \`{processed, matched, not_found, transient}\` stats twice a day.
- [ ] Kill switch: \`UNTAPPD_LOOKUP_ENABLED=false\` already silences PR-D2; same for PR-D3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)