### PR TITLE
fix(import): retry batches on SQLITE_BUSY (litestream checkpoint contention)

### DIFF
--- a/src/bot/commands/import.ts
+++ b/src/bot/commands/import.ts
@@ -11,6 +11,7 @@ import { upsertBeer } from '../../storage/beers';
 import { mergeCheckin } from '../../storage/checkins';
 import { ensureProfile } from '../../storage/user_profiles';
 import { normalizeBrewery, normalizeName } from '../../domain/normalize';
+import { withBusyRetry } from '../../storage/busy-retry';
 
 const BATCH_SIZE = 500;
 const PROGRESS_INTERVAL_MS = 2000;
@@ -90,7 +91,7 @@ importCommand.on('document', async (ctx) => {
     for await (const row of iterExport(stream, format)) {
       batch.push(row);
       if (batch.length >= BATCH_SIZE) {
-        flushBatch(batch);
+        await withBusyRetry(() => flushBatch(batch));
         total += batch.length;
         batch = [];
         if (Date.now() - lastReport > PROGRESS_INTERVAL_MS) {
@@ -100,7 +101,7 @@ importCommand.on('document', async (ctx) => {
       }
     }
     if (batch.length) {
-      flushBatch(batch);
+      await withBusyRetry(() => flushBatch(batch));
       total += batch.length;
     }
     await report(ctx.t('import.done', { total, format: format.toUpperCase() }));

--- a/src/storage/busy-retry.test.ts
+++ b/src/storage/busy-retry.test.ts
@@ -1,0 +1,65 @@
+import { isBusyError, withBusyRetry } from './busy-retry';
+
+function sqliteBusy(): Error {
+  const e = new Error('database is locked') as Error & { code: string };
+  e.code = 'SQLITE_BUSY';
+  return e;
+}
+
+const noSleep = async () => {};
+
+describe('isBusyError', () => {
+  test('true for SQLITE_BUSY', () => {
+    expect(isBusyError(sqliteBusy())).toBe(true);
+  });
+  test('false for other errors / non-errors', () => {
+    expect(isBusyError(new Error('nope'))).toBe(false);
+    expect(isBusyError(null)).toBe(false);
+    expect(isBusyError('SQLITE_BUSY')).toBe(false);
+  });
+});
+
+describe('withBusyRetry', () => {
+  test('returns the result without retrying when fn succeeds', async () => {
+    let calls = 0;
+    const out = await withBusyRetry(() => { calls++; return 42; }, { sleep: noSleep });
+    expect(out).toBe(42);
+    expect(calls).toBe(1);
+  });
+
+  test('retries on SQLITE_BUSY and returns once it succeeds', async () => {
+    let calls = 0;
+    const out = await withBusyRetry(() => {
+      calls++;
+      if (calls < 3) throw sqliteBusy();
+      return 'ok';
+    }, { attempts: 5, sleep: noSleep });
+    expect(out).toBe('ok');
+    expect(calls).toBe(3);
+  });
+
+  test('rethrows a non-BUSY error immediately without retrying', async () => {
+    let calls = 0;
+    await expect(withBusyRetry(() => { calls++; throw new Error('boom'); }, { sleep: noSleep }))
+      .rejects.toThrow('boom');
+    expect(calls).toBe(1);
+  });
+
+  test('gives up after exhausting attempts on persistent BUSY', async () => {
+    let calls = 0;
+    await expect(withBusyRetry(() => { calls++; throw sqliteBusy(); }, { attempts: 4, sleep: noSleep }))
+      .rejects.toThrow('database is locked');
+    expect(calls).toBe(4);
+  });
+
+  test('backs off with increasing delays between attempts', async () => {
+    const delays: number[] = [];
+    let calls = 0;
+    await withBusyRetry(() => {
+      calls++;
+      if (calls < 4) throw sqliteBusy();
+      return 0;
+    }, { attempts: 5, baseDelayMs: 10, sleep: async (ms) => { delays.push(ms); } });
+    expect(delays).toEqual([10, 20, 40]);
+  });
+});

--- a/src/storage/busy-retry.ts
+++ b/src/storage/busy-retry.ts
@@ -1,0 +1,41 @@
+// SQLite can return SQLITE_BUSY when a concurrent writer (here: the litestream
+// replication process running a WAL checkpoint) holds the lock longer than the
+// connection's busy_timeout. better-sqlite3 is synchronous, so we retry the
+// whole operation with an async backoff that yields the event loop — giving the
+// checkpoint time to finish before the next attempt. Safe because callers wrap
+// idempotent work (upsertBeer/mergeCheckin key off UNIQUE columns).
+
+export function isBusyError(e: unknown): boolean {
+  return (
+    typeof e === 'object' &&
+    e !== null &&
+    (e as { code?: unknown }).code === 'SQLITE_BUSY'
+  );
+}
+
+interface Options {
+  attempts?: number;
+  baseDelayMs?: number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+export async function withBusyRetry<T>(fn: () => T, opts: Options = {}): Promise<T> {
+  const attempts = opts.attempts ?? 5;
+  const baseDelayMs = opts.baseDelayMs ?? 100;
+  const sleep = opts.sleep ?? defaultSleep;
+
+  let lastError: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return fn();
+    } catch (e) {
+      if (!isBusyError(e)) throw e;
+      lastError = e;
+      if (i < attempts - 1) await sleep(baseDelayMs * 2 ** i);
+    }
+  }
+  throw lastError;
+}


### PR DESCRIPTION
## Проблема

Після BOM-фіксу (#66) друг повторив імпорт — CSV (6 МБ) пройшов **~10500 записів** і впав:

```
SqliteError: database is locked (SQLITE_BUSY)
  at upsertBeer → flushBatch transaction
```

## Root cause

WAL + **litestream** (активний, окремий процес) робить періодичний WAL-checkpoint. Під час швидкого bulk-імпорту WAL роздувається, checkpoint тримає лок **довше за 5 с** (`busy_timeout` better-sqlite3 за замовчуванням), і чергова батч-транзакція падає на `SQLITE_BUSY`. Час помилки (20:22:09) не збігається з жодним кроном → саме litestream.

> Примітка: початкова гіпотеза `busy_timeout=0` була хибною — прод-CLI читав власне окреме з'єднання; з'єднання бота вже має дефолтні 5000 мс. Діагноз скориговано за реальним стектрейсом.

## Зміни

| Файл | Зміна |
|------|-------|
| `storage/busy-retry.ts` | новий `withBusyRetry` — retry на `SQLITE_BUSY` з експоненційним **async** backoff (yield-ить event loop, даючи checkpoint завершитись) |
| `bot/commands/import.ts` | обидва `flushBatch` обгорнуті в `withBusyRetry` |

Безпечно повторювати: `flushBatch` — одна атомарна транзакція (rollback при помилці), а `upsertBeer`/`mergeCheckin` ідемпотентні по UNIQUE-ключах.

## Перевірка

- ✅ 439/439 Jest (+7 на retry-хелпер: success/retry/non-busy passthrough/exhaustion/backoff)
- ✅ `tsc --noEmit` чисто

🤖 Generated with [Claude Code](https://claude.com/claude-code)