### PR TITLE
fix(deploy): exclude *.png from rsync to /opt

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -20,6 +20,7 @@ sudo rsync -a --delete \
   --exclude .git \
   --exclude .worktrees \
   --exclude dist \
+  --exclude '*.png' \
   ./ "$APP"/
 
 # rsync -a preserves source ownership (root); reset before npm runs as warsaw-beer-bot.

--- a/deploy/sudoers.d/warsaw-beer-bot
+++ b/deploy/sudoers.d/warsaw-beer-bot
@@ -22,7 +22,7 @@ Cmnd_Alias WBB_DEPLOY_FILES = \
     /usr/bin/install -d -o warsaw-beer-bot -g warsaw-beer-bot -m 750 /home/warsaw-beer-bot, \
     /usr/bin/install -m 0644 deploy/warsaw-beer-bot.service /etc/systemd/system/warsaw-beer-bot.service, \
     /usr/bin/install -m 0644 deploy/litestream.service /etc/systemd/system/litestream.service, \
-    /usr/bin/rsync -a --delete --exclude node_modules --exclude tests --exclude docs --exclude .git --exclude .worktrees --exclude dist ./ /opt/warsaw-beer-bot/, \
+    /usr/bin/rsync -a --delete --exclude node_modules --exclude tests --exclude docs --exclude .git --exclude .worktrees --exclude dist --exclude *.png ./ /opt/warsaw-beer-bot/, \
     /usr/bin/chown -R warsaw-beer-bot\:warsaw-beer-bot /opt/warsaw-beer-bot, \
     /usr/bin/chown -R warsaw-beer-bot\:warsaw-beer-bot /etc/warsaw-beer-bot
 


### PR DESCRIPTION
## Summary
Stray root-level artifacts (e.g. `task.txt`, `Screenshot ….png`) get rsynced into the prod working copy at `/opt/warsaw-beer-bot`, because `deploy.sh` rsyncs the whole working tree. This adds `--exclude '*.png'` to the deploy rsync to stop screenshots leaking into prod.

- `deploy/deploy.sh` — add `--exclude '*.png'` to the rsync.
- `deploy/sudoers.d/warsaw-beer-bot` — mirror the same `--exclude *.png` in the pinned rsync command. **This is required:** the NOPASSWD sudoers entry matches the rsync command line exactly, so the two must stay in lockstep or `sudo rsync` will start prompting for a password.
- `visudo -cf deploy/sudoers.d/warsaw-beer-bot` → `parsed OK`.

## ⚠️ One-time host step (before the next deploy)
The installed `/etc/sudoers.d/warsaw-beer-bot` must be re-installed from the updated file, or the next deploy's rsync will fail the NOPASSWD match:

```
sudo visudo -cf deploy/sudoers.d/warsaw-beer-bot
sudo install -m 0440 -o root -g root \
  deploy/sudoers.d/warsaw-beer-bot /etc/sudoers.d/warsaw-beer-bot
```

## Test Plan
- [x] `visudo -cf` validates the updated sudoers fragment
- [ ] After host sudoers reinstall: `./deploy/deploy.sh` runs rsync without a password prompt and `/opt` contains no `*.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)