### PR TITLE
fix(cron): pin daily-status digest to Europe/Warsaw

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -136,13 +136,14 @@ async function main(): Promise<void> {
         log.error({ err: e }, 'cleanup-old-snapshots cron');
       }
     }),
-    // daily-status: admin health digest at 09:00 Warsaw, after the overnight
-    // jobs (00:00 ontap, 03:00 untappd, 05:00 cleanup) have settled. Async →
-    // .catch. Self-noops when ADMIN_TELEGRAM_ID is unset.
+    // daily-status: admin health digest at 09:00 Warsaw. The server runs in UTC
+    // (Etc/UTC), and node-cron fires in the server's local time unless told
+    // otherwise — so we pin the timezone explicitly, else 09:00 UTC lands at
+    // 11:00 CEST. Async → .catch. Self-noops when ADMIN_TELEGRAM_ID is unset.
     cron.schedule('0 9 * * *', () => {
       dailyStatus({ db, log, notifyAdmin })
         .catch((e) => log.error({ err: e }, 'daily-status cron'));
-    }),
+    }, { timezone: 'Europe/Warsaw' }),
   ];
 
   if (untappdHttp) {


### PR DESCRIPTION
## Summary
The daily status digest fired at **11:00 Warsaw instead of 09:00**. Root cause: the prod server runs `Etc/UTC`, and node-cron fires schedules in the server's local time unless a timezone is given — so `0 9 * * *` ran at 09:00 UTC = 11:00 CEST.

Fix: pass `{ timezone: 'Europe/Warsaw' }` to the digest's `cron.schedule` (node-cron v4 `TaskOptions.timezone`). One-line change + clarifying comment.

## Note (out of scope)
The other crons (`refreshOntap`, `refreshAllUntappd`, `enrichOrphans`, `refreshTapRatings`, `cleanupOldSnapshots`) have comments saying "Warsaw" but actually run in UTC too (their relative offsets are preserved, only absolute wall-clock differs). Left untouched here to avoid shifting scraper timing; can be addressed separately if desired.

## Test Plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx jest` — 477 pass, 0 failures
- [ ] Post-deploy: confirm next digest arrives at 09:00 Warsaw

🤖 Generated with [Claude Code](https://claude.com/claude-code)