### PR TITLE
feat(newbeers): pub disambiguation by address in pubQuery

### DIFF
--- a/docs/superpowers/plans/2026-06-01-pub-query-disambiguation.md
+++ b/docs/superpowers/plans/2026-06-01-pub-query-disambiguation.md
@@ -1,0 +1,227 @@
+# Pub Query Disambiguation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Дозволити команді `/newbeers` розрізняти паби-двійники за адресою через запит (`pinta nowogrodzka` → тільки Nowogrodzka pub).
+
+**Architecture:** Витягуємо чисту функцію `filterPubsByQuery` з `newbeers-build.ts` яка реалізує двоетапний пошук: спочатку підрядок у назві, потім слова у `(name + address)` як уточнювач або fallback. `buildNewbeersMessage` делегує фільтрацію цій функції. `NewbeersResult` та `BeerGroup` — без змін.
+
+**Tech Stack:** TypeScript, Jest, SQLite (better-sqlite3), наявні helpers у `src/bot/commands/newbeers-build.test.ts`.
+
+---
+
+## File Map
+
+| Файл | Дія |
+|---|---|
+| `src/bot/commands/newbeers-build.ts` | Додати `filterPubsByQuery` як named export; замінити inline-логіку |
+| `src/bot/commands/newbeers-build.test.ts` | Додати `describe('filterPubsByQuery')` з 6 тестами |
+
+---
+
+## Task 1: Скинути uncommitted чернетку
+
+**Files:**
+- Modify: `src/bot/commands/newbeers-build.ts`
+- Modify: `src/bot/commands/newbeers-build.test.ts`
+
+- [ ] **Step 1: Переконатися що uncommitted зміни існують**
+
+```bash
+git diff --stat HEAD
+```
+
+Expected: обидва файли показані як змінені.
+
+- [ ] **Step 2: Скинути обидва файли до HEAD**
+
+```bash
+git checkout HEAD -- src/bot/commands/newbeers-build.ts src/bot/commands/newbeers-build.test.ts
+```
+
+Expected: no output (clean checkout).
+
+- [ ] **Step 3: Перевірити що тести проходять у базовому стані**
+
+```bash
+npx jest newbeers-build --no-coverage 2>&1 | tail -15
+```
+
+Expected: `Tests: X passed` (без нових тестів), suite green.
+
+---
+
+## Task 2: Написати failing тести для `filterPubsByQuery`
+
+**Files:**
+- Modify: `src/bot/commands/newbeers-build.test.ts`
+
+- [ ] **Step 1: Додати import `filterPubsByQuery` та describe-блок з 6 тестами**
+
+Додати в кінець файлу `src/bot/commands/newbeers-build.test.ts` (перед останньою `}`):
+
+```typescript
+import { filterPubsByQuery } from './newbeers-build';
+```
+
+Замінити рядок 8 файлу (існуючий import):
+```typescript
+import { buildNewbeersMessage, filterPubsByQuery } from './newbeers-build';
+```
+
+Додати перед останнім `});` файлу новий describe-блок:
+
+```typescript
+describe('filterPubsByQuery', () => {
+  const pubChmielna = {
+    id: 1, slug: 'pinta-chmielna', name: 'PINTA Warszawa',
+    address: 'Chmielna 7/9, Warszawa', lat: null, lon: null,
+  };
+  const pubNowogrodzka = {
+    id: 2, slug: 'pinta-nowogrodzka', name: 'PINTA Warszawa',
+    address: 'Nowogrodzka 4, Warszawa', lat: null, lon: null,
+  };
+  const pubKufel = {
+    id: 3, slug: 'kufel', name: 'Kufel i Chmiel',
+    address: 'Nowy Swiat 22, Warszawa', lat: null, lon: null,
+  };
+  const allPubs = [pubChmielna, pubNowogrodzka, pubKufel];
+
+  test('unique name-match returns that pub without address check', () => {
+    expect(filterPubsByQuery(allPubs, 'kufel')).toEqual([pubKufel]);
+  });
+
+  test('2 name-matches without disambiguating word returns both', () => {
+    expect(filterPubsByQuery(allPubs, 'pinta warszawa')).toEqual([pubChmielna, pubNowogrodzka]);
+  });
+
+  test('2 name-matches + address word narrows to Nowogrodzka', () => {
+    expect(filterPubsByQuery(allPubs, 'pinta nowogrodzka')).toEqual([pubNowogrodzka]);
+  });
+
+  test('2 name-matches + address word narrows to Chmielna', () => {
+    expect(filterPubsByQuery(allPubs, 'pinta chmielna')).toEqual([pubChmielna]);
+  });
+
+  test('0 name-matches uses address fallback', () => {
+    expect(filterPubsByQuery(allPubs, 'nowogrodzka')).toEqual([pubNowogrodzka]);
+  });
+
+  test('unknown query returns empty array', () => {
+    expect(filterPubsByQuery(allPubs, 'xxxxxx')).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Запустити тести — мають впасти через відсутній export**
+
+```bash
+npx jest newbeers-build --no-coverage 2>&1 | tail -15
+```
+
+Expected: compile error — `Module '"./newbeers-build"' has no exported member 'filterPubsByQuery'`.
+
+---
+
+## Task 3: Реалізувати `filterPubsByQuery` та інтегрувати в `buildNewbeersMessage`
+
+**Files:**
+- Modify: `src/bot/commands/newbeers-build.ts`
+
+- [ ] **Step 1: Додати import `PubRow` та нову функцію перед `buildNewbeersMessage`**
+
+Додати до рядка з imports у верхівці `src/bot/commands/newbeers-build.ts`:
+
+```typescript
+import { listPubs, type PubRow } from '../../storage/pubs';
+```
+
+(замінити існуючий `import { listPubs }` — додати `, type PubRow`).
+
+Додати одразу після блоку imports (перед `export interface NewbeersDeps`):
+
+```typescript
+export function filterPubsByQuery(pubs: PubRow[], query: string): PubRow[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return pubs;
+
+  const nameMatches = pubs.filter((p) => p.name.toLowerCase().includes(q));
+
+  if (nameMatches.length === 1) return nameMatches;
+
+  const words = q.split(/\s+/).filter(Boolean);
+  const searchBase = nameMatches.length === 0 ? pubs : nameMatches;
+  const combined = searchBase.filter((p) =>
+    words.every((w) => (p.name + ' ' + (p.address ?? '')).toLowerCase().includes(w)),
+  );
+
+  if (nameMatches.length === 0) return combined;
+  return combined.length === 1 ? combined : nameMatches;
+}
+```
+
+- [ ] **Step 2: Замінити inline-логіку в `buildNewbeersMessage`**
+
+Замінити весь блок `if (q) { ... }` в `buildNewbeersMessage` (приблизно рядки 44–70) на:
+
+```typescript
+  if (q) {
+    const filtered = filterPubsByQuery([...pubs.values()], q);
+    if (filtered.length === 0) return { kind: 'pub_not_found', query: deps.pubQuery! };
+    matchedIds = new Set(filtered.map((p) => p.id));
+  }
+```
+
+- [ ] **Step 3: Запустити тести `filterPubsByQuery` — мають пройти**
+
+```bash
+npx jest newbeers-build --no-coverage 2>&1 | tail -15
+```
+
+Expected: всі 6 нових тестів + існуючі — `Tests: N passed`, suite green.
+
+- [ ] **Step 4: Запустити повний suite**
+
+```bash
+npx jest --no-coverage 2>&1 | tail -10
+```
+
+Expected: `Test Suites: X passed`, `Tests: Y passed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bot/commands/newbeers-build.ts src/bot/commands/newbeers-build.test.ts
+git commit -m "$(cat <<'EOF'
+feat(newbeers): pub disambiguation by address in pubQuery
+
+Extract filterPubsByQuery: name substring match first (unique → done),
+then word-by-word on (name + address) as tiebreaker for duplicates or
+address-only fallback when no name matches. Allows 'pinta nowogrodzka'
+to narrow two same-named pubs to the one on Nowogrodzka.
+EOF
+)"
+```
+
+Expected: commit hash printed, `nothing to commit` on follow-up `git status`.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Unique name-match → step 3, test 1 ✓
+- 2 name-matches, no disambiguating word → test 2 ✓
+- 2 name-matches + address word → tests 3 & 4 ✓
+- Address-only fallback → test 5 ✓
+- Unknown query → test 6 + `pub_not_found` in step 3 implementation ✓
+- `NewbeersResult` unchanged → `buildNewbeersMessage` return type not touched ✓
+- `BeerGroup` unchanged → `newbeers-format.ts` not touched ✓
+- Uncommitted draft discarded → Task 1 ✓
+
+**Placeholder scan:** Немає TBD/TODO, всі кроки мають повний код. ✓
+
+**Type consistency:**
+- `filterPubsByQuery` визначена в Task 3 Step 1, імпортована в тестах в Task 2 Step 1 ✓
+- `PubRow` — тип з `src/storage/pubs.ts`, використовується як параметр `filterPubsByQuery` ✓
+- Fixtures в тестах відповідають структурі `PubRow` (`id, slug, name, address, lat, lon`) ✓

--- a/docs/superpowers/specs/2026-06-01-pub-query-disambiguation-design.md
+++ b/docs/superpowers/specs/2026-06-01-pub-query-disambiguation-design.md
@@ -1,0 +1,97 @@
+# Pub Query Disambiguation — дизайн-документ
+
+> Статус: **spec approved, pending implementation**
+> Дата: 2026-06-01
+
+## 1. Проблема
+
+В ontap.pl є два паби з однаковою назвою «PINTA Warszawa» на різних вулицях
+(Chmielna та Nowogrodzka). Команда `/newbeers pinta nowogrodzka` має показувати
+пиво тільки з одного паба, але зараз не може — `pubQuery` перевіряє лише
+підрядок у назві, а обидва паби мають однакову назву.
+
+## 2. Вимоги
+
+| Запит | Очікуваний результат |
+|---|---|
+| `pinta` | обидва паби (стара поведінка збережена) |
+| `pinta nowogrodzka` | тільки PINTA на Новогродзькій |
+| `pinta chmielna` | тільки PINTA на Хмельній |
+| `nowogrodzka` | паби де «nowogrodzka» є в адресі |
+| унікальна назва (1 match) | цей один паб, адреса не перевіряється |
+| невідомий запит | `pub_not_found` |
+
+## 3. Дизайн
+
+### 3.1 Нова чиста функція
+
+```ts
+export function filterPubsByQuery(pubs: Pub[], query: string): Pub[]
+```
+
+Розташування: `src/bot/commands/newbeers-build.ts` (named export).
+
+**Алгоритм (два етапи):**
+
+**Етап 1 — name-match:**
+`nameMatches` = паби де `pub.name.toLowerCase()` містить `query` як підрядок.
+
+- `nameMatches.length === 1` → повернути `[nameMatches[0]]` (адреса не потрібна)
+- `nameMatches.length === 0` → перейти до address fallback (§ нижче)
+- `nameMatches.length >= 2` → перейти до address tiebreaker (§ нижче)
+
+**Address fallback (0 name-matches):**
+Розбити `query` на слова (`/\s+/`). Повернути паби де кожне слово є в
+`(pub.name + ' ' + (pub.address ?? '')).toLowerCase()`.
+Порожній результат = `pub_not_found`.
+
+**Address tiebreaker (2+ name-matches):**
+Серед `nameMatches` залишити паби де кожне слово query є в `(name + ' ' + address)`.
+- Звузилось до 1 → повернути його
+- Інакше → повернути всі `nameMatches` (стара поведінка)
+
+**Обґрунтування двох етапів:** якщо спочатку name-match не виконується,
+слово запиту може збігтись з назвою іншого паба в його адресі і дати хибний
+результат. Name-match має пріоритет над address-match.
+
+### 3.2 Інтеграція в `buildNewbeersMessage`
+
+Inline-логіку фільтрації пабів замінити на виклик `filterPubsByQuery`.
+`pub_not_found` повертається якщо результат порожній при непорожньому запиті.
+
+### 3.3 Тип `NewbeersResult` — без змін
+
+```ts
+type NewbeersResult =
+  | { kind: 'ok'; html: string }
+  | { kind: 'empty' }
+  | { kind: 'pub_not_found'; query: string };
+```
+
+`BeerGroup` і `newbeers-format.ts` — без змін.
+
+## 4. Тестування
+
+Тести для `filterPubsByQuery` у `newbeers-build.test.ts`, з fixture-пабами
+в пам'яті (без DB):
+
+| Сценарій | Вхід | Очікуваний результат |
+|---|---|---|
+| Унікальний name-match | `'pinta chmielna unique'` | `[pubChmielna]` |
+| 2 name-matches, tiebreaker → 1 | `'pinta nowogrodzka'` | `[pubNowogrodzka]` |
+| 2 name-matches, tiebreaker → 1 | `'pinta chmielna'` | `[pubChmielna]` |
+| 2 name-matches, tiebreaker → 2 | `'pinta warszawa'` | обидва |
+| Address fallback → 1 | `'nowogrodzka'` | `[pubNowogrodzka]` |
+| Address fallback → not found | `'xxxxxx'` | `[]` |
+
+Існуючі тести `buildNewbeersMessage` на HTML-вміст — **без змін**.
+Нові uncommitted тести з `out.groups` / `pub_ids` — **видалити**.
+
+## 5. Зміни у файлах
+
+| Файл | Дія |
+|---|---|
+| `src/bot/commands/newbeers-build.ts` | витягти `filterPubsByQuery`, замінити inline-логіку |
+| `src/bot/commands/newbeers-build.test.ts` | видалити тести з `out.groups`, додати тести `filterPubsByQuery` |
+| `src/bot/commands/newbeers-format.ts` | без змін |
+| решта | без змін |

--- a/src/bot/commands/newbeers-build.test.ts
+++ b/src/bot/commands/newbeers-build.test.ts
@@ -5,7 +5,7 @@ import { createSnapshot, insertTaps } from '../../storage/snapshots';
 import { upsertBeer } from '../../storage/beers';
 import { upsertMatch } from '../../storage/match_links';
 import { createTranslator } from '../../i18n';
-import { buildNewbeersMessage } from './newbeers-build';
+import { buildNewbeersMessage, filterPubsByQuery } from './newbeers-build';
 
 function fresh() {
   const db = openDb(':memory:');
@@ -164,5 +164,45 @@ describe('buildNewbeersMessage', () => {
     // Both pubs visible — same as no-arg call.
     expect(out.html).toContain('Pub A');
     expect(out.html).toContain('Pub B');
+  });
+});
+
+describe('filterPubsByQuery', () => {
+  const pubChmielna = {
+    id: 1, slug: 'pinta-chmielna', name: 'PINTA Warszawa',
+    address: 'Chmielna 7/9, Warszawa', lat: null, lon: null,
+  };
+  const pubNowogrodzka = {
+    id: 2, slug: 'pinta-nowogrodzka', name: 'PINTA Warszawa',
+    address: 'Nowogrodzka 4, Warszawa', lat: null, lon: null,
+  };
+  const pubKufel = {
+    id: 3, slug: 'kufel', name: 'Kufel i Chmiel',
+    address: 'Nowy Swiat 22, Warszawa', lat: null, lon: null,
+  };
+  const allPubs = [pubChmielna, pubNowogrodzka, pubKufel];
+
+  test('unique name-match returns that pub without address check', () => {
+    expect(filterPubsByQuery(allPubs, 'kufel')).toEqual([pubKufel]);
+  });
+
+  test('2 name-matches without disambiguating word returns both', () => {
+    expect(filterPubsByQuery(allPubs, 'pinta warszawa')).toEqual([pubChmielna, pubNowogrodzka]);
+  });
+
+  test('2 name-matches + address word narrows to Nowogrodzka', () => {
+    expect(filterPubsByQuery(allPubs, 'pinta nowogrodzka')).toEqual([pubNowogrodzka]);
+  });
+
+  test('2 name-matches + address word narrows to Chmielna', () => {
+    expect(filterPubsByQuery(allPubs, 'pinta chmielna')).toEqual([pubChmielna]);
+  });
+
+  test('0 name-matches uses address fallback', () => {
+    expect(filterPubsByQuery(allPubs, 'nowogrodzka')).toEqual([pubNowogrodzka]);
+  });
+
+  test('unknown query returns empty array', () => {
+    expect(filterPubsByQuery(allPubs, 'xxxxxx')).toEqual([]);
   });
 });

--- a/src/bot/commands/newbeers-build.ts
+++ b/src/bot/commands/newbeers-build.ts
@@ -4,7 +4,7 @@ import { latestSnapshotsPerPub, tapsForSnapshotWithBeer } from '../../storage/sn
 import { triedBeerIds } from '../../storage/untappd_had';
 import { getFilters } from '../../storage/user_filters';
 import { filterInteresting } from '../../domain/filters';
-import { listPubs } from '../../storage/pubs';
+import { listPubs, type PubRow } from '../../storage/pubs';
 import { normalizeBrewery, normalizeName } from '../../domain/normalize';
 import {
   groupTaps,
@@ -12,6 +12,24 @@ import {
   formatGroupedBeers,
   type CandidateTap,
 } from './newbeers-format';
+
+export function filterPubsByQuery(pubs: PubRow[], query: string): PubRow[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return pubs;
+
+  const nameMatches = pubs.filter((p) => p.name.toLowerCase().includes(q));
+
+  if (nameMatches.length === 1) return nameMatches;
+
+  const words = q.split(/\s+/).filter(Boolean);
+  const searchBase = nameMatches.length === 0 ? pubs : nameMatches;
+  const combined = searchBase.filter((p) =>
+    words.every((w) => (p.name + ' ' + (p.address ?? '')).toLowerCase().includes(w)),
+  );
+
+  if (nameMatches.length === 0) return combined;
+  return combined.length === 1 ? combined : nameMatches;
+}
 
 export interface NewbeersDeps {
   db: DB;
@@ -39,15 +57,12 @@ export function buildNewbeersMessage(deps: NewbeersDeps): NewbeersResult {
     };
   const pubs = new Map(listPubs(db).map((p) => [p.id, p]));
 
-  const q = deps.pubQuery?.trim().toLowerCase();
+  const q = deps.pubQuery?.trim().toLowerCase() ?? '';
   let matchedIds: Set<number> | null = null;
   if (q) {
-    const matched = [...pubs.values()].filter((p) => p.name.toLowerCase().includes(q));
-    if (matched.length === 0) {
-      // Preserve user's original casing/whitespace in the error message.
-      return { kind: 'pub_not_found', query: deps.pubQuery! };
-    }
-    matchedIds = new Set(matched.map((p) => p.id));
+    const filtered = filterPubsByQuery([...pubs.values()], q);
+    if (filtered.length === 0) return { kind: 'pub_not_found', query: deps.pubQuery! };
+    matchedIds = new Set(filtered.map((p) => p.id));
   }
 
   const candidates: CandidateTap[] = [];


### PR DESCRIPTION
## Summary

- Extract `filterPubsByQuery(pubs, query)` as a named export from `newbeers-build.ts`
- Two-phase algorithm: name substring match first (unique → done), then word-by-word on `(name + address)` as tiebreaker for duplicates or address-only fallback when no name matches
- Allows `/newbeers pinta nowogrodzka` to narrow two same-named pubs to the one on Nowogrodzka street, while `/newbeers pinta` preserves old behavior (both pubs)

## Test Plan

- [ ] 6 unit tests for `filterPubsByQuery` (pure function, no DB): unique name-match, 2 name-matches without/with address disambiguation, address-only fallback, unknown query
- [ ] All 367 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)