### PR TITLE
perf(match): non-blocking /match via cooperative event-loop yielding

### DIFF
--- a/docs/superpowers/plans/2026-06-08-match-nonblocking-cooperative-yield.md
+++ b/docs/superpowers/plans/2026-06-08-match-nonblocking-cooperative-yield.md
@@ -1,0 +1,347 @@
+# Non-blocking /match (cooperative yield) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop `POST /match` from freezing the bot by yielding the event loop during catalog preparation (chunked) and between input beers, keeping match results byte-for-byte identical.
+
+**Architecture:** `matcher.ts` stays the synchronous, pure matching kernel — refactored only to expose `prepareBeer` (per-row) and `makePreparedCatalog` (assembles the lazy-searcher object). The async/yielding orchestration lives in `match-list.ts`: `matchBeerList` becomes async, builds the prepared catalog in `PREP_CHUNK`-sized chunks with `setImmediate` yields, and yields between beers. The `/match` route awaits it.
+
+**Tech Stack:** TypeScript, `fast-fuzzy`, Hono, Jest, better-sqlite3, `setImmediate`.
+
+**Spec:** `docs/superpowers/specs/2026-06-08-match-nonblocking-cooperative-yield-design.md`
+
+---
+
+### Task 1: Refactor `matcher.ts` — extract `prepareBeer` + `makePreparedCatalog`
+
+Behavior-preserving. `prepareCatalog` keeps its signature and behavior; the existing
+`matcher.test.ts` suite (including the Task-1 lazy/memoized + field tests) must stay green.
+
+**Files:**
+- Modify: `src/domain/matcher.ts:49-65`
+- Test: `src/domain/matcher.test.ts` (existing suite must pass; one small test added)
+
+- [ ] **Step 1: Replace `prepareCatalog` with `prepareBeer` + `makePreparedCatalog` + a delegating `prepareCatalog`**
+
+Replace the current `prepareCatalog` (lines 47-65) with:
+
+```ts
+// Per-row preparation: precompute the normalizations once.
+export function prepareBeer(c: CatalogBeer): PreparedBeer {
+  return {
+    ...c,
+    nameNorm: normalizeName(c.name),
+    breweryNorm: normalizeBrewery(c.brewery),
+    aliases: breweryAliases(c.brewery),
+  };
+}
+
+// Assembles a PreparedCatalog from already-prepared rows. `build` is injectable
+// purely so tests can observe Searcher construction; the default is the
+// production builder. `fullSearcher()` is memoized + lazily built.
+export function makePreparedCatalog(
+  beers: PreparedBeer[],
+  build: (rows: PreparedBeer[]) => PreparedSearcher = defaultBuildSearcher,
+): PreparedCatalog {
+  let full: PreparedSearcher | undefined;
+  return {
+    beers,
+    searcherFor: build,
+    fullSearcher: () => (full ??= build(beers)),
+  };
+}
+
+export function prepareCatalog(
+  catalog: CatalogBeer[],
+  build: (rows: PreparedBeer[]) => PreparedSearcher = defaultBuildSearcher,
+): PreparedCatalog {
+  return makePreparedCatalog(catalog.map(prepareBeer), build);
+}
+```
+
+- [ ] **Step 2: Run the existing matcher suite — must stay green**
+
+Run: `npx jest src/domain/matcher.test.ts`
+Expected: PASS, same count as before (53 tests). The lazy/memoized test still passes because
+`prepareCatalog(cat, build)` forwards `build` to `makePreparedCatalog`.
+
+- [ ] **Step 3: Add a `prepareBeer` unit test**
+
+Append to `src/domain/matcher.test.ts` (the import line already pulls from `./matcher`; add
+`prepareBeer` to it):
+
+```ts
+import { prepareBeer } from './matcher';
+
+describe('prepareBeer', () => {
+  it('precomputes nameNorm, breweryNorm and aliases', () => {
+    const p = prepareBeer({ id: 7, brewery: 'Piwne Podziemie Brewery', name: 'Hopinka IPA', abv: 6 });
+    expect(p.id).toBe(7);
+    expect(p.nameNorm).toBe('hopinka');          // STYLE_WORD "ipa" stripped
+    expect(p.breweryNorm).toBe('piwne podziemie'); // noise word "brewery" stripped
+    expect(p.aliases).toEqual(['piwne podziemie']);
+  });
+});
+```
+
+- [ ] **Step 4: Run the added test + typecheck**
+
+Run: `npx jest src/domain/matcher.test.ts -t "prepareBeer" && npx tsc --noEmit`
+Expected: PASS, tsc clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/domain/matcher.ts src/domain/matcher.test.ts
+git commit -m "refactor(matcher): extract prepareBeer + makePreparedCatalog building blocks
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Async, yielding `matchBeerList` in `match-list.ts`
+
+Make `matchBeerList` async; chunk-yield during prep and yield between beers. The per-item
+result mapping is unchanged.
+
+**Files:**
+- Modify: `src/domain/match-list.ts`
+- Test: `src/domain/match-list.test.ts`
+
+- [ ] **Step 1: Rewrite `match-list.ts` to the async, yielding version**
+
+Replace the import line and the `matchBeerList` function. The interfaces
+(`CatalogBeerWithRating`, `MatchInput`, `MatchedBeer`, `MatchListResult`) stay unchanged.
+
+New import (top of file, replacing the current `import { matchPrepared, prepareCatalog, type CatalogBeer } from './matcher';`):
+
+```ts
+import {
+  matchPrepared,
+  prepareBeer,
+  makePreparedCatalog,
+  type CatalogBeer,
+  type PreparedBeer,
+  type PreparedCatalog,
+} from './matcher';
+```
+
+Replace the `matchBeerList` function (the whole `export function matchBeerList(...) { ... }`) with:
+
+```ts
+// ~0.027 ms/row on the prod catalog → 2000 rows ≈ ≤60 ms of normalization per chunk.
+const PREP_CHUNK = 2000;
+
+// Hands control back to the event loop so the long-poll bot processes its updates
+// between CPU bursts. setImmediate fires after pending I/O callbacks.
+export const yieldToEventLoop = (): Promise<void> =>
+  new Promise((resolve) => setImmediate(resolve));
+
+// Builds PreparedBeer[] in chunks, yielding between chunks, then assembles the catalog.
+async function prepareCatalogChunked(
+  catalog: CatalogBeerWithRating[],
+  yield_: () => Promise<void>,
+): Promise<PreparedCatalog> {
+  const beers: PreparedBeer[] = [];
+  for (let i = 0; i < catalog.length; i += PREP_CHUNK) {
+    const end = Math.min(i + PREP_CHUNK, catalog.length);
+    for (let j = i; j < end; j++) beers.push(prepareBeer(catalog[j]));
+    await yield_();
+  }
+  return makePreparedCatalog(beers);
+}
+
+export interface MatchListOptions {
+  // DI seam so tests can count yields deterministically; production uses the default.
+  yield?: () => Promise<void>;
+}
+
+export async function matchBeerList(
+  catalog: CatalogBeerWithRating[],
+  drunkSet: Set<number>,
+  ratingByBeerId: Map<number, number>,
+  items: MatchInput[],
+  opts: MatchListOptions = {},
+): Promise<MatchListResult[]> {
+  const yield_ = opts.yield ?? yieldToEventLoop;
+  const byId = new Map(catalog.map((c) => [c.id, c]));
+  const prepared = await prepareCatalogChunked(catalog, yield_);
+  const out: MatchListResult[] = [];
+  for (const item of items) {
+    const raw = { brewery: item.brewery, name: item.name };
+    const m = matchPrepared(item, prepared);
+    if (!m) {
+      out.push({ raw, matched_beer: null, is_drunk: false, user_rating: null });
+    } else {
+      const beer = byId.get(m.id)!;
+      out.push({
+        raw,
+        matched_beer: {
+          id: beer.id,
+          name: beer.name,
+          brewery: beer.brewery,
+          rating_global: beer.rating_global,
+        },
+        is_drunk: drunkSet.has(m.id),
+        user_rating: ratingByBeerId.get(m.id) ?? null,
+      });
+    }
+    await yield_();
+  }
+  return out;
+}
+```
+
+Note: `CatalogBeer` is still imported because `CatalogBeerWithRating extends CatalogBeer`.
+
+- [ ] **Step 2: Update existing `match-list.test.ts` cases to `await`**
+
+Every `matchBeerList(...)` call in `src/domain/match-list.test.ts` must be awaited and its
+test made `async`. Concretely:
+- `it('marks a matched, drunk beer with its personal rating', async () => { const res = await matchBeerList(...); ... })`
+- `it('drunk via had-list only → is_drunk true, user_rating null', async () => { const res = await matchBeerList(...); ... })`
+- `it('no catalog match → matched_beer null, not drunk', async () => { const res = await matchBeerList(...); ... })`
+- `it('preserves input order', async () => { const res = await matchBeerList(...); ... })`
+- In `describe('matchBeerList — prepare-once equivalence', ...)`: `it('per-batch result equals matching each beer alone', async () => { const batch = await matchBeerList(bigCatalog, new Set(), new Map(), inputs); inputs.forEach(...) })` — `matchBeer` (sync) stays un-awaited.
+
+- [ ] **Step 3: Add the yield test**
+
+Append to `src/domain/match-list.test.ts`:
+
+```ts
+describe('matchBeerList — cooperative yielding', () => {
+  it('yields between prep chunks and after each beer', async () => {
+    // 2001 rows → ceil(2001/2000) = 2 prep-chunk yields.
+    const big: CatalogBeerWithRating[] = Array.from({ length: 2001 }, (_, i) => ({
+      id: i + 1, brewery: `Brew ${i}`, name: `Beer ${i}`, abv: null, rating_global: null,
+    }));
+    const items = [
+      { brewery: 'Brew 0', name: 'Beer 0' },   // exact match
+      { brewery: 'Nowhere', name: 'Unknown' }, // empty-pool fallback
+    ];
+    const yieldSpy = jest.fn(() => Promise.resolve());
+    await matchBeerList(big, new Set(), new Map(), items, { yield: yieldSpy });
+    // 2 prep-chunk yields + 1 yield per beer.
+    expect(yieldSpy.mock.calls.length).toBe(2 + items.length);
+  });
+});
+```
+
+- [ ] **Step 4: Run match-list tests + typecheck**
+
+Run: `npx jest src/domain/match-list.test.ts && npx tsc --noEmit`
+Expected: PASS (all updated cases + equivalence + yield), tsc clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/domain/match-list.ts src/domain/match-list.test.ts
+git commit -m "perf(match): matchBeerList yields the event loop during prep and between beers
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Make the `/match` route async
+
+**Files:**
+- Modify: `src/api/routes/match.ts:26-36`
+
+- [ ] **Step 1: Await the now-async `matchBeerList`**
+
+Change the handler to `async` and `await` the call:
+
+```ts
+  app.post('/match', zValidator('json', MatchBody), async (c) => {
+    const telegramId = c.get('telegramId');
+    const { beers } = c.req.valid('json');
+
+    const catalog = loadCatalog(deps.db);
+    const drunkSet = triedBeerIds(deps.db, telegramId);
+    const ratings = latestRatingsByBeer(deps.db, telegramId);
+
+    const results = await matchBeerList(catalog, drunkSet, ratings, beers);
+    return c.json({ results });
+  });
+```
+
+- [ ] **Step 2: Run the API tests + typecheck**
+
+Run: `npx jest src/api && npx tsc --noEmit`
+Expected: PASS, tsc clean. (Hono awaits async handlers; `app.onError` still wraps thrown errors.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/api/routes/match.ts
+git commit -m "perf(api): await async matchBeerList in /match handler (non-blocking)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Update benchmark, full suite, spec.md review
+
+**Files:**
+- Modify: `scripts/bench-match.ts`
+
+- [ ] **Step 1: Await the async `matchBeerList` in the benchmark**
+
+In `scripts/bench-match.ts`, the matching block uses top-level `await` (the file is ESM —
+it has imports). Change:
+
+```ts
+const t0 = performance.now();
+const results = await matchBeerList(catalog, new Set(), new Map(), beers);
+const ms = performance.now() - t0;
+```
+
+- [ ] **Step 2: Run the full suite**
+
+Run: `npm test`
+Expected: all green (existing + the 2 new tests: `prepareBeer`, yielding).
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: clean. (`scripts/` is outside `tsconfig` `include`, so the bench file runs via `tsx`.)
+
+- [ ] **Step 4: (Optional, manual) Re-run the benchmark against prod DB**
+
+Run: `npx tsx scripts/bench-match.ts /var/lib/warsaw-beer-bot/bot.db /home/ysi/warsaw-beer-bot/input.json`
+Expected: matched count unchanged (29/48); total ≈ 2 s (yielding adds only negligible
+`setImmediate` overhead — it does not reduce wall-clock, it interleaves).
+
+- [ ] **Step 5: Review `spec.md` for a `/match`-is-synchronous note**
+
+Run: `grep -ni "synchron\|better-sqlite3 виклик\|/match\|event loop\|подія" spec.md`
+The public `/match` contract and results are unchanged. §3.3 currently frames "synchronous
+better-sqlite3 calls" as not-external-I/O — that statement stays true. If a sentence asserts
+`/match` is fully synchronous / blocks the loop, update it to note it now yields cooperatively,
+in this PR (per CLAUDE.md). If nothing relevant, note "no spec change needed" in the PR body.
+
+- [ ] **Step 6: Commit any spec.md change (only if made)**
+
+```bash
+git add spec.md
+git commit -m "docs(spec): note /match yields the event loop cooperatively
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Notes for the implementer
+
+- **Cardinal rule:** match results must not change. The Task-1 equivalence test
+  (`matchBeerList` vs per-beer `matchBeer`) and the full `matcher.test.ts` suite are the
+  guards. Yielding is pure scheduling — it must not touch the matching logic.
+- `matcher.ts` stays synchronous and pure. Do NOT add `async`/`setImmediate` there — all
+  yielding lives in `match-list.ts`. The two job callers (`refresh-ontap`,
+  `cleanup-polluted-ontap`) and the `matchBeer` wrapper keep using the sync `prepareCatalog`.
+- `opts.yield` is a test seam; production passes nothing and uses `yieldToEventLoop`.
+- Worker-thread / true off-thread matching is out of scope — GitHub issue #84.
+```

--- a/docs/superpowers/specs/2026-06-08-match-nonblocking-cooperative-yield-design.md
+++ b/docs/superpowers/specs/2026-06-08-match-nonblocking-cooperative-yield-design.md
@@ -1,0 +1,161 @@
+# Non-blocking /match: cooperative event-loop yielding
+
+**Date:** 2026-06-08
+**Status:** Approved (design)
+**Scope:** Task 3 of the post-extension match-perf follow-ups (option A). Option B
+(worker_threads, true off-thread matching) is deferred — tracked as GitHub issue **#84**.
+
+## Problem
+
+The Telegram bot (`bot.launch()`) and the Hono API server (`createApiServer`) run in
+the **same Node process / event loop** (`src/index.ts`). `POST /match` is fully
+synchronous, so for its whole duration the event loop is blocked and the bot freezes
+(long-poll updates are not processed).
+
+After PR #83 (per-request `prepareCatalog`), a real 48-beer batch is ~2 s instead of
+~10 s, but it still blocks. Measured split on the prod catalog (20,120 rows, read-only):
+
+```
+loadCatalog = 60 ms    prepareCatalog = 541 ms    matchLoop = 1574 ms (48 beers)
+per-beer: top5 = 66,51,46,44,44 ms   median = 37 ms
+```
+
+Two things matter:
+- **`prepareCatalog` is a single ~541 ms CPU block** (normalizing 20k rows). Yielding only
+  between beers would leave a ~half-second freeze at the start.
+- The **per-beer** blocks are now small (≤66 ms) — the full-catalog `Searcher` is built once
+  (lazily) and reused, not rebuilt per beer. So yielding between beers caps blocks at ~66 ms.
+
+## Goal
+
+`POST /match` no longer freezes the bot. No single synchronous block exceeds ~tens of ms
+beyond an atomic DB read. Wall-clock latency stays ~2 s (we interleave, not parallelize —
+parallelism is issue #84). Match results stay byte-for-byte identical (the cardinal
+constraint: a false "ти це пив" is the worst bug).
+
+Non-goal: reducing `/match` latency or running matching on another thread (issue #84).
+
+## Approach: yield the event loop in the two CPU-heavy places
+
+Insert cooperative `await setImmediate`-based yields (a) between chunks of catalog
+preparation and (b) between input beers in the match loop. Between yields the long-poll
+bot processes its updates, so it stays responsive (worst added latency ≈ one block, ≤~66 ms).
+
+### `src/domain/matcher.ts` — stays synchronous and pure (the matching kernel)
+
+Refactor only to expose reusable building blocks; no async enters this module:
+
+```ts
+export function prepareBeer(c: CatalogBeer): PreparedBeer;          // per-row norm/aliases
+export function makePreparedCatalog(
+  beers: PreparedBeer[],
+  build?: (rows: PreparedBeer[]) => PreparedSearcher,
+): PreparedCatalog;                                                  // assembles lazy fullSearcher
+```
+
+`prepareCatalog(catalog, build?)` becomes `makePreparedCatalog(catalog.map(prepareBeer), build)`
+— **identical signature and behavior**. The two job callers and the `matchBeer` back-compat
+wrapper are untouched; `matchPrepared` is unchanged.
+
+### `src/domain/match-list.ts` — all async / yielding orchestration lives here
+
+```ts
+const PREP_CHUNK = 2000;  // ≈ ≤60 ms of normalization per chunk at ~0.027 ms/row
+
+export const yieldToEventLoop = (): Promise<void> =>
+  new Promise((resolve) => setImmediate(resolve));
+
+// Builds PreparedBeer[] in chunks, yielding between chunks, then assembles the catalog.
+async function prepareCatalogChunked(
+  catalog: CatalogBeerWithRating[],
+  yield_: () => Promise<void>,
+): Promise<PreparedCatalog> {
+  const beers: PreparedBeer[] = [];
+  for (let i = 0; i < catalog.length; i += PREP_CHUNK) {
+    const end = Math.min(i + PREP_CHUNK, catalog.length);
+    for (let j = i; j < end; j++) beers.push(prepareBeer(catalog[j]));
+    await yield_();
+  }
+  return makePreparedCatalog(beers);
+}
+
+export interface MatchListOptions {
+  yield?: () => Promise<void>;  // DI seam for deterministic yield-count tests
+}
+
+export async function matchBeerList(
+  catalog: CatalogBeerWithRating[],
+  drunkSet: Set<number>,
+  ratingByBeerId: Map<number, number>,
+  items: MatchInput[],
+  opts: MatchListOptions = {},
+): Promise<MatchListResult[]> {
+  const yield_ = opts.yield ?? yieldToEventLoop;
+  const byId = new Map(catalog.map((c) => [c.id, c]));
+  const prepared = await prepareCatalogChunked(catalog, yield_);
+  const out: MatchListResult[] = [];
+  for (const item of items) {
+    const raw = { brewery: item.brewery, name: item.name };
+    const m = matchPrepared(item, prepared);
+    if (!m) {
+      out.push({ raw, matched_beer: null, is_drunk: false, user_rating: null });
+    } else {
+      const beer = byId.get(m.id)!;
+      out.push({
+        raw,
+        matched_beer: { id: beer.id, name: beer.name, brewery: beer.brewery, rating_global: beer.rating_global },
+        is_drunk: drunkSet.has(m.id),
+        user_rating: ratingByBeerId.get(m.id) ?? null,
+      });
+    }
+    await yield_();
+  }
+  return out;
+}
+```
+
+`matchBeerList` becomes async; the synchronous version is dropped (the route is its only
+production caller). The pure synchronous matching kernel (`matchPrepared` / `prepareCatalog`)
+remains in `matcher.ts`, fully covered by sync tests.
+
+### `src/api/routes/match.ts`
+
+The handler becomes `async` and `await`s `matchBeerList`. `loadCatalog`, `triedBeerIds`,
+`latestRatingsByBeer` stay synchronous at the top (atomic DB reads, ~60–80 ms total).
+
+## Error handling
+
+`yieldToEventLoop` cannot reject. The matching logic is unchanged, so no new failure modes.
+Hono's existing `app.onError` already turns a thrown handler error into a `500`; awaiting an
+async handler preserves that.
+
+## Testing
+
+**Correctness (CI):**
+- Every existing `match-list.test.ts` case is updated to `await matchBeerList(...)` and must
+  pass unchanged in its assertions.
+- The Task-1 "prepare-once equivalence" test (`matchBeerList` vs per-beer `matchBeer`) stays
+  valid (now awaited) — proves yielding/chunking moves no match.
+- `matcher.test.ts` (sync kernel) is unaffected.
+
+**Yielding (CI, deterministic via DI):**
+- With an injected `opts.yield` spy and a catalog larger than `PREP_CHUNK` (e.g. 2001 synthetic
+  rows) plus N input beers, assert the spy was called at least `ceil(catalog.length / PREP_CHUNK)
+  + N` times (prep-chunk yields + per-beer yields).
+- A small-catalog case asserts at least `1 + N` yields (one prep chunk + per beer).
+
+**Manual (not CI):** existing `scripts/bench-match.ts` — make its caller `await` the now-async
+`matchBeerList`; confirm matched count and ~2 s wall-clock are unchanged (yielding adds only
+negligible `setImmediate` overhead).
+
+## spec.md
+
+`spec.md §5` documents intentional invariants; §3.3 currently scopes "external I/O timeout" to
+outbound network and notes "synchronous better-sqlite3 calls are not external I/O". The change
+keeps the public `/match` contract and results identical, so no contract edit is required.
+Review §5/§3.3 during implementation; if a note about `/match` being synchronous needs
+updating (it now yields cooperatively), update it in the same PR (per CLAUDE.md).
+
+## Out of scope
+- **Worker-thread / true off-thread matching** — GitHub issue **#84**.
+- **Cross-request catalog caching** — rejected in PR #83 (premature for single-user load).

--- a/scripts/bench-match.ts
+++ b/scripts/bench-match.ts
@@ -19,14 +19,20 @@ const parsed = JSON.parse(json);
 const beers: { brewery: string; name: string; abv?: number }[] =
   Array.isArray(parsed) ? parsed : parsed.beers;
 
-const db = new Database(dbPath, { readonly: true });
-const catalog = loadCatalog(db);
+// Wrapped in an async main() because matchBeerList is async and the project
+// compiles to CommonJS (no top-level await).
+async function main(): Promise<void> {
+  const db = new Database(dbPath, { readonly: true });
+  const catalog = loadCatalog(db);
 
-const t0 = performance.now();
-const results = matchBeerList(catalog, new Set(), new Map(), beers);
-const ms = performance.now() - t0;
+  const t0 = performance.now();
+  const results = await matchBeerList(catalog, new Set(), new Map(), beers);
+  const ms = performance.now() - t0;
 
-const matched = results.filter((r) => r.matched_beer !== null).length;
-console.log(`catalog=${catalog.length} beers=${beers.length}`);
-console.log(`total=${ms.toFixed(0)}ms  perBeer=${(ms / beers.length).toFixed(1)}ms  matched=${matched}/${beers.length}`);
-db.close();
+  const matched = results.filter((r) => r.matched_beer !== null).length;
+  console.log(`catalog=${catalog.length} beers=${beers.length}`);
+  console.log(`total=${ms.toFixed(0)}ms  perBeer=${(ms / beers.length).toFixed(1)}ms  matched=${matched}/${beers.length}`);
+  db.close();
+}
+
+void main();

--- a/src/api/routes/match.ts
+++ b/src/api/routes/match.ts
@@ -23,7 +23,7 @@ const MatchBody = z.object({
 // Registers POST /match on the given app. Assumes auth middleware has set
 // 'telegramId' on the context for this route.
 export function matchRoute(app: Hono<ApiEnv>, deps: ApiDeps): void {
-  app.post('/match', zValidator('json', MatchBody), (c) => {
+  app.post('/match', zValidator('json', MatchBody), async (c) => {
     const telegramId = c.get('telegramId');
     const { beers } = c.req.valid('json');
 
@@ -31,7 +31,7 @@ export function matchRoute(app: Hono<ApiEnv>, deps: ApiDeps): void {
     const drunkSet = triedBeerIds(deps.db, telegramId);
     const ratings = latestRatingsByBeer(deps.db, telegramId);
 
-    const results = matchBeerList(catalog, drunkSet, ratings, beers);
+    const results = await matchBeerList(catalog, drunkSet, ratings, beers);
     return c.json({ results });
   });
 }

--- a/src/domain/match-list.test.ts
+++ b/src/domain/match-list.test.ts
@@ -7,8 +7,8 @@ const catalog: CatalogBeerWithRating[] = [
 ];
 
 describe('matchBeerList', () => {
-  it('marks a matched, drunk beer with its personal rating', () => {
-    const res = matchBeerList(
+  it('marks a matched, drunk beer with its personal rating', async () => {
+    const res = await matchBeerList(
       catalog,
       new Set([105]),
       new Map([[105, 4.0]]),
@@ -24,16 +24,16 @@ describe('matchBeerList', () => {
     ]);
   });
 
-  it('drunk via had-list only → is_drunk true, user_rating null', () => {
-    const res = matchBeerList(catalog, new Set([200]), new Map(), [
+  it('drunk via had-list only → is_drunk true, user_rating null', async () => {
+    const res = await matchBeerList(catalog, new Set([200]), new Map(), [
       { brewery: 'PINTA', name: 'Atak Chmielu' },
     ]);
     expect(res[0].is_drunk).toBe(true);
     expect(res[0].user_rating).toBeNull();
   });
 
-  it('no catalog match → matched_beer null, not drunk', () => {
-    const res = matchBeerList(catalog, new Set(), new Map(), [
+  it('no catalog match → matched_beer null, not drunk', async () => {
+    const res = await matchBeerList(catalog, new Set(), new Map(), [
       { brewery: 'Nowhere', name: 'Unknown Stout' },
     ]);
     expect(res[0]).toEqual({
@@ -44,8 +44,8 @@ describe('matchBeerList', () => {
     });
   });
 
-  it('preserves input order', () => {
-    const res = matchBeerList(catalog, new Set(), new Map(), [
+  it('preserves input order', async () => {
+    const res = await matchBeerList(catalog, new Set(), new Map(), [
       { brewery: 'PINTA', name: 'Atak Chmielu' },
       { brewery: 'Trzech Kumpli', name: 'Pan IPAni' },
     ]);
@@ -70,11 +70,28 @@ describe('matchBeerList — prepare-once equivalence', () => {
     { brewery: 'Nowhere', name: 'Totally Unknown Stout' },    // no match
   ];
 
-  it('per-batch result equals matching each beer alone', () => {
-    const batch = matchBeerList(bigCatalog, new Set(), new Map(), inputs);
+  it('per-batch result equals matching each beer alone', async () => {
+    const batch = await matchBeerList(bigCatalog, new Set(), new Map(), inputs);
     inputs.forEach((input, i) => {
       const solo = matchBeer(input, bigCatalog);
       expect(batch[i].matched_beer?.id ?? null).toBe(solo?.id ?? null);
     });
+  });
+});
+
+describe('matchBeerList — cooperative yielding', () => {
+  it('yields between prep chunks and after each beer', async () => {
+    // 2001 rows → ceil(2001/2000) = 2 prep-chunk yields.
+    const big: CatalogBeerWithRating[] = Array.from({ length: 2001 }, (_, i) => ({
+      id: i + 1, brewery: `Brew ${i}`, name: `Beer ${i}`, abv: null, rating_global: null,
+    }));
+    const items = [
+      { brewery: 'Brew 0', name: 'Beer 0' },   // exact match
+      { brewery: 'Nowhere', name: 'Unknown' }, // empty-pool fallback
+    ];
+    const yieldSpy = jest.fn(() => Promise.resolve());
+    await matchBeerList(big, new Set(), new Map(), items, { yield: yieldSpy });
+    // 2 prep-chunk yields + 1 yield per beer.
+    expect(yieldSpy.mock.calls.length).toBe(2 + items.length);
   });
 });

--- a/src/domain/match-list.ts
+++ b/src/domain/match-list.ts
@@ -1,4 +1,11 @@
-import { matchPrepared, prepareCatalog, type CatalogBeer } from './matcher';
+import {
+  matchPrepared,
+  prepareBeer,
+  makePreparedCatalog,
+  type CatalogBeer,
+  type PreparedBeer,
+  type PreparedCatalog,
+} from './matcher';
 
 export interface CatalogBeerWithRating extends CatalogBeer {
   rating_global: number | null;
@@ -24,31 +31,64 @@ export interface MatchListResult {
   user_rating: number | null;
 }
 
-export function matchBeerList(
+// ~0.027 ms/row on the prod catalog → 2000 rows ≈ ≤60 ms of normalization per chunk.
+const PREP_CHUNK = 2000;
+
+// Hands control back to the event loop so the long-poll bot processes its updates
+// between CPU bursts. setImmediate fires after pending I/O callbacks.
+export const yieldToEventLoop = (): Promise<void> =>
+  new Promise((resolve) => setImmediate(resolve));
+
+// Builds PreparedBeer[] in chunks, yielding between chunks, then assembles the catalog.
+async function prepareCatalogChunked(
+  catalog: CatalogBeerWithRating[],
+  yield_: () => Promise<void>,
+): Promise<PreparedCatalog> {
+  const beers: PreparedBeer[] = [];
+  for (let i = 0; i < catalog.length; i += PREP_CHUNK) {
+    const end = Math.min(i + PREP_CHUNK, catalog.length);
+    for (let j = i; j < end; j++) beers.push(prepareBeer(catalog[j]));
+    await yield_();
+  }
+  return makePreparedCatalog(beers);
+}
+
+export interface MatchListOptions {
+  // DI seam so tests can count yields deterministically; production uses the default.
+  yield?: () => Promise<void>;
+}
+
+export async function matchBeerList(
   catalog: CatalogBeerWithRating[],
   drunkSet: Set<number>,
   ratingByBeerId: Map<number, number>,
   items: MatchInput[],
-): MatchListResult[] {
+  opts: MatchListOptions = {},
+): Promise<MatchListResult[]> {
+  const yield_ = opts.yield ?? yieldToEventLoop;
   const byId = new Map(catalog.map((c) => [c.id, c]));
-  const prepared = prepareCatalog(catalog);
-  return items.map((item) => {
+  const prepared = await prepareCatalogChunked(catalog, yield_);
+  const out: MatchListResult[] = [];
+  for (const item of items) {
     const raw = { brewery: item.brewery, name: item.name };
     const m = matchPrepared(item, prepared);
     if (!m) {
-      return { raw, matched_beer: null, is_drunk: false, user_rating: null };
+      out.push({ raw, matched_beer: null, is_drunk: false, user_rating: null });
+    } else {
+      const beer = byId.get(m.id)!;
+      out.push({
+        raw,
+        matched_beer: {
+          id: beer.id,
+          name: beer.name,
+          brewery: beer.brewery,
+          rating_global: beer.rating_global,
+        },
+        is_drunk: drunkSet.has(m.id),
+        user_rating: ratingByBeerId.get(m.id) ?? null,
+      });
     }
-    const beer = byId.get(m.id)!;
-    return {
-      raw,
-      matched_beer: {
-        id: beer.id,
-        name: beer.name,
-        brewery: beer.brewery,
-        rating_global: beer.rating_global,
-      },
-      is_drunk: drunkSet.has(m.id),
-      user_rating: ratingByBeerId.get(m.id) ?? null,
-    };
-  });
+    await yield_();
+  }
+  return out;
 }

--- a/src/domain/matcher.test.ts
+++ b/src/domain/matcher.test.ts
@@ -1,4 +1,4 @@
-import { matchBeer, breweryAliases, breweryAliasesMatch, extractYear, prepareCatalog, matchPrepared, type CatalogBeer } from './matcher';
+import { matchBeer, breweryAliases, breweryAliasesMatch, extractYear, prepareCatalog, matchPrepared, prepareBeer, type CatalogBeer } from './matcher';
 
 const c = (over: Partial<CatalogBeer> & { id: number }): CatalogBeer => ({
   brewery: 'Pinta',
@@ -423,6 +423,16 @@ describe('matchBeer with official-suffix brewery', () => {
       cat,
     );
     expect(result).toEqual({ id: 42, confidence: 1, source: 'exact' });
+  });
+});
+
+describe('prepareBeer', () => {
+  it('precomputes nameNorm, breweryNorm and aliases', () => {
+    const p = prepareBeer({ id: 7, brewery: 'Piwne Podziemie Brewery', name: 'Hopinka IPA', abv: 6 });
+    expect(p.id).toBe(7);
+    expect(p.nameNorm).toBe('hopinka');            // STYLE_WORD "ipa" stripped
+    expect(p.breweryNorm).toBe('piwne podziemie');  // noise word "brewery" stripped
+    expect(p.aliases).toEqual(['piwne podziemie']);
   });
 });
 

--- a/src/domain/matcher.ts
+++ b/src/domain/matcher.ts
@@ -44,24 +44,36 @@ export interface PreparedCatalog {
   fullSearcher(): PreparedSearcher;
 }
 
-// `build` is injectable purely so tests can observe Searcher construction; the
-// default is the production builder.
-export function prepareCatalog(
-  catalog: CatalogBeer[],
-  build: (rows: PreparedBeer[]) => PreparedSearcher = defaultBuildSearcher,
-): PreparedCatalog {
-  const beers: PreparedBeer[] = catalog.map((c) => ({
+// Per-row preparation: precompute the normalizations once.
+export function prepareBeer(c: CatalogBeer): PreparedBeer {
+  return {
     ...c,
     nameNorm: normalizeName(c.name),
     breweryNorm: normalizeBrewery(c.brewery),
     aliases: breweryAliases(c.brewery),
-  }));
+  };
+}
+
+// Assembles a PreparedCatalog from already-prepared rows. `build` is injectable
+// purely so tests can observe Searcher construction; the default is the
+// production builder. `fullSearcher()` is memoized + lazily built.
+export function makePreparedCatalog(
+  beers: PreparedBeer[],
+  build: (rows: PreparedBeer[]) => PreparedSearcher = defaultBuildSearcher,
+): PreparedCatalog {
   let full: PreparedSearcher | undefined;
   return {
     beers,
     searcherFor: build,
     fullSearcher: () => (full ??= build(beers)),
   };
+}
+
+export function prepareCatalog(
+  catalog: CatalogBeer[],
+  build: (rows: PreparedBeer[]) => PreparedSearcher = defaultBuildSearcher,
+): PreparedCatalog {
+  return makePreparedCatalog(catalog.map(prepareBeer), build);
 }
 
 // Separator regex for collab/bilingual brewery names. Untappd uses:


### PR DESCRIPTION
## Summary
Follow-up to #83. The bot and Hono API share one Node event loop, so the synchronous `/match` froze the bot for its whole duration (~2 s on a 48-beer grid). This makes `/match` yield the event loop cooperatively so the long-poll bot stays responsive — **without** changing any match result.

Measured split (prod) showed the freeze was two CPU blocks: `prepareCatalog` (~541 ms over 20k rows) and the per-beer loop (≤66 ms/beer). So we yield in **both** places.

- `matcher.ts` stays the **synchronous, pure** matching kernel — refactored only to expose `prepareBeer` (per-row) + `makePreparedCatalog` (assembles the lazy searcher). `prepareCatalog` keeps its signature; the two jobs and the `matchBeer` wrapper are untouched.
- `match-list.ts`: `matchBeerList` is now **async** — builds the prepared catalog in `PREP_CHUNK = 2000` chunks with `setImmediate` yields, and yields after each beer. `opts.yield` is a test seam.
- `/match` route awaits it.

Stays single-threaded by design — true off-thread matching (worker_threads) is deferred to **#84**.

## Results
- Max synchronous block drops from ~2 s to ≤~66 ms (one beer) / ≤~60 ms (one prep chunk); bot no longer freezes.
- Wall-clock unchanged (~2 s — we interleave, not parallelize); matched count unchanged (equivalence test guards correctness).

## Test Plan
- [x] `matcher.test.ts` unchanged + new `prepareBeer` test (54 tests)
- [x] `match-list.test.ts`: existing cases awaited; prepare-once equivalence still green; new cooperative-yield test asserts exactly `2 prep + N beer` yields
- [x] `npm test` green: 528 passed (+2)
- [x] `npx tsc --noEmit` clean
- [x] Benchmark runs end-to-end against prod DB (async `matchBeerList`), matched count consistent with catalog

Spec: `docs/superpowers/specs/2026-06-08-match-nonblocking-cooperative-yield-design.md` · Plan: `docs/superpowers/plans/2026-06-08-match-nonblocking-cooperative-yield.md`. No `spec.md` contract change (public `/match` behavior + results unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)