### PR TITLE
deploy: NOPASSWD sudoers fragment for password-less deploy

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -28,6 +28,33 @@ apt-get install -y nodejs build-essential python3
 
 `build-essential` + `python3` are needed for the `better-sqlite3` native build.
 
+### Operator sudo + journal access
+
+The deploy script and routine maintenance commands run a fixed set of
+privileged operations. To run them without a password prompt, install the
+NOPASSWD sudoers fragment shipped in this repo and put the operator user in
+the `systemd-journal` group:
+
+```bash
+# As root (one time per host). The visudo -cf check rejects malformed files,
+# so an accidental edit can't lock you out of sudo.
+visudo -cf deploy/sudoers.d/warsaw-beer-bot
+install -m 0440 -o root -g root \
+  deploy/sudoers.d/warsaw-beer-bot /etc/sudoers.d/warsaw-beer-bot
+
+# `journalctl -u <unit>` works without sudo for members of systemd-journal.
+usermod -aG systemd-journal ysi
+# The new group takes effect on the next login (or `newgrp systemd-journal`).
+```
+
+The sudoers fragment is scoped to specific binaries with pinned arguments
+(see `deploy/sudoers.d/warsaw-beer-bot` for the full list). It does not
+grant the operator extra capability — the operator is already in the `sudo`
+group — it only removes the password prompt for the scoped commands.
+
+If the operator user is not `ysi`, edit `deploy/sudoers.d/warsaw-beer-bot`
+and replace `ysi` with the correct username before installing.
+
 ## Deploy
 
 From a dev checkout:
@@ -46,9 +73,9 @@ git pull
 ## Operate
 
 ```bash
-sudo systemctl status warsaw-beer-bot
-sudo journalctl -u warsaw-beer-bot -f
-sudo systemctl restart warsaw-beer-bot
+systemctl status warsaw-beer-bot       # no sudo: status is unprivileged
+journalctl -u warsaw-beer-bot -f       # no sudo: operator is in systemd-journal
+sudo systemctl restart warsaw-beer-bot # NOPASSWD via /etc/sudoers.d/warsaw-beer-bot
 ```
 
 ## Backup: Litestream → Cloudflare R2
@@ -97,8 +124,8 @@ systemctl enable --now litestream
 ### Operate
 
 ```bash
-sudo systemctl status litestream
-sudo journalctl -u litestream -f
+systemctl status litestream
+journalctl -u litestream -f
 ```
 
 A successful first run logs `replicating to: ...`. If you see

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -30,4 +30,6 @@ sudo systemctl enable warsaw-beer-bot
 # `enable --now` is a no-op on an already-running unit, so a redeploy with new
 # code would leave the old process in memory. Always restart explicitly.
 sudo systemctl restart warsaw-beer-bot
-sudo journalctl -u warsaw-beer-bot -n 30 --no-pager
+# journalctl works without sudo because the operator user is in the
+# systemd-journal group (see deploy/README.md → "One-time host setup").
+journalctl -u warsaw-beer-bot -n 30 --no-pager

--- a/deploy/sudoers.d/warsaw-beer-bot
+++ b/deploy/sudoers.d/warsaw-beer-bot
@@ -1,0 +1,47 @@
+# /etc/sudoers.d/warsaw-beer-bot
+#
+# Lets the operator user (default: ysi) run the warsaw-beer-bot deploy and
+# maintenance commands without a password prompt. Installed once on the host
+# via:
+#
+#   sudo visudo -cf deploy/sudoers.d/warsaw-beer-bot
+#   sudo install -m 0440 -o root -g root \
+#       deploy/sudoers.d/warsaw-beer-bot /etc/sudoers.d/warsaw-beer-bot
+#
+# Threat model: the operator is already in the `sudo` group, so NOPASSWD does
+# not grant new capabilities — it just removes the password prompt for this
+# scoped set of commands. The bot continues to run under the dedicated
+# unprivileged `warsaw-beer-bot` user with `nologin` shell; nothing about the
+# privilege-separation model changes.
+#
+# If the operator user is not `ysi`, change `ysi` below to match.
+
+# 1. Filesystem ops the deploy script performs as root.
+Cmnd_Alias WBB_DEPLOY_FILES = \
+    /usr/bin/install -d -o warsaw-beer-bot -g warsaw-beer-bot /opt/warsaw-beer-bot /var/lib/warsaw-beer-bot /etc/warsaw-beer-bot, \
+    /usr/bin/install -d -o warsaw-beer-bot -g warsaw-beer-bot -m 750 /home/warsaw-beer-bot, \
+    /usr/bin/install -m 0644 deploy/warsaw-beer-bot.service /etc/systemd/system/warsaw-beer-bot.service, \
+    /usr/bin/install -m 0644 deploy/litestream.service /etc/systemd/system/litestream.service, \
+    /usr/bin/rsync -a --delete --exclude node_modules --exclude tests --exclude docs --exclude .git --exclude .worktrees --exclude dist ./ /opt/warsaw-beer-bot/, \
+    /usr/bin/chown -R warsaw-beer-bot\:warsaw-beer-bot /opt/warsaw-beer-bot
+
+# 2. systemctl ops on our two units only (matched by unit name, not wildcard).
+Cmnd_Alias WBB_SYSTEMCTL = \
+    /usr/bin/systemctl daemon-reload, \
+    /usr/bin/systemctl enable warsaw-beer-bot, \
+    /usr/bin/systemctl disable warsaw-beer-bot, \
+    /usr/bin/systemctl restart warsaw-beer-bot, \
+    /usr/bin/systemctl stop warsaw-beer-bot, \
+    /usr/bin/systemctl start warsaw-beer-bot, \
+    /usr/bin/systemctl enable litestream, \
+    /usr/bin/systemctl disable litestream, \
+    /usr/bin/systemctl restart litestream, \
+    /usr/bin/systemctl stop litestream, \
+    /usr/bin/systemctl start litestream
+
+# 3. Build step runs as the service user (so npm cache + node_modules end up
+# owned by warsaw-beer-bot). Allowed as Runas=warsaw-beer-bot only — not root.
+ysi ALL=(warsaw-beer-bot) NOPASSWD: /usr/bin/bash -lc *
+
+# 4. Root-runnable deploy + systemctl ops.
+ysi ALL=(root) NOPASSWD: WBB_DEPLOY_FILES, WBB_SYSTEMCTL


### PR DESCRIPTION
## Summary

Operator user (`ysi`) was getting a sudo password prompt at every step of `deploy/deploy.sh` since we stopped running deploys as root. This PR ships a scoped NOPASSWD sudoers fragment and drops the redundant `sudo` from journal/status commands.

**Why NOPASSWD sudoers, not `systemctl --user`:** keeping the bot under the dedicated unprivileged `warsaw-beer-bot` user (with `nologin` shell, files under `/opt`, `/var/lib`, `/etc`) is the right privilege-separation model. `--user` would push everything into the login user's `\$HOME` and lose that isolation — wrong trade for an ergonomics fix. The operator is already in the `sudo` group, so NOPASSWD doesn't grant new capability — it only removes the password prompt for the scoped commands.

## Files

- `deploy/sudoers.d/warsaw-beer-bot` — new. Scoped Cmnd_Alias groups for: filesystem ops (install, rsync, chown), systemctl ops on the two units (warsaw-beer-bot, litestream), and the `sudo -u warsaw-beer-bot bash -lc …` build step. Pinned args where it's tight enough.
- `deploy/deploy.sh` — drop `sudo` from final `journalctl` call (operator is added to `systemd-journal` group during host setup).
- `deploy/README.md` — new "Operator sudo + journal access" subsection with the one-time install commands; Operate sections updated to use unprivileged `systemctl status` / `journalctl -u`.

## One-time install on prod

```bash
sudo visudo -cf deploy/sudoers.d/warsaw-beer-bot          # validates syntax
sudo install -m 0440 -o root -g root \
  deploy/sudoers.d/warsaw-beer-bot /etc/sudoers.d/warsaw-beer-bot
sudo usermod -aG systemd-journal ysi                       # already done on this host
```

## Test plan

- [x] `visudo -cf` parses the fragment OK (verified locally without root)
- [ ] After install: `sudo -ln` shows the NOPASSWD entries for ysi
- [ ] After install: running `./deploy/deploy.sh` from a fresh shell produces zero password prompts
- [ ] `journalctl -u warsaw-beer-bot -n 5` (no sudo) works
- [ ] `systemctl status warsaw-beer-bot` (no sudo) works