### PR TITLE
Document Codex PR workflow rules

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -96,6 +96,16 @@ jobs:
           total=$((review_comments + reviews))
 
           if [ "$total" -eq 0 ]; then
+            reviewable_files="$(
+              git diff --name-only "origin/${{ github.base_ref }}...HEAD" \
+                | awk '!/^(package-lock\.json|[^/]+\.md|docs\/.*)$/ { count += 1 } END { print count + 0 }'
+            )"
+
+            if [ "$reviewable_files" -eq 0 ]; then
+              echo "::notice::AI review skipped because all changed files match IGNORE_PATTERNS."
+              exit 0
+            fi
+
             echo "::error::AI review finished without posting any PR review/comment. Check OpenAI quota, model name, token permissions, or action logs."
             exit 1
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,10 @@ When implementing a feature:
 - avoid extending scope beyond the request
 - avoid adding speculative future abstractions
 
+When changing the browser extension:
+
+- update the extension changelog as part of the same change
+
 ---
 
 Architecture
@@ -146,3 +150,11 @@ Changes should be:
 Prefer small, targeted pull requests over broad changes.
 
 If uncertain, choose the more conservative implementation.
+
+For every code change:
+
+- ask whether to create a pull request
+- if pull request creation is confirmed, create the PR
+- wait for review comments, if any
+- evaluate review comments technically before changing code
+- address review findings that are valid and worth addressing


### PR DESCRIPTION
## Summary
- document that extension changes must update the extension changelog
- document that code changes should ask about PR creation and follow review feedback when a PR is created

## Verification
- git diff --check