### PR TITLE
fix(abv): prefer authoritative Untappd ABV over garbage tap ABV

### DIFF
--- a/docs/investigations/abv-ibu-swap-gardees.md
+++ b/docs/investigations/abv-ibu-swap-gardees.md
@@ -1,0 +1,117 @@
+# Investigation: ABV/IBU swapped for "GARDEES II - 2025"
+
+**Date:** 2026-06-03
+**Symptom:** Beer line rendered as
+`24 • Brasserie La Malpolon Brewery GARDEES II - 2025 • 40% • 3.9 • 🟢`
+ABV shows **40%**, impossible for a Bière de Garde.
+
+## Phase 1 — Root cause investigation
+
+### Evidence chain
+
+1. **`beers` table** (matched beer, `untappd_id=6400148`):
+   - `abv` = **NULL**, `rating_global` = 3.85 (→ "3.9" on screen ✓).
+   - So the displayed `40%` does **not** come from `beers.abv`. It falls back to the
+     tap snapshot's ABV.
+
+2. **`taps` table** (latest snapshots, White Crow pub, tap 24):
+   - `abv = 40.0`  ❌
+   - `ibu = 8.4`   ❌ (8.4 is the *real* ABV)
+   - `style` = "Assemblage 2025 de bières de garde élevées en barriques …" — the
+     French **description**, not a style.
+
+3. **Source HTML** (`https://white-crow.ontap.pl/`, the panel for this beer):
+   ```html
+   <h4 class="cml_shadow"><span>
+     <b class="brewery">Brasserie La Malpolon Brewery</b><br/>
+     GARDEES II - 2025 <img .../><br/>
+     40,0%&nbsp;                         <!-- ABV field on source = 40,0% -->
+   </span></h4>
+   <span class="cml_shadow"><b>Assemblage 2025 de bières de garde …</b></span>
+   ...
+   <kbd>8.4 IBU</kbd>                     <!-- IBU field on source = 8.4 -->
+   ```
+
+### Conclusion
+
+**The data is wrong at the source.** The pub (White Crow) entered the values
+swapped in the ontap system: ABV field = `40,0%`, IBU field = `8.4`. In reality
+GARDEES II ≈ **8.4% ABV** and ~**40 IBU**.
+
+Our parser (`src/sources/ontap/pub.ts`) is behaving correctly — it faithfully
+extracts:
+- `abv` from the first `\d+%` in the `<h4>` → 40,0 → 40.0
+- `ibu` from `<kbd>… IBU</kbd>` → 8.4
+
+So this is **not a parser field-crossing bug**; it's garbage-in.
+
+### Scope (prod DB, read-only)
+
+- Beers with `abv > 30` ever recorded: exactly **one** — GARDEES II (40.0),
+  across 21 snapshot rows.
+- Beers with `abv` 15–20: 83 rows — all legitimate strong beers (Ice bock 16%,
+  Vanilla Gorilla 16% …). **Must not be touched.**
+- Isolated single-pub bad-data case.
+
+### UPDATE — Untappd HAS the correct ABV
+
+Untappd search for this beer (`/b/brasserie-la-malpolon-gardees-ii-2025/6400148`)
+returns **`8.4% ABV`**, style `Farmhouse Ale - Bière de Garde`. So the authoritative
+ABV is available — we just never store or prefer it.
+
+Two gaps found:
+
+1. **Ingestion gap — `beers.abv` is NULL though Untappd has it.**
+   - `parseUserBeersPage` (the "had"-list scraper, `src/sources/untappd/scraper.ts`)
+     does **not parse abv at all**.
+   - `refresh-untappd.ts:48` hardcodes `abv: null` when inserting a newly-seen beer,
+     and for existing matched beers only refreshes `rating_global` (never abv).
+   - (The orphan-lookup path `recordLookupSuccess` *does* write abv via
+     `abv = COALESCE(?, abv)`, but this beer arrived via the had-list scrape, so abv
+     stayed null.)
+
+2. **Display gap — ABV never falls back to Untappd.**
+   `tapsForSnapshotWithBeer` (`src/storage/snapshots.ts:67`) already does
+   `COALESCE(t.u_rating, b.rating_global) AS u_rating` for the rating (why "3.9"
+   showed despite an empty tap rating), but ABV is selected as bare `t.abv` — no
+   fallback to `b.abv`. So the display always trusts the (garbage) tap ABV.
+
+## Phase 2/3/4 — Fix (pending decision)
+
+Preferred, principled fix (mirrors the existing rating pattern; Untappd is
+authoritative for matched beers):
+
+- **Display:** in `tapsForSnapshotWithBeer`, use `COALESCE(b.abv, t.abv) AS abv`
+  (beer/Untappd first, tap fallback). For matched beers, Untappd's 8.4% wins over
+  the tap's bogus 40%. Also covers `/newbeers` if it shares the join.
+- **Ingestion:** parse abv in `parseUserBeersPage` and stop hardcoding `abv: null`
+  in `refresh-untappd.ts`, so `beers.abv` actually gets populated from Untappd.
+
+Optional belt-and-suspenders for **orphans** (no Untappd data to fall back on):
+drop implausible tap ABV (`abv > 30 → null`) in `parsePubPage`. Zero false
+positives (legit max on Warsaw taps ≈ 16%).
+
+All to be implemented test-first (TDD). Behaviour change → spec.md review per
+CLAUDE.md.
+
+## RESOLUTION (implemented, branch `fix/abv-prefer-untappd`)
+
+Chosen scope: **display + ingestion** (no orphan guard).
+
+1. **Display** — `tapsForSnapshotWithBeer` now selects `COALESCE(b.abv, t.abv) AS abv`
+   (`src/storage/snapshots.ts`). Fixes both `/beers` and `/newbeers`.
+2. **Ingestion (parse)** — `parseUserBeersPage` parses `.abv` (`8.4% ABV` → 8.4)
+   from the had-list row (`.abv` sits outside `.beer-details`, so scoped to row).
+3. **Ingestion (store)** — `refreshAllUntappd` inserts `abv: it.abv` for new beers
+   and backfills existing matched beers via `abv = COALESCE(?, abv)` (never wipes a
+   known abv with a missing one).
+
+Tests: 430/430 pass, `tsc --noEmit` clean. spec.md updated.
+
+**Prod resolution of the reported beer:** GARDEES (beers.id 12373) is in
+`untappd_had` for user 207079110, so the next `refreshAllUntappd` cron run
+backfills `beers.abv = 8.4`, after which the display shows `COALESCE(8.4, 40) = 8.4`.
+
+**Known limitation:** 102 matched beers still have NULL abv; they backfill
+opportunistically as they reappear in a had-list's top-25 (`MAX_ITEMS`). A one-time
+backfill of those was out of the chosen scope.

--- a/spec.md
+++ b/spec.md
@@ -173,7 +173,7 @@ src/
 | `name` | TEXT | NOT NULL | канонічна назва пива |
 | `brewery` | TEXT | NOT NULL | пивоварня |
 | `style` | TEXT | nullable | стиль |
-| `abv` | REAL | nullable | міцність, % |
+| `abv` | REAL | nullable | міцність, %; заповнюється з Untappd (`refreshAllUntappd` парсить `.abv`, backfill через `COALESCE`; orphan-lookup — теж) |
 | `rating_global` | REAL | nullable | публічний рейтинг Untappd (`global_weighted_rating_score`) |
 | `normalized_name` | TEXT | NOT NULL | для матчингу |
 | `normalized_brewery` | TEXT | NOT NULL | для матчингу |
@@ -348,7 +348,9 @@ pubs          *───* pubs             via pub_distances (a<b)
 Топ-**15** цікавих непитих пив, **згруповано по пиву**.
 **Під капотом:**
 1. для кожного паба беремо latest snapshot → `tapsForSnapshotWithBeer`
-   (COALESCE рейтингу: `tap.u_rating` → `beers.rating_global`);
+   (COALESCE рейтингу: `tap.u_rating` → `beers.rating_global`; COALESCE ABV —
+   **навпаки**: `beers.abv` → `tap.abv`, бо tap-ABV з ontap вводиться вручну й
+   буває помилковим, тож авторитетний Untappd-ABV переважає);
 2. `filterInteresting(taps, drunkSet, user_filters)` — відсів випитого
    (`checkins ∪ untappd_had`) і застосування фільтрів;
 3. групування за `match_links.untappd_beer_id` (fallback —

--- a/src/jobs/refresh-untappd.test.ts
+++ b/src/jobs/refresh-untappd.test.ts
@@ -43,6 +43,24 @@ const PAGE_ONE_BEER = (bid: number, name: string, brewery: string, global: strin
     </div>
   </div>`;
 
+const PAGE_ONE_BEER_ABV = (
+  bid: number, name: string, brewery: string, global: string, abv: string,
+) => `
+  <div class="beer-item" data-bid="${bid}">
+    <div class="beer-details">
+      <p class="name"><a href="/b/x/${bid}">${name}</a></p>
+      <p class="brewery"><a href="/x">${brewery}</a></p>
+      <p class="style">IPA</p>
+      <div class="ratings">
+        <div class="you">
+          <p>Global Rating (${global})</p>
+          <div class="caps" data-rating="${global}"></div>
+        </div>
+      </div>
+    </div>
+    <p class="abv">${abv}</p>
+  </div>`;
+
 // IMPORTANT for test names: `normalizeBrewery` strips tokens
 // `brewing/brewery/co/company/browar`; `normalizeName` strips style words
 // like `ipa/lager/stout/...`. Keep test fixtures clear of those tokens
@@ -66,6 +84,52 @@ describe('refreshAllUntappd', () => {
     expect(row!.rating_global).toBe(4.12);
     expect(row!.abv).toBeNull();
     expect(row!.style).toBe('IPA');
+  });
+
+  test('inserts a new beer with abv parsed from /beers', async () => {
+    const db = fresh();
+    ensureProfile(db, 1);
+    setUntappdUsername(db, 1, 'someone');
+
+    const http = fakeHttp({
+      'https://untappd.com/user/someone/beers':
+        PAGE_ONE_BEER_ABV(300, 'Gardees', 'Malpolon', '3.85', '8.4% ABV'),
+    });
+
+    await refreshAllUntappd({ db, log: silentLog, http });
+
+    const row = findBeerByNormalized(db, 'malpolon', 'gardees')!;
+    expect(row.untappd_id).toBe(300);
+    expect(row.abv).toBe(8.4);
+  });
+
+  test('backfills abv on an existing matched beer whose abv was NULL', async () => {
+    const db = fresh();
+    ensureProfile(db, 1);
+    setUntappdUsername(db, 1, 'someone');
+
+    const seededId = upsertBeer(db, {
+      untappd_id: 6400148,
+      name: 'Gardees',
+      brewery: 'Malpolon',
+      style: 'Farmhouse Ale',
+      abv: null,
+      rating_global: 3.85,
+      normalized_name: 'gardees',
+      normalized_brewery: 'malpolon',
+    });
+
+    const http = fakeHttp({
+      'https://untappd.com/user/someone/beers':
+        PAGE_ONE_BEER_ABV(6400148, 'Gardees', 'Malpolon', '3.90', '8.4% ABV'),
+    });
+
+    await refreshAllUntappd({ db, log: silentLog, http });
+
+    const row = findBeerByNormalized(db, 'malpolon', 'gardees')!;
+    expect(row.id).toBe(seededId);
+    expect(row.abv).toBe(8.4);
+    expect(row.rating_global).toBe(3.90);
   });
 
   test('matches existing row by normalized name+brewery; updates rating_global only', async () => {

--- a/src/jobs/refresh-untappd.ts
+++ b/src/jobs/refresh-untappd.ts
@@ -22,7 +22,11 @@ export async function refreshAllUntappd(deps: Deps): Promise<void> {
   const profiles = allProfiles(db).filter((p) => p.untappd_username);
   await onProgress(`👤 untappd: 0/${profiles.length} профілів`, { force: true });
 
-  const updateRatingOnly = db.prepare('UPDATE beers SET rating_global = ? WHERE id = ?');
+  // Refresh the rating and backfill abv when Untappd has it; COALESCE keeps an
+  // existing abv if this scrape didn't surface one (don't wipe known values).
+  const updateRatingAndAbv = db.prepare(
+    'UPDATE beers SET rating_global = ?, abv = COALESCE(?, abv) WHERE id = ?',
+  );
 
   let i = 0;
   let ok = 0;
@@ -37,7 +41,7 @@ export async function refreshAllUntappd(deps: Deps): Promise<void> {
         const existing = findBeerByNormalized(db, nb, nn);
         let beerId: number;
         if (existing) {
-          updateRatingOnly.run(it.global_rating, existing.id);
+          updateRatingAndAbv.run(it.global_rating, it.abv, existing.id);
           beerId = existing.id;
         } else {
           beerId = upsertBeer(db, {
@@ -45,7 +49,7 @@ export async function refreshAllUntappd(deps: Deps): Promise<void> {
             name: it.beer_name,
             brewery: it.brewery_name,
             style: it.style,
-            abv: null,
+            abv: it.abv,
             rating_global: it.global_rating,
             normalized_name: nn,
             normalized_brewery: nb,

--- a/src/sources/untappd/scraper.test.ts
+++ b/src/sources/untappd/scraper.test.ts
@@ -117,6 +117,41 @@ describe('parseUserBeersPage', () => {
     expect(out[0].bid).toBe(99);
   });
 
+  test('parses abv from .abv text', () => {
+    const html = `
+      <div class="beer-item" data-bid="55">
+        <div class="beer-details">
+          <p class="name"><a>Strong One</a></p>
+          <p class="brewery"><a>Brew</a></p>
+          <p class="style">Imperial Stout</p>
+          <p class="abv">8.4% ABV</p>
+          <div class="ratings"></div>
+        </div>
+      </div>`;
+    const [it] = parseUserBeersPage(html);
+    expect(it.abv).toBe(8.4);
+  });
+
+  test('missing abv → null', () => {
+    const html = `
+      <div class="beer-item" data-bid="56">
+        <div class="beer-details">
+          <p class="name"><a>No Abv</a></p>
+          <p class="brewery"><a>Brew</a></p>
+          <p class="style">Lager</p>
+          <div class="ratings"></div>
+        </div>
+      </div>`;
+    const [it] = parseUserBeersPage(html);
+    expect(it.abv).toBeNull();
+  });
+
+  test('extracts a numeric abv from real fixture markup (at least one item)', () => {
+    const withAbv = parseUserBeersPage(html).filter((b) => b.abv !== null);
+    expect(withAbv.length).toBeGreaterThan(0);
+    expect(withAbv.every((b) => typeof b.abv === 'number' && b.abv! >= 0)).toBe(true);
+  });
+
   test('blank style → null', () => {
     const html = `
       <div class="beer-item" data-bid="7">

--- a/src/sources/untappd/scraper.ts
+++ b/src/sources/untappd/scraper.ts
@@ -5,6 +5,7 @@ export interface ScrapedBeer {
   beer_name: string;
   brewery_name: string;
   style: string | null;
+  abv: number | null;
   their_rating: number | null;
   global_rating: number | null;
 }
@@ -14,6 +15,13 @@ const MAX_ITEMS = 25;
 function parseRating(raw: string | undefined): number | null {
   if (!raw) return null;
   const n = parseFloat(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+function parseAbv(raw: string): number | null {
+  const m = raw.match(/(\d+(?:[.,]\d+)?)\s*%/);
+  if (!m) return null;
+  const n = parseFloat(m[1].replace(',', '.'));
   return Number.isFinite(n) ? n : null;
 }
 
@@ -35,6 +43,10 @@ export function parseUserBeersPage(html: string): ScrapedBeer[] {
     const styleText = details.find('.style').first().text().trim().replace(/\s+/g, ' ');
     const style = styleText.length > 0 ? styleText : null;
 
+    // .abv lives in the beer-item row but outside .beer-details, so scope to row.
+    const abvText = row.find('.abv').first().text().trim();
+    const abv = abvText ? parseAbv(abvText) : null;
+
     let their_rating: number | null = null;
     let global_rating: number | null = null;
     details.find('.ratings .you').each((_, you) => {
@@ -44,7 +56,7 @@ export function parseUserBeersPage(html: string): ScrapedBeer[] {
       else if (/^Global Rating/i.test(label)) global_rating = value;
     });
 
-    out.push({ bid, beer_name, brewery_name, style, their_rating, global_rating });
+    out.push({ bid, beer_name, brewery_name, style, abv, their_rating, global_rating });
   });
 
   return out;

--- a/src/storage/snapshots.test.ts
+++ b/src/storage/snapshots.test.ts
@@ -120,6 +120,56 @@ describe('tapsForSnapshotWithBeer', () => {
     expect(row.beer_id).toBeNull();
   });
 
+  test('matched beer with abv → prefers beers.abv over the (garbage) tap abv', () => {
+    const { db, snapId } = setupWithBeer();
+    const beerId = upsertBeer(db, {
+      untappd_id: 6400148,
+      name: 'Gardees II - 2025',
+      brewery: 'Brasserie La Malpolon',
+      style: 'Farmhouse Ale - Bière de Garde',
+      abv: 8.4,
+      rating_global: 3.85,
+      normalized_name: 'gardees ii',
+      normalized_brewery: 'brasserie la malpolon',
+    });
+    upsertMatch(db, 'GARDEES II - 2025', beerId, 1.0);
+    insertTaps(db, snapId, [
+      { tap_number: 24, beer_ref: 'GARDEES II - 2025', brewery_ref: 'Brasserie La Malpolon Brewery', abv: 40, ibu: 8.4, style: null, u_rating: null },
+    ]);
+    const [row] = tapsForSnapshotWithBeer(db, snapId);
+    expect(row.abv).toBe(8.4);
+    expect(row.beer_id).toBe(beerId);
+  });
+
+  test('matched beer with NULL abv → falls back to tap abv', () => {
+    const { db, snapId } = setupWithBeer();
+    const beerId = upsertBeer(db, {
+      untappd_id: 200,
+      name: 'No Abv Beer',
+      brewery: 'X',
+      style: null,
+      abv: null,
+      rating_global: 3.5,
+      normalized_name: 'no abv beer',
+      normalized_brewery: 'x',
+    });
+    upsertMatch(db, 'X No Abv Beer', beerId, 1.0);
+    insertTaps(db, snapId, [
+      { tap_number: 1, beer_ref: 'X No Abv Beer', brewery_ref: 'X', abv: 5.2, ibu: null, style: null, u_rating: null },
+    ]);
+    const [row] = tapsForSnapshotWithBeer(db, snapId);
+    expect(row.abv).toBe(5.2);
+  });
+
+  test('orphan tap (no match) → keeps tap abv', () => {
+    const { db, snapId } = setupWithBeer();
+    insertTaps(db, snapId, [
+      { tap_number: 1, beer_ref: 'Lonely', brewery_ref: 'Nobody', abv: 6.6, ibu: null, style: null, u_rating: null },
+    ]);
+    const [row] = tapsForSnapshotWithBeer(db, snapId);
+    expect(row.abv).toBe(6.6);
+  });
+
   test('preserves ORDER BY tap_number', () => {
     const { db, snapId } = setupWithBeer();
     insertTaps(db, snapId, [

--- a/src/storage/snapshots.ts
+++ b/src/storage/snapshots.ts
@@ -57,13 +57,17 @@ export interface TapWithBeer extends TapRow {
   beer_id: number | null;
   untappd_id: number | null;
   // u_rating on this row is the COALESCEd value: tap.u_rating ?? beers.rating_global ?? null
+  // abv prefers the matched beer's Untappd value over the tap's: beers.abv ?? tap.abv ?? null.
+  // (Opposite precedence from rating: ontap's hand-entered tap ABV is unreliable — e.g. a
+  // pub once entered 40% ABV / 8.4 IBU swapped — so the authoritative Untappd value wins.)
 }
 
 export function tapsForSnapshotWithBeer(db: DB, snapshotId: number): TapWithBeer[] {
   return db.prepare(`
     SELECT
       t.id, t.snapshot_id, t.tap_number, t.beer_ref, t.brewery_ref,
-      t.abv, t.ibu, t.style,
+      COALESCE(b.abv, t.abv) AS abv,
+      t.ibu, t.style,
       COALESCE(t.u_rating, b.rating_global) AS u_rating,
       ml.untappd_beer_id AS beer_id,
       b.untappd_id AS untappd_id


### PR DESCRIPTION
## Проблема

`/beers` показував `24 • Brasserie La Malpolon Brewery GARDEES II - 2025 • 40% • 3.9 • 🟢` — **40% ABV** неможливе для Bière de Garde.

## Root cause (двошаровий)

1. **Першоджерело:** паб White Crow ввів значення навпаки в ontap — у поле ABV `40,0%`, у IBU `8.4` (а 8.4 — це і є справжній ABV). Untappd при цьому має коректні `8.4% ABV`. Наш парсер чесно витягує те, що показано → не наша помилка в парсингу.
2. **Наш pipeline:** ABV (на відміну від рейтингу) не мав fallback на авторитетний Untappd-ABV, а `beers.abv` взагалі не заповнювався — скрейпер had-списку не парсив `.abv`, а `refresh-untappd` хардкодив `abv: null`.

Деталі розслідування: `docs/investigations/abv-ibu-swap-gardees.md`.

## Зміни

| Файл | Зміна |
|------|-------|
| `storage/snapshots.ts` | `tapsForSnapshotWithBeer` → `COALESCE(b.abv, t.abv)` (Untappd-ABV переважає; зворотний precedence до рейтингу). Лікує `/beers` і `/newbeers` |
| `sources/untappd/scraper.ts` | `parseUserBeersPage` тепер парсить `.abv` |
| `jobs/refresh-untappd.ts` | вставляє `it.abv`; backfill наявних через `abv = COALESCE(?, abv)` |
| `spec.md` | задокументовано напрямок COALESCE та джерело `beers.abv` |

## Перевірка

- ✅ 430/430 Jest тестів (нові: precedence у snapshots, парсинг abv у scraper, insert+backfill у refresh-untappd)
- ✅ `tsc --noEmit` чистий

## Прод

GARDEES (beers.id 12373) є в `untappd_had` користувача 207079110 → наступний `refreshAllUntappd` запише `beers.abv=8.4`, після чого дисплей покаже `COALESCE(8.4, 40)=8.4`.

**Відома межа:** ще 102 матчнутих пива мають NULL abv — добиратимуться опортуністично при появі в топ-25 had-списку (`MAX_ITEMS`). Разовий backfill — поза обсягом цього PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)