### PR TITLE
Wire AGENTS.md into reviewer PROMPT + cost guard

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -17,6 +17,23 @@ jobs:
   review:
     runs-on: ubuntu-latest
     steps:
+      # Needed so AGENTS.md is present on the runner; the action itself works
+      # off the GitHub API and would otherwise never clone the repo. Uses the
+      # PR head, so the reviewer prompt tracks the branch under review.
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Load the reviewer persona / focus rules from AGENTS.md into an env var
+      # so it can be passed as the action's PROMPT. Heredoc delimiter keeps the
+      # multi-line markdown intact in $GITHUB_ENV.
+      - name: Load reviewer prompt from AGENTS.md
+        run: |
+          {
+            echo 'REVIEW_PROMPT<<__AGENTS_EOF__'
+            cat AGENTS.md
+            echo '__AGENTS_EOF__'
+          } >> "$GITHUB_ENV"
+
       - name: AI code review
         uses: anc95/ChatGPT-CodeReview@main
         env:
@@ -25,3 +42,6 @@ jobs:
           # Added manually in repo Settings → Secrets and variables → Actions.
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           LANGUAGE: English
+          # Drives the review with our AGENTS.md persona instead of the
+          # action's built-in generic prompt.
+          PROMPT: ${{ env.REVIEW_PROMPT }}

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -45,3 +45,8 @@ jobs:
           # Drives the review with our AGENTS.md persona instead of the
           # action's built-in generic prompt.
           PROMPT: ${{ env.REVIEW_PROMPT }}
+          # Cost guard: skip files whose diff exceeds this many characters so a
+          # huge generated/vendored change can't blow up token usage (the full
+          # PROMPT is sent per reviewed file). Tune if large hand-written diffs
+          # get skipped.
+          MAX_PATCH_LENGTH: 8000


### PR DESCRIPTION
Follow-up to #74. The #74 merge captured only the base-workflow commit (`e00490a`); these two enhancements never landed on `main`:

- **Wire AGENTS.md into PROMPT** — `actions/checkout` + load `AGENTS.md` into the action's `PROMPT` env so reviews use our persona/focus rules instead of the action's generic built-in prompt.
- **MAX_PATCH_LENGTH cost guard** — skip files whose diff exceeds 8000 chars so large generated/vendored changes don't multiply per-file token cost.

Verified `main` currently has neither (`PROMPT`/`MAX_PATCH_LENGTH` absent from the merged workflow). Commits cherry-picked from `chore/ai-pr-reviewer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)