### PR TITLE
build(extension): auto-zip dist on build

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "postbuild": "python3 scripts/zip-dist.py",
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "package": "vite build && tsx scripts/release-notes.ts && python3 scripts/zip-dist.py",


### PR DESCRIPTION
## Summary

`npm run build` now also emits `warsaw-beer-overlay-<version>.zip` (the same loadable / bot-deliverable archive) via a `postbuild` hook calling the existing `scripts/zip-dist.py`. A downloadable artifact is always produced without a separate step.

- `package` / `release` invoke `vite build` directly (not `npm run build`), so they are unaffected — no double-zip.
- No CI workflow runs `npm run build` (only the AI-review workflow exists), so this adds nothing to CI.
- The zip is already gitignored.

## Test Plan

- [x] `npm run build` → builds dist/ and writes `warsaw-beer-overlay-0.1.0.zip` (verified, 9 files)
- [x] git status clean (zip ignored)