### PR TITLE
feat(matcher): vintage year matching + enrich duplicate handling

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -9,6 +9,10 @@ HOMEDIR=/home/warsaw-beer-bot
 sudo install -d -o warsaw-beer-bot -g warsaw-beer-bot "$APP" "$DATA" "$ENVDIR"
 sudo install -d -o warsaw-beer-bot -g warsaw-beer-bot -m 750 "$HOMEDIR"
 
+# Re-assert ownership of env files — created manually as root during first
+# setup, must be owned by warsaw-beer-bot so refresh-cookie.sh can edit them.
+sudo chown -R warsaw-beer-bot:warsaw-beer-bot "$ENVDIR"
+
 sudo rsync -a --delete \
   --exclude node_modules \
   --exclude tests \

--- a/deploy/sudoers.d/warsaw-beer-bot
+++ b/deploy/sudoers.d/warsaw-beer-bot
@@ -23,7 +23,8 @@ Cmnd_Alias WBB_DEPLOY_FILES = \
     /usr/bin/install -m 0644 deploy/warsaw-beer-bot.service /etc/systemd/system/warsaw-beer-bot.service, \
     /usr/bin/install -m 0644 deploy/litestream.service /etc/systemd/system/litestream.service, \
     /usr/bin/rsync -a --delete --exclude node_modules --exclude tests --exclude docs --exclude .git --exclude .worktrees --exclude dist ./ /opt/warsaw-beer-bot/, \
-    /usr/bin/chown -R warsaw-beer-bot\:warsaw-beer-bot /opt/warsaw-beer-bot
+    /usr/bin/chown -R warsaw-beer-bot\:warsaw-beer-bot /opt/warsaw-beer-bot, \
+    /usr/bin/chown -R warsaw-beer-bot\:warsaw-beer-bot /etc/warsaw-beer-bot
 
 # 2. systemctl ops on our two units only (matched by unit name, not wildcard).
 Cmnd_Alias WBB_SYSTEMCTL = \

--- a/docs/superpowers/plans/2026-05-31-vintage-year-matching.md
+++ b/docs/superpowers/plans/2026-05-31-vintage-year-matching.md
@@ -1,0 +1,399 @@
+# Vintage Year Matching Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `matchBeer` year-aware so that ontap beers with an explicit vintage year (e.g. "AFFECTION 2023") prefer a catalog entry with the same year, fall back to no-year entries, and never silently cross-match to a different vintage.
+
+**Architecture:** Two pure additions to `src/domain/matcher.ts`: (1) `extractYear(name)` extracts a 4-digit year from a raw beer name; (2) the exact-match selection block is replaced with a priority chain — yearMatch → noYear fallback → null — with an ABV-mismatch escape hatch inside the yearMatch branch. No changes to storage, jobs, or bot commands. Retroactive cleanup deletes 3 confirmed wrong match_links so `/refresh` re-creates them with the corrected logic.
+
+**Tech Stack:** TypeScript, Jest. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-05-31-vintage-year-matching.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/domain/matcher.ts` | Modify | Export `extractYear`; replace exact-match selection block (lines 71–80) with year-aware logic |
+| `src/domain/matcher.test.ts` | Modify | `extractYear` unit tests + 8 new `matchBeer` vintage scenarios |
+
+No new files. No changes to `normalize.ts`, storage, jobs, or bot.
+
+---
+
+## Task 1: `extractYear` — tests then implementation
+
+**Files:**
+- Modify: `src/domain/matcher.ts` (add function)
+- Modify: `src/domain/matcher.test.ts` (add describe block)
+
+- [ ] **Step 1: Write failing tests for `extractYear`**
+
+Open `src/domain/matcher.test.ts`. After the existing `import` line, add to the import:
+
+```ts
+import { matchBeer, breweryAliases, extractYear, type CatalogBeer } from './matcher';
+```
+
+Then append a new describe block at the **end of the file** (after all existing tests):
+
+```ts
+describe('extractYear', () => {
+  test('finds 4-digit year in parentheses', () => {
+    expect(extractYear('Affection (2025)')).toBe(2025);
+  });
+  test('finds bare 4-digit year', () => {
+    expect(extractYear('AFFECTION 2023')).toBe(2023);
+  });
+  test('returns null when no 4-digit year present', () => {
+    expect(extractYear('Affection')).toBeNull();
+  });
+  test('ignores abbreviated 2-digit year form', () => {
+    expect(extractYear("Farm to Glass '25: Citra")).toBeNull();
+  });
+  test('1900-range year is detected', () => {
+    expect(extractYear('Vintage 1998')).toBe(1998);
+  });
+  test('number outside 19xx/20xx range is not a year', () => {
+    expect(extractYear('Tripel 888')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /home/ysi/warsaw-beer-bot && npx jest matcher.test --no-coverage 2>&1 | tail -15
+```
+
+Expected: `extractYear` not exported → compile error or 6 failing tests.
+
+- [ ] **Step 3: Implement `extractYear` in `matcher.ts`**
+
+Open `src/domain/matcher.ts`. After the `COLLAB_SEP` export (line 26), add:
+
+```ts
+// Extracts the first 4-digit calendar year (1900–2099) from a raw beer name.
+// Called on the un-normalized name because normalizeName strips digit tokens.
+export function extractYear(name: string): number | null {
+  const m = name.match(/\b(19|20)\d{2}\b/);
+  return m ? parseInt(m[0], 10) : null;
+}
+```
+
+- [ ] **Step 4: Verify `extractYear` tests pass**
+
+```bash
+cd /home/ysi/warsaw-beer-bot && npx jest matcher.test --no-coverage 2>&1 | tail -10
+```
+
+Expected: all `extractYear` tests pass (existing tests still green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/ysi/warsaw-beer-bot && git add src/domain/matcher.ts src/domain/matcher.test.ts && git commit -m "feat(matcher): extractYear — detect 4-digit vintage year in raw beer name"
+```
+
+---
+
+## Task 2: Year-aware exact match — tests then implementation
+
+**Files:**
+- Modify: `src/domain/matcher.ts` (replace lines 71–80)
+- Modify: `src/domain/matcher.test.ts` (new describe block)
+
+- [ ] **Step 1: Write 9 failing tests**
+
+Append a new describe block to the end of `src/domain/matcher.test.ts`:
+
+```ts
+describe('matchBeer — vintage year disambiguation', () => {
+  // Helper: build a minimal CatalogBeer
+  const beer = (id: number, name: string, brewery: string, abv: number | null): CatalogBeer =>
+    ({ id, name, brewery, abv });
+
+  const pinta = (id: number, name: string, abv: number | null) =>
+    beer(id, name, 'PINTA Barrel Brewing', abv);
+
+  test('year match + ABV ok → returns yearMatch candidate', () => {
+    const catalog = [
+      pinta(10, 'Affection (2025)', 7.1),
+      pinta(9,  'Affection (2024)', 6.8),
+      pinta(8,  'Affection',        7.0),
+    ];
+    const m = matchBeer({ brewery: 'PINTA Barrel Brewing', name: 'Affection 2025', abv: 7.0 }, catalog);
+    expect(m?.id).toBe(10);
+    expect(m?.source).toBe('exact');
+  });
+
+  test('year match + ABV mismatch → noYear ABV hit wins', () => {
+    const catalog = [
+      pinta(10, 'Affection (2025)', 9.9),  // year matches but ABV wrong
+      pinta(8,  'Affection',        7.0),  // no year, ABV matches
+    ];
+    const m = matchBeer({ brewery: 'PINTA Barrel Brewing', name: 'Affection 2025', abv: 7.0 }, catalog);
+    expect(m?.id).toBe(8);
+  });
+
+  test('year match + ABV mismatch + no noYear → wrongYear ABV hit wins (most recent)', () => {
+    const catalog = [
+      pinta(10, 'Affection (2025)', 9.9),  // year matches but ABV wrong
+      pinta(9,  'Affection (2024)', 7.0),  // wrong year, ABV matches
+      pinta(7,  'Affection (2022)', 7.0),  // wrong year, ABV matches (older)
+    ];
+    const m = matchBeer({ brewery: 'PINTA Barrel Brewing', name: 'Affection 2025', abv: 7.0 }, catalog);
+    expect(m?.id).toBe(9);  // most recent (highest id) wrongYear with ABV match
+  });
+
+  test('year match + ABV mismatch + no alternatives → accept ABV error, return yearMatch', () => {
+    const catalog = [
+      pinta(10, 'Affection (2025)', 9.9),  // year matches, ABV wrong, nothing else
+    ];
+    const m = matchBeer({ brewery: 'PINTA Barrel Brewing', name: 'Affection 2025', abv: 7.0 }, catalog);
+    expect(m?.id).toBe(10);
+  });
+
+  test('year match + no input ABV → returns yearMatch without ABV check', () => {
+    const catalog = [
+      pinta(10, 'Affection (2025)', 9.9),
+      pinta(8,  'Affection',        7.0),
+    ];
+    const m = matchBeer({ brewery: 'PINTA Barrel Brewing', name: 'Affection 2025' }, catalog);
+    expect(m?.id).toBe(10);
+  });
+
+  test('no same-year entry → noYear fallback, ABV applied', () => {
+    const catalog = [
+      pinta(10, 'Affection (2025)', 7.1),
+      pinta(9,  'Affection (2024)', 6.8),
+      pinta(8,  'Affection',        7.0),
+    ];
+    const m = matchBeer({ brewery: 'PINTA Barrel Brewing', name: 'Affection 2023', abv: 7.0 }, catalog);
+    expect(m?.id).toBe(8);  // noYear with ABV match
+  });
+
+  test('no same-year entry → noYear fallback, most-recent when no ABV', () => {
+    const catalog = [
+      pinta(10, 'Affection (2025)', 7.1),
+      pinta(9,  'Affection (2024)', 6.8),
+      pinta(8,  'Affection',        7.0),
+      pinta(6,  'Affection',        6.5),  // older no-year entry
+    ];
+    const m = matchBeer({ brewery: 'PINTA Barrel Brewing', name: 'Affection 2023' }, catalog);
+    expect(m?.id).toBe(8);  // most recent noYear (id 8 > 6)
+  });
+
+  test('only wrong-year candidates → null (no cross-vintage match)', () => {
+    const catalog = [
+      pinta(10, 'Affection (2025)', 7.1),
+      pinta(9,  'Affection (2024)', 6.8),
+    ];
+    const m = matchBeer({ brewery: 'PINTA Barrel Brewing', name: 'Affection 2023', abv: 7.0 }, catalog);
+    expect(m).toBeNull();
+  });
+
+  test('no year in input → existing behavior (ABV then most-recent)', () => {
+    const catalog = [
+      pinta(10, 'Affection (2025)', 7.1),
+      pinta(9,  'Affection (2024)', 6.8),
+    ];
+    // No year in input name — falls through to old logic: ABV match first
+    const m = matchBeer({ brewery: 'PINTA Barrel Brewing', name: 'Affection', abv: 6.8 }, catalog);
+    expect(m?.id).toBe(9);
+  });
+});
+```
+
+- [ ] **Step 2: Verify tests fail**
+
+```bash
+cd /home/ysi/warsaw-beer-bot && npx jest matcher.test --no-coverage 2>&1 | tail -20
+```
+
+Expected: 9 new tests fail (current logic ignores year entirely).
+
+- [ ] **Step 3: Replace the exact-match selection block in `matcher.ts`**
+
+Find this block in `src/domain/matcher.ts` (currently lines 71–80):
+
+```ts
+  if (exacts.length) {
+    const wantAbv = input.abv ?? null;
+    if (wantAbv !== null) {
+      const abvHit = exacts.find(
+        (c) => c.abv !== null && Math.abs(c.abv - wantAbv) <= ABV_TOLERANCE,
+      );
+      if (abvHit) return { id: abvHit.id, confidence: 1, source: 'exact' };
+    }
+    return { id: exacts[0].id, confidence: 1, source: 'exact' };
+  }
+```
+
+Replace with:
+
+```ts
+  if (exacts.length) {
+    const wantAbv = input.abv ?? null;
+    const inputYear = extractYear(input.name);
+
+    if (inputYear === null) {
+      // No year in input — original behaviour: ABV first, else most-recent.
+      if (wantAbv !== null) {
+        const abvHit = exacts.find(
+          (c) => c.abv !== null && Math.abs(c.abv - wantAbv) <= ABV_TOLERANCE,
+        );
+        if (abvHit) return { id: abvHit.id, confidence: 1, source: 'exact' };
+      }
+      return { id: exacts[0].id, confidence: 1, source: 'exact' };
+    }
+
+    // Year found in input — partition candidates by vintage relationship.
+    // exacts is already sorted id DESC so each filtered array is too.
+    const yearMatch = exacts.filter((c) => extractYear(c.name) === inputYear);
+    const noYear    = exacts.filter((c) => extractYear(c.name) === null);
+    const wrongYear = exacts.filter(
+      (c) => { const y = extractYear(c.name); return y !== null && y !== inputYear; },
+    );
+
+    if (yearMatch.length > 0) {
+      const candidate = yearMatch[0];
+      const abvMismatch =
+        wantAbv !== null &&
+        candidate.abv !== null &&
+        Math.abs(candidate.abv - wantAbv) > ABV_TOLERANCE;
+
+      if (!abvMismatch) {
+        return { id: candidate.id, confidence: 1, source: 'exact' };
+      }
+
+      // ABV mismatch on the year-matching row — likely an ontap data entry error.
+      // Try other candidates that have a matching ABV: noYear first, then wrongYear.
+      const abvHit =
+        noYear.find((c) => c.abv !== null && Math.abs(c.abv - wantAbv) <= ABV_TOLERANCE) ??
+        wrongYear.find((c) => c.abv !== null && Math.abs(c.abv - wantAbv) <= ABV_TOLERANCE);
+      if (abvHit) return { id: abvHit.id, confidence: 1, source: 'exact' };
+
+      // Nothing with a better ABV — accept the ontap ABV error, stay on year-match.
+      return { id: candidate.id, confidence: 1, source: 'exact' };
+    }
+
+    // No same-year catalog entry — fall back to no-year entries if any exist.
+    if (noYear.length > 0) {
+      if (wantAbv !== null) {
+        const abvHit = noYear.find(
+          (c) => c.abv !== null && Math.abs(c.abv - wantAbv) <= ABV_TOLERANCE,
+        );
+        if (abvHit) return { id: abvHit.id, confidence: 1, source: 'exact' };
+      }
+      return { id: noYear[0].id, confidence: 1, source: 'exact' };
+    }
+
+    // Only wrong-year candidates exist — do not cross-match vintages.
+    return null;
+  }
+```
+
+- [ ] **Step 4: Verify all matcher tests pass**
+
+```bash
+cd /home/ysi/warsaw-beer-bot && npx jest matcher.test --no-coverage 2>&1 | tail -10
+```
+
+Expected: all tests pass (existing 28 + 6 extractYear + 9 vintage = 43 total).
+
+- [ ] **Step 5: Full suite**
+
+```bash
+cd /home/ysi/warsaw-beer-bot && npm test 2>&1 | tail -8
+```
+
+Expected: all suites green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/ysi/warsaw-beer-bot && git add src/domain/matcher.ts src/domain/matcher.test.ts && git commit -m "$(cat <<'EOF'
+feat(matcher): year-aware exact match — prefer same vintage, ABV fallback
+
+When ontap name has a 4-digit year Y, prefer catalog entries with year Y.
+If the year-match has a suspicious ABV delta (>0.3, likely ontap entry error),
+try no-year entries then wrong-year entries that have a matching ABV.
+If no same-year entry exists, fall back to no-year entries; if only
+wrong-year entries exist, return null to prevent cross-vintage matches.
+EOF
+)"
+```
+
+---
+
+## Task 3: Retroactive cleanup + verification
+
+**Files:** N/A (SQL + runtime verification)
+
+- [ ] **Step 1: Deploy updated code to production**
+
+```bash
+cd /home/ysi/warsaw-beer-bot && ./deploy/deploy.sh 2>&1 | tail -10
+```
+
+Expected: clean build and restart, no errors.
+
+- [ ] **Step 2: Delete the 3 confirmed wrong match_links**
+
+```bash
+sqlite3 /var/lib/warsaw-beer-bot/bot.db "
+DELETE FROM match_links
+WHERE ontap_ref IN (
+  'AFFECTION 2023',
+  'Farm To Glass 2026 : Citra',
+  'Farm To Glass 2026 : Mosaic'
+);
+SELECT changes() AS deleted_rows;"
+```
+
+Expected: `deleted_rows = 3`.
+
+- [ ] **Step 3: Trigger /refresh via Telegram**
+
+Send `/refresh` in Telegram to re-run the matcher on the current tap list.
+
+- [ ] **Step 4: Verify new match_links were created**
+
+```bash
+sqlite3 /var/lib/warsaw-beer-bot/bot.db "
+SELECT ml.ontap_ref, b.name, b.id, ml.confidence
+FROM match_links ml
+JOIN beers b ON b.id = ml.untappd_beer_id
+WHERE ml.ontap_ref IN (
+  'AFFECTION 2023',
+  'Farm To Glass 2026 : Citra',
+  'Farm To Glass 2026 : Mosaic'
+);" | column -t -s '|'
+```
+
+Expected: 3 rows. For `AFFECTION 2023`: `b.name` should be `Affection` (no-year fallback, since no 2023 entry exists in catalog). For the two Farm To Glass rows: should map to the `'25` entries (no 4-digit year detected in `'25` form → treated as no-year fallback).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- `extractYear` helper → Task 1 ✓
+- Year-preference (yearMatch first) → Task 2 Step 3 ✓
+- ABV-mismatch fallback chain (noYear → wrongYear → accept) → Task 2 Step 3 ✓
+- No-year fallback when no yearMatch → Task 2 Step 3 ✓
+- null when only wrongYear → Task 2 Step 3 ✓
+- No change when inputYear null → Task 2 Step 3 (inputYear === null branch) ✓
+- Retroactive cleanup of 3 wrong match_links → Task 3 ✓
+- All spec test scenarios covered by 9 new tests → Task 2 Step 1 ✓
+
+**Placeholder scan:** None. All code blocks complete, all commands have expected output. ✓
+
+**Type consistency:**
+- `extractYear` exported in Task 1, used in Task 2 implementation ✓
+- `extractYear` imported in test file in Task 1 Step 1 and used throughout ✓
+- `yearMatch`, `noYear`, `wrongYear` defined and used within same block ✓
+- `CatalogBeer` imported in test file for the `beer()` helper ✓

--- a/docs/superpowers/specs/2026-05-31-vintage-year-matching.md
+++ b/docs/superpowers/specs/2026-05-31-vintage-year-matching.md
@@ -1,0 +1,120 @@
+# Vintage Year Matching — Design Spec
+
+> **Status:** Approved for implementation (2026-05-31)
+
+## Problem
+
+`normalizeName` strips digit-only tokens (including years), so `"AFFECTION 2023"` and `"Affection (2025)"` both normalize to `"affection"`. The current `matchBeer` exact-match fallback returns the most recent catalog entry by `id DESC`, causing cross-vintage matches: ontap's 2023 beer links to the user's checked-in 2025 beer and gets filtered from `/newbeers`.
+
+**Confirmed wrong matches in DB:**
+- `AFFECTION 2023` → `Affection (2025)` (user has had both 9873 and 9847)
+- `Farm To Glass 2026 : Citra` → `Farm to Glass '25: Citra` (2026 matched to '25)
+- `Farm To Glass 2026 : Mosaic` → `Farm To Glass '25: Mosaic`
+
+## Goal
+
+When the ontap name contains an explicit 4-digit year, prefer a catalog entry with the same year. Fall back to no-year entries if no year-match exists. Use ABV to further disambiguate when a year-match has a suspicious ABV discrepancy (likely an ontap data entry error).
+
+---
+
+## Architecture
+
+### New helper: `extractYear(name: string): number | null`
+
+Extracts the first 4-digit year matching `/\b(19|20)\d{2}\b/` from a **raw** (un-normalized) name. Returns `null` if none found.
+
+Must be called on the raw `input.name`, not the normalized `nn`, because `normalizeName` strips digit tokens.
+
+### Modified exact-match selection in `matchBeer`
+
+The current exact match block (lines 63–80 in `matcher.ts`) becomes:
+
+```
+exacts = catalog entries with matching normalized brewery + name, sorted id DESC
+
+if exacts is empty → go to fuzzy (unchanged)
+
+inputYear = extractYear(input.name)
+
+if inputYear is null:
+  → existing logic: ABV hit first, else exacts[0]
+
+if inputYear is non-null:
+  yearMatch  = exacts where extractYear(c.name) === inputYear   (sorted id DESC)
+  noYear     = exacts where extractYear(c.name) === null         (sorted id DESC)
+  wrongYear  = exacts where extractYear(c.name) ∉ {inputYear, null}  (sorted id DESC)
+  // wrongYear excluded from normal selection path
+
+  if yearMatch is non-empty:
+    candidate = yearMatch[0]   (most recent year-matching entry)
+
+    abvMismatch = input.abv ≠ null
+               && candidate.abv ≠ null
+               && |input.abv − candidate.abv| > ABV_TOLERANCE (0.3)
+
+    if NOT abvMismatch:
+      → return candidate  (year matches, ABV OK or not checkable)
+
+    // ABV mismatch: likely an ontap data entry error on the year-specific row.
+    // Try alternatives that have a better ABV match.
+    abvHit = first of noYear  where |c.abv − input.abv| ≤ 0.3
+          ?? first of wrongYear (id DESC) where |c.abv − input.abv| ≤ 0.3
+    if abvHit:
+      → return abvHit
+    // Nothing with matching ABV: accept the ontap ABV error, stay on year-match.
+    → return candidate
+
+  if yearMatch is empty:
+    // No same-year catalog entry; fall back to no-year entries.
+    if noYear is non-empty:
+      → apply existing logic to noYear only (ABV hit first, else noYear[0])
+    else:
+      → return null  (only wrong-year entries exist; don't cross-match vintages)
+```
+
+### Retroactive cleanup (run after deploy)
+
+Delete the 3 confirmed wrong match_links via SQL, then run `/refresh`. The corrected matcher will re-create match_links using the new logic.
+
+```sql
+DELETE FROM match_links
+WHERE ontap_ref IN (
+  'AFFECTION 2023',
+  'Farm To Glass 2026 : Citra',
+  'Farm To Glass 2026 : Mosaic'
+);
+```
+
+After `/refresh`:
+- `AFFECTION 2023` → inputYear=2023, no 2023 in catalog, noYear=[`Affection` id=9847] → matches `Affection` (best available without 2023-specific Untappd entry)
+- `Farm To Glass 2026 : Citra` → inputYear=2026, no 2026 in catalog, noYear=[`Farm to Glass '25: Citra`] (the `'25` is not a 4-digit year) → matches `'25` entry (limitation of 4-digit detector)
+
+Note: `Affection 2023` will still map to `Affection` (id=9847) since the user has also checked in that. A proper fix requires `Affection (2023)` to exist as a separate Untappd catalog entry — which enrich-orphans cannot create without a match_link pointing to an orphan beer. This is an acceptable limitation for now.
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/domain/matcher.ts` | Add `extractYear`; replace lines 71–80 with year-aware selection |
+| `src/domain/matcher.test.ts` | New tests for year-preference, ABV-mismatch fallback, no-year fallback, wrongYear-only null |
+
+**Not changed:** `normalize.ts`, storage, bot, jobs.
+
+---
+
+## Test Cases
+
+| Scenario | Input | Catalog candidates | Expected |
+|----------|-------|-------------------|----------|
+| Year match, ABV OK | `Affection 2025, abv=7.0` | `[Affection(2025) abv=7.1, Affection(2024) abv=6.8, Affection abv=7.0]` | `Affection(2025)` |
+| Year match, ABV mismatch → noYear ABV hit | `Affection 2025, abv=7.0` | `[Affection(2025) abv=9.9, Affection abv=7.0]` | `Affection` (noYear ABV match) |
+| Year match, ABV mismatch → wrongYear ABV hit | `Affection 2025, abv=7.0` | `[Affection(2025) abv=9.9, Affection(2024) abv=7.0]` | `Affection(2024)` (wrongYear ABV match) |
+| Year match, ABV mismatch, no alternatives | `Affection 2025, abv=7.0` | `[Affection(2025) abv=9.9]` | `Affection(2025)` (accept ABV error) |
+| No year match → noYear fallback | `Affection 2023` | `[Affection(2025), Affection(2024), Affection]` | `Affection` (noYear) |
+| No year match, no noYear → null | `Affection 2023` | `[Affection(2025), Affection(2024)]` | `null` |
+| No year in input → existing behavior | `Affection, abv=7.0` | `[Affection(2025) abv=7.1, Affection(2024) abv=6.8]` | `Affection(2025)` (id DESC) |
+| noYear only with ABV | `Affection, abv=7.0` | `[Affection(2025) abv=7.1, Affection abv=7.0]` | `Affection` (ABV hit) |
+| wrongYear only → null | `Affection 2023` | `[Affection(2025)]` | `null` |
+| No year input, no year in catalog | `Affection` | `[Affection]` | `Affection` |

--- a/src/domain/matcher.test.ts
+++ b/src/domain/matcher.test.ts
@@ -103,6 +103,13 @@ describe('breweryAliases', () => {
     );
   });
 
+  test('&-connector collab returns full + each side', () => {
+    const out = breweryAliases('Moon Lark & AleBrowar Brewery');
+    expect(new Set(out)).toEqual(
+      new Set(['moon lark alebrowar', 'moon lark', 'alebrowar']),
+    );
+  });
+
   test('empty input returns empty array', () => {
     expect(breweryAliases('')).toEqual([]);
   });

--- a/src/domain/matcher.test.ts
+++ b/src/domain/matcher.test.ts
@@ -1,4 +1,4 @@
-import { matchBeer, breweryAliases, type CatalogBeer } from './matcher';
+import { matchBeer, breweryAliases, extractYear, type CatalogBeer } from './matcher';
 
 const c = (over: Partial<CatalogBeer> & { id: number }): CatalogBeer => ({
   brewery: 'Pinta',
@@ -271,4 +271,114 @@ test('ontap-style raw beer_ref + ABV maps to clean Untappd entry', () => {
     [c({ id: 99, brewery: 'Harpagan', name: 'Buzdygan Rozkoszy', abv: 8.5 })],
   );
   expect(m?.id).toBe(99);
+});
+
+describe('extractYear', () => {
+  test('finds 4-digit year in parentheses', () => {
+    expect(extractYear('Affection (2025)')).toBe(2025);
+  });
+  test('finds bare 4-digit year', () => {
+    expect(extractYear('AFFECTION 2023')).toBe(2023);
+  });
+  test('returns null when no 4-digit year present', () => {
+    expect(extractYear('Affection')).toBeNull();
+  });
+  test('ignores abbreviated 2-digit year form', () => {
+    expect(extractYear("Farm to Glass '25: Citra")).toBeNull();
+  });
+  test('1900-range year is detected', () => {
+    expect(extractYear('Vintage 1998')).toBe(1998);
+  });
+  test('number outside 19xx/20xx range is not a year', () => {
+    expect(extractYear('Tripel 888')).toBeNull();
+  });
+});
+
+describe('matchBeer — vintage year disambiguation', () => {
+  const pinta = (id: number, name: string, abv: number | null): CatalogBeer =>
+    ({ id, name, brewery: 'PINTA Barrel Brewing', abv });
+
+  test('year match + ABV ok → returns yearMatch candidate', () => {
+    const catalog = [
+      pinta(10, 'Affection (2025)', 7.1),
+      pinta(9,  'Affection (2024)', 6.8),
+      pinta(8,  'Affection',        7.0),
+    ];
+    const m = matchBeer({ brewery: 'PINTA Barrel Brewing', name: 'Affection 2025', abv: 7.0 }, catalog);
+    expect(m?.id).toBe(10);
+    expect(m?.source).toBe('exact');
+  });
+
+  test('year match + ABV mismatch → noYear ABV hit wins', () => {
+    const catalog = [
+      pinta(10, 'Affection (2025)', 9.9),
+      pinta(8,  'Affection',        7.0),
+    ];
+    const m = matchBeer({ brewery: 'PINTA Barrel Brewing', name: 'Affection 2025', abv: 7.0 }, catalog);
+    expect(m?.id).toBe(8);
+  });
+
+  test('year match + ABV mismatch + no noYear → wrongYear ABV hit wins (most recent)', () => {
+    const catalog = [
+      pinta(10, 'Affection (2025)', 9.9),
+      pinta(9,  'Affection (2024)', 7.0),
+      pinta(7,  'Affection (2022)', 7.0),
+    ];
+    const m = matchBeer({ brewery: 'PINTA Barrel Brewing', name: 'Affection 2025', abv: 7.0 }, catalog);
+    expect(m?.id).toBe(9);
+  });
+
+  test('year match + ABV mismatch + no alternatives → accept ABV error, return yearMatch', () => {
+    const catalog = [pinta(10, 'Affection (2025)', 9.9)];
+    const m = matchBeer({ brewery: 'PINTA Barrel Brewing', name: 'Affection 2025', abv: 7.0 }, catalog);
+    expect(m?.id).toBe(10);
+  });
+
+  test('year match + no input ABV → returns yearMatch without ABV check', () => {
+    const catalog = [
+      pinta(10, 'Affection (2025)', 9.9),
+      pinta(8,  'Affection',        7.0),
+    ];
+    const m = matchBeer({ brewery: 'PINTA Barrel Brewing', name: 'Affection 2025' }, catalog);
+    expect(m?.id).toBe(10);
+  });
+
+  test('no same-year entry → noYear fallback, ABV applied', () => {
+    const catalog = [
+      pinta(10, 'Affection (2025)', 7.1),
+      pinta(9,  'Affection (2024)', 6.8),
+      pinta(8,  'Affection',        7.0),
+    ];
+    const m = matchBeer({ brewery: 'PINTA Barrel Brewing', name: 'Affection 2023', abv: 7.0 }, catalog);
+    expect(m?.id).toBe(8);
+  });
+
+  test('no same-year entry → noYear fallback, most-recent when no ABV', () => {
+    const catalog = [
+      pinta(10, 'Affection (2025)', 7.1),
+      pinta(9,  'Affection (2024)', 6.8),
+      pinta(8,  'Affection',        7.0),
+      pinta(6,  'Affection',        6.5),
+    ];
+    const m = matchBeer({ brewery: 'PINTA Barrel Brewing', name: 'Affection 2023' }, catalog);
+    expect(m?.id).toBe(8);
+  });
+
+  test('only wrong-year candidates → null (no cross-vintage match)', () => {
+    const catalog = [
+      pinta(10, 'Affection (2025)', 7.1),
+      pinta(9,  'Affection (2024)', 6.8),
+    ];
+    const m = matchBeer({ brewery: 'PINTA Barrel Brewing', name: 'Affection 2023', abv: 7.0 }, catalog);
+    expect(m).toBeNull();
+  });
+
+  test('no year in input → existing behavior (ABV then most-recent)', () => {
+    const catalog = [
+      pinta(10, 'Affection (2025)', 8.5),  // outside 0.3 tolerance of 6.8
+      pinta(9,  'Affection (2024)', 6.8),  // exact ABV match
+    ];
+    const m = matchBeer({ brewery: 'PINTA Barrel Brewing', name: 'Affection', abv: 6.8 }, catalog);
+    expect(m?.id).toBe(9);
+  });
 });

--- a/src/domain/matcher.ts
+++ b/src/domain/matcher.ts
@@ -20,9 +20,10 @@ const ABV_TOLERANCE = 0.3;
 // Separator regex for collab/bilingual brewery names. Untappd uses:
 //   "A / B"  — slash with any spacing (bilingual or collab)
 //   "A x B"  — " x "/" X " connector (collab, case-insensitive)
+//   "A & B"  — " & " connector (collab)
 //   "A (B)"  — paren form for German aliases
 // Ontap.pl renders only one side. All forms collapse to: "any side is valid".
-export const COLLAB_SEP = /\s*\/\s*|\s+[Xx]\s+/;
+export const COLLAB_SEP = /\s*\/\s*|\s+[Xx]\s+|\s+&\s+/;
 
 export function breweryAliases(brewery: string): string[] {
   const aliases = new Set<string>();

--- a/src/domain/matcher.ts
+++ b/src/domain/matcher.ts
@@ -25,6 +25,13 @@ const ABV_TOLERANCE = 0.3;
 // Ontap.pl renders only one side. All forms collapse to: "any side is valid".
 export const COLLAB_SEP = /\s*\/\s*|\s+[Xx]\s+|\s+&\s+/;
 
+// Extracts the first 4-digit calendar year (1900–2099) from a raw beer name.
+// Called on the un-normalized name because normalizeName strips digit tokens.
+export function extractYear(name: string): number | null {
+  const m = name.match(/\b(19|20)\d{2}\b/);
+  return m ? parseInt(m[0], 10) : null;
+}
+
 export function breweryAliases(brewery: string): string[] {
   const aliases = new Set<string>();
   const full = normalizeBrewery(brewery);
@@ -70,13 +77,62 @@ export function matchBeer(
 
   if (exacts.length) {
     const wantAbv = input.abv ?? null;
-    if (wantAbv !== null) {
-      const abvHit = exacts.find(
-        (c) => c.abv !== null && Math.abs(c.abv - wantAbv) <= ABV_TOLERANCE,
-      );
-      if (abvHit) return { id: abvHit.id, confidence: 1, source: 'exact' };
+    const inputYear = extractYear(input.name);
+
+    if (inputYear === null) {
+      // No year in input — original behaviour: ABV first, else most-recent.
+      if (wantAbv !== null) {
+        const abvHit = exacts.find(
+          (c) => c.abv !== null && Math.abs(c.abv - wantAbv) <= ABV_TOLERANCE,
+        );
+        if (abvHit) return { id: abvHit.id, confidence: 1, source: 'exact' };
+      }
+      return { id: exacts[0].id, confidence: 1, source: 'exact' };
     }
-    return { id: exacts[0].id, confidence: 1, source: 'exact' };
+
+    // Year found in input — partition candidates by vintage relationship.
+    // exacts is already sorted id DESC so each filtered array preserves that order.
+    const yearMatch = exacts.filter((c) => extractYear(c.name) === inputYear);
+    const noYear    = exacts.filter((c) => extractYear(c.name) === null);
+    const wrongYear = exacts.filter(
+      (c) => { const y = extractYear(c.name); return y !== null && y !== inputYear; },
+    );
+
+    if (yearMatch.length > 0) {
+      const candidate = yearMatch[0];
+      const abvMismatch =
+        wantAbv !== null &&
+        candidate.abv !== null &&
+        Math.abs(candidate.abv - wantAbv) > ABV_TOLERANCE;
+
+      if (!abvMismatch) {
+        return { id: candidate.id, confidence: 1, source: 'exact' };
+      }
+
+      // ABV mismatch on the year-matching row — likely an ontap data entry error.
+      // Try other candidates that have a matching ABV: noYear first, then wrongYear.
+      const abvHit =
+        noYear.find((c) => c.abv !== null && Math.abs(c.abv - wantAbv) <= ABV_TOLERANCE) ??
+        wrongYear.find((c) => c.abv !== null && Math.abs(c.abv - wantAbv) <= ABV_TOLERANCE);
+      if (abvHit) return { id: abvHit.id, confidence: 1, source: 'exact' };
+
+      // Nothing with a better ABV — accept the ontap ABV error, stay on year-match.
+      return { id: candidate.id, confidence: 1, source: 'exact' };
+    }
+
+    // No same-year catalog entry — fall back to no-year entries if any exist.
+    if (noYear.length > 0) {
+      if (wantAbv !== null) {
+        const abvHit = noYear.find(
+          (c) => c.abv !== null && Math.abs(c.abv - wantAbv) <= ABV_TOLERANCE,
+        );
+        if (abvHit) return { id: abvHit.id, confidence: 1, source: 'exact' };
+      }
+      return { id: noYear[0].id, confidence: 1, source: 'exact' };
+    }
+
+    // Only wrong-year candidates exist — do not cross-match vintages.
+    return null;
   }
 
   // Fuzzy fallback: prefer rows whose brewery aliases overlap the input's,

--- a/src/jobs/untappd-enrich.test.ts
+++ b/src/jobs/untappd-enrich.test.ts
@@ -146,6 +146,42 @@ describe('enrichOneOrphan', () => {
     expect(httpCalled).toBe(false);
   });
 
+  test('duplicate untappd_id: merges orphan into canonical, returns not_found', async () => {
+    const db = fresh();
+
+    // Canonical entry already has untappd_id=999.
+    const canonicalId = upsertBeer(db, {
+      untappd_id: 999,
+      name: 'Marine', brewery: 'Moon Lark Brewery',
+      style: null, abv: null, rating_global: null,
+      normalized_name: 'marine', normalized_brewery: 'moon lark',
+    });
+
+    // Orphan for the same Untappd beer (collab ontap name, no untappd_id).
+    const orphanId = upsertBeer(db, {
+      name: 'Marine', brewery: 'Moon Lark & AleBrowar Brewery',
+      style: null, abv: null, rating_global: null,
+      normalized_name: 'marine', normalized_brewery: 'moon lark alebrowar',
+    });
+    db.prepare('INSERT INTO match_links (ontap_ref, untappd_beer_id, confidence) VALUES (?,?,1)')
+      .run('Marine ontap', orphanId);
+
+    // Untappd returns bid=999 — same as canonical.
+    const http = fakeHttp(searchHtml([
+      { bid: 999, name: 'Marine', brewery: 'Moon Lark Brewery' },
+    ]));
+
+    const out = await enrichOneOrphan({ db, log: silentLog, http }, orphanId);
+
+    expect(out).toBe('not_found');
+    // Orphan row deleted.
+    expect(getBeer(db, orphanId)).toBeNull();
+    // match_link redirected to canonical.
+    const ml = db.prepare('SELECT untappd_beer_id FROM match_links WHERE ontap_ref = ?')
+      .get('Marine ontap') as { untappd_beer_id: number } | undefined;
+    expect(ml?.untappd_beer_id).toBe(canonicalId);
+  });
+
   test('skipped: beer does not exist (defensive)', async () => {
     const db = fresh();
     let httpCalled = false;

--- a/src/jobs/untappd-enrich.ts
+++ b/src/jobs/untappd-enrich.ts
@@ -8,6 +8,7 @@ import {
   recordLookupSuccess,
   recordLookupNotFound,
   recordLookupTransient,
+  mergeIntoCanonical,
 } from '../storage/beers';
 
 export type EnrichOutcomeKind = 'matched' | 'not_found' | 'transient' | 'skipped';
@@ -40,8 +41,25 @@ export async function enrichOneOrphan(
   const nowIso = now.toISOString();
   switch (outcome.kind) {
     case 'matched':
-      recordLookupSuccess(deps.db, beerId, outcome.result);
-      return 'matched';
+      try {
+        recordLookupSuccess(deps.db, beerId, outcome.result);
+        return 'matched';
+      } catch (e: unknown) {
+        if ((e as { code?: string }).code !== 'SQLITE_CONSTRAINT_UNIQUE') throw e;
+        // The found untappd_id already belongs to another catalog entry.
+        // Redirect match_links to that canonical row and delete this orphan.
+        const canonical = deps.db
+          .prepare('SELECT id FROM beers WHERE untappd_id = ?')
+          .get(outcome.result.bid) as { id: number } | undefined;
+        if (canonical) {
+          mergeIntoCanonical(deps.db, beerId, canonical.id);
+          deps.log.warn(
+            { beerId, canonicalId: canonical.id, bid: outcome.result.bid },
+            'enrich: merged duplicate orphan into canonical',
+          );
+        }
+        return 'not_found';
+      }
     case 'not_found':
       recordLookupNotFound(deps.db, beerId, nowIso);
       return 'not_found';

--- a/src/storage/beers.ts
+++ b/src/storage/beers.ts
@@ -92,6 +92,15 @@ export function recordLookupSuccess(
   ).run(r.bid, r.style, r.abv, r.global_rating, beerId);
 }
 
+// Merges an orphan beer into a canonical catalog entry by redirecting all
+// match_links and deleting the orphan. Called when recordLookupSuccess hits a
+// UNIQUE constraint (the found untappd_id already belongs to another row).
+export function mergeIntoCanonical(db: DB, orphanId: number, canonicalId: number): void {
+  db.prepare('UPDATE match_links SET untappd_beer_id = ? WHERE untappd_beer_id = ?')
+    .run(canonicalId, orphanId);
+  db.prepare('DELETE FROM beers WHERE id = ?').run(orphanId);
+}
+
 export function recordLookupNotFound(db: DB, beerId: number, at: string): void {
   db.prepare(
     `UPDATE beers SET


### PR DESCRIPTION
## Summary

### ` & ` collab separator (` feat(matcher): add ' & ' collab separator`)
- `breweryAliases` now splits on ` & ` (e.g. `Moon Lark & AleBrowar Brewery`) alongside `/` and ` x `
- Fixes enrich-orphans search for `&`-style collab beers

### Year-aware exact matching (`feat(matcher): year-aware exact match`)
- New `extractYear(name)` helper detects 4-digit vintage year (1900–2099) in raw beer names
- `matchBeer` exact-match selection now prefers catalog entries with the same year
- ABV-mismatch escape hatch: if the year-match has suspicious ABV, tries no-year then wrong-year entries with matching ABV
- If no same-year catalog entry: falls back to no-year entries; if only wrong-year: returns `null` (no cross-vintage match)
- **Root cause fixed:** `AFFECTION 2023` was matching `Affection (2025)` (user had that, so 2023 filtered from `/newbeers`)

### Enrich duplicate handling (`fix(enrich): handle UNIQUE constraint`)
- `recordLookupSuccess` was crashing every 3h with `SQLITE_CONSTRAINT_UNIQUE` when an orphan's lookup found a `bid` already in another catalog row
- New `mergeIntoCanonical(db, orphanId, canonicalId)` in `beers.ts`: redirects match_links and deletes the orphan
- `enrichOneOrphan` catches `SQLITE_CONSTRAINT_UNIQUE`, calls merge, returns `not_found`

### Deploy: chown ENVDIR
- `deploy.sh` now re-asserts `warsaw-beer-bot` ownership of `/etc/warsaw-beer-bot/` files so `refresh-cookie.sh` works passwordlessly after every deploy

## Test plan
- [x] `npm test` green — 361 tests, 43 suites
- [x] `npm run typecheck` clean
- [x] Deployed and verified: `Affection (2023)` appears in `/newbeers pinta`
- [x] enrich-orphans cron no longer crashes (duplicate `Marine` merged manually, code handles future cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)