### PR TITLE
ci: fix false 'empty review' failures; review extension code

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -72,7 +72,7 @@ jobs:
           max_tokens: 10000
           MAX_PATCH_LENGTH: 10000
 
-          INCLUDE_PATTERNS: src//*.ts,tests//*.ts,scripts/**/*.ts,.github/workflows/*.yml
+          INCLUDE_PATTERNS: src/**/*.ts,tests/**/*.ts,scripts/**/*.ts,extension/**/*.ts,.github/workflows/*.yml
           IGNORE_PATTERNS: package-lock.json,*.md,docs/**
 
       - name: Verify review was posted
@@ -96,13 +96,17 @@ jobs:
           total=$((review_comments + reviews))
 
           if [ "$total" -eq 0 ]; then
+            # Count only files the reviewer actually looks at — must mirror
+            # INCLUDE_PATTERNS above. Files outside that scope (e.g. package.json,
+            # *.md, docs/, lockfiles) never get reviewed, so a PR touching only
+            # those legitimately produces no comment and must not fail here.
             reviewable_files="$(
               git diff --name-only "origin/${{ github.base_ref }}...HEAD" \
-                | awk '!/^(package-lock\.json|[^/]+\.md|docs\/.*)$/ { count += 1 } END { print count + 0 }'
+                | awk '/^(src|tests|scripts|extension)\/.*\.ts$/ || /^\.github\/workflows\/[^/]+\.yml$/ { count += 1 } END { print count + 0 }'
             )"
 
             if [ "$reviewable_files" -eq 0 ]; then
-              echo "::notice::AI review skipped because all changed files match IGNORE_PATTERNS."
+              echo "::notice::AI review skipped: no changed files are in the reviewer's scope (INCLUDE_PATTERNS)."
               exit 0
             fi
 


### PR DESCRIPTION
## Summary

Fixes the AI-review workflow going **red on PRs whose only changes are outside the reviewer's scope** (e.g. #99, which touches only `extension/package.json`).

**Root cause:** the *Verify review was posted* step counted any file not in a narrow ignore list (`package-lock.json`, root `*.md`, `docs/`) as "reviewable", but the reviewer (`anc95/ChatGPT-CodeReview`) only looks at `INCLUDE_PATTERNS`. So a `package.json`-only PR gets no comment (correct) yet was flagged as a silent failure (wrong) → red.

**Changes:**
- Mirror the verify step's reviewable-file count to `INCLUDE_PATTERNS` (only `.ts` under `src|tests|scripts|extension/` and `.github/workflows/*.yml`). Out-of-scope-only PRs now skip green with a notice.
- `INCLUDE_PATTERNS`: fix the `src//*.ts` typo and add `extension/**/*.ts` — the extension codebase was not being reviewed at all before.

## Test Plan
- [x] Verified the new awk locally: `package.json`/`*.md`/`docs/`/`.html` → 0 (skip); `.ts` under src/extension + workflow `.yml` → counted
- [ ] This PR changes a `.yml` in scope → reviewer should post a real review (green)
- [ ] After merge: re-run #99 (package.json only) → expect green "skipped" notice

🤖 Generated with [Claude Code](https://claude.com/claude-code)