### PR TITLE
Add BeerFreak extension adapter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,6 @@ For every code change:
 
 - ask whether to create a pull request
 - if pull request creation is confirmed, create the PR
-- wait for review comments, if any
+- after creating the PR, wait for review comments/checks to complete before reporting final status
 - evaluate review comments technically before changing code
 - address review findings that are valid and worth addressing

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+- Added BeerFreak shop support.
+
 ## [0.1.0] - 2026-06-08
 
 - Initial beta: drunk-status + rating overlay for beerrepublic.eu and onemorebeer.pl.

--- a/extension/manifest.config.ts
+++ b/extension/manifest.config.ts
@@ -22,6 +22,8 @@ export default defineManifest({
         'https://*.beerrepublic.eu/*',
         'https://onemorebeer.pl/*',
         'https://*.onemorebeer.pl/*',
+        'https://beerfreak.org/*',
+        'https://*.beerfreak.org/*',
       ],
       js: ['src/content/main.ts'],
       run_at: 'document_idle',

--- a/extension/src/manifest.test.ts
+++ b/extension/src/manifest.test.ts
@@ -22,7 +22,11 @@ describe('manifest', () => {
   });
 
   it('injects the content script on BeerFreak pages', () => {
-    expect(manifest.content_scripts[0].matches).toContain('https://beerfreak.org/*');
-    expect(manifest.content_scripts[0].matches).toContain('https://*.beerfreak.org/*');
+    expect(Array.isArray(manifest.content_scripts)).toBe(true);
+    expect(manifest.content_scripts.length).toBeGreaterThan(0);
+    const [contentScript] = manifest.content_scripts;
+    expect(Array.isArray(contentScript.matches)).toBe(true);
+    expect(contentScript.matches).toContain('https://beerfreak.org/*');
+    expect(contentScript.matches).toContain('https://*.beerfreak.org/*');
   });
 });

--- a/extension/src/manifest.test.ts
+++ b/extension/src/manifest.test.ts
@@ -5,7 +5,11 @@ import pkg from '../package.json';
 
 // defineManifest's return type is a union (object | Promise | fn); at build time
 // we pass a plain object, so narrow to a record for property access in the test.
-const manifest = manifestExport as { version: string; key: string };
+const manifest = manifestExport as {
+  version: string;
+  key: string;
+  content_scripts: Array<{ matches: string[] }>;
+};
 
 describe('manifest', () => {
   it('derives version from package.json (single source of truth)', () => {
@@ -15,5 +19,10 @@ describe('manifest', () => {
   it('pins a stable extension id via the key field', () => {
     expect(typeof manifest.key).toBe('string');
     expect(manifest.key.length).toBeGreaterThan(100);
+  });
+
+  it('injects the content script on BeerFreak pages', () => {
+    expect(manifest.content_scripts[0].matches).toContain('https://beerfreak.org/*');
+    expect(manifest.content_scripts[0].matches).toContain('https://*.beerfreak.org/*');
   });
 });

--- a/extension/src/sites/beerfreak.test.ts
+++ b/extension/src/sites/beerfreak.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { beerfreak } from './beerfreak';
+
+const html = readFileSync(resolve(__dirname, '../../tests/fixtures/beerfreak.html'), 'utf8');
+
+let cards: ReturnType<typeof beerfreak.parseCards>;
+beforeAll(() => {
+  cards = beerfreak.parseCards(new DOMParser().parseFromString(html, 'text/html'));
+});
+
+describe('beerfreak adapter', () => {
+  it('parses the Horoshop catalog cards', () => {
+    expect(cards.length).toBeGreaterThan(20);
+  });
+
+  it('uses embedded product metadata for brewery and name', () => {
+    expect(cards[0]).toMatchObject({
+      brewery: 'VOLTA BREWERY',
+      name: 'SMOOTHIE BEAST: RED CURRANT, YUZU, BLUEBERRY, RASPBERRY, BERGAMOT',
+    });
+  });
+
+  it('keeps collab slash names intact when metadata has no brewery', () => {
+    const collab = cards.find((c) => c.name.includes('Popihn/Brasserie Cambier'));
+    expect(collab).toMatchObject({
+      brewery: '',
+      name: 'Popihn/Brasserie Cambier DIPA DDH - DOLCITA',
+    });
+  });
+
+  it('does not define waitForGrid (SSR)', () => {
+    expect(beerfreak.waitForGrid).toBeUndefined();
+  });
+});

--- a/extension/src/sites/beerfreak.test.ts
+++ b/extension/src/sites/beerfreak.test.ts
@@ -4,6 +4,12 @@ import { resolve } from 'node:path';
 import { beerfreak } from './beerfreak';
 
 const html = readFileSync(resolve(__dirname, '../../tests/fixtures/beerfreak.html'), 'utf8');
+const PRODUCT_METADATA_RE = /products = \[[\s\S]*?\],\n    ids = \[[\s\S]*?\];/;
+
+function withoutProductMetadata(source: string): string {
+  expect(source).toMatch(PRODUCT_METADATA_RE);
+  return source.replace(PRODUCT_METADATA_RE, '');
+}
 
 let cards: ReturnType<typeof beerfreak.parseCards>;
 beforeAll(() => {
@@ -31,7 +37,7 @@ describe('beerfreak adapter', () => {
   });
 
   it('falls back to card title text when embedded product metadata is absent', () => {
-    const doc = new DOMParser().parseFromString(html.replace(/products = \[[\s\S]*?\],\n    ids = \[[\s\S]*?\];/, ''), 'text/html');
+    const doc = new DOMParser().parseFromString(withoutProductMetadata(html), 'text/html');
     const parsed = beerfreak.parseCards(doc);
 
     expect(parsed.length).toBeGreaterThan(20);

--- a/extension/src/sites/beerfreak.test.ts
+++ b/extension/src/sites/beerfreak.test.ts
@@ -30,6 +30,17 @@ describe('beerfreak adapter', () => {
     });
   });
 
+  it('falls back to card title text when embedded product metadata is absent', () => {
+    const doc = new DOMParser().parseFromString(html.replace(/products = \[[\s\S]*?\],\n    ids = \[[\s\S]*?\];/, ''), 'text/html');
+    const parsed = beerfreak.parseCards(doc);
+
+    expect(parsed.length).toBeGreaterThan(20);
+    expect(parsed[0]).toMatchObject({
+      brewery: '',
+      name: 'Volta Brewery SMOOTHIE BEAST: RED CURRANT, YUZU, BLUEBERRY, RASPBERRY, BERGAMOT',
+    });
+  });
+
   it('does not define waitForGrid (SSR)', () => {
     expect(beerfreak.waitForGrid).toBeUndefined();
   });

--- a/extension/src/sites/beerfreak.ts
+++ b/extension/src/sites/beerfreak.ts
@@ -1,0 +1,77 @@
+import type { Card, SiteAdapter } from './types';
+
+const CARD_SELECTOR = '.catalogCard.j-catalog-card';
+const CONTAINER_SELECTOR = '[data-catalog-view-block="products"]';
+
+interface ProductMeta {
+  id: number;
+  brand_title: string | null;
+  title: string;
+}
+
+function text(el: Element | null): string {
+  return el?.textContent?.replace(/\s+/g, ' ').trim() ?? '';
+}
+
+function cleanBrewery(raw: string | null): string {
+  return (raw ?? '')
+    .replace(/\s*\([^)]*\)\s*$/, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function cleanName(rawTitle: string, brewery: string): string {
+  const b = brewery.trim();
+  if (!b) return rawTitle.trim();
+
+  const prefix = rawTitle.slice(0, b.length);
+  if (prefix.toLowerCase() !== b.toLowerCase()) return rawTitle.trim();
+
+  return rawTitle.slice(b.length).trim() || rawTitle.trim();
+}
+
+function ownerDocument(root: ParentNode): Document | null {
+  return root instanceof Document ? root : root.ownerDocument;
+}
+
+function productMeta(root: ParentNode): Map<number, ProductMeta> {
+  const doc = ownerDocument(root);
+  if (!doc) return new Map();
+  const scripts = Array.from(doc.querySelectorAll('script'));
+  for (const script of scripts) {
+    const source = script.textContent ?? '';
+    const match = source.match(/products\s*=\s*(\[[\s\S]*?\])\s*,\s*ids\s*=/);
+    if (!match) continue;
+
+    try {
+      const rows = JSON.parse(match[1]) as ProductMeta[];
+      return new Map(rows.map((row) => [row.id, row]));
+    } catch {
+      return new Map();
+    }
+  }
+  return new Map();
+}
+
+export const beerfreak: SiteAdapter = {
+  id: 'beerfreak',
+  hostMatch: (url) => url.hostname === 'beerfreak.org' || url.hostname.endsWith('.beerfreak.org'),
+  reRenderContainerSelector: CONTAINER_SELECTOR,
+
+  parseCards(root) {
+    const meta = productMeta(root);
+    const cards: Card[] = [];
+    for (const el of Array.from(root.querySelectorAll<HTMLElement>(CARD_SELECTOR))) {
+      const id = Number(el.querySelector<HTMLElement>('.j-product-container')?.dataset.id);
+      const product = Number.isFinite(id) ? meta.get(id) : undefined;
+      const rawTitle = product?.title ?? text(el.querySelector('.catalogCard-title a'));
+      if (!rawTitle) continue;
+
+      const brewery = cleanBrewery(product?.brand_title ?? null);
+      const name = cleanName(rawTitle, brewery);
+      if (!name) continue;
+      cards.push({ el, brewery, name });
+    }
+    return cards;
+  },
+};

--- a/extension/src/sites/registry.test.ts
+++ b/extension/src/sites/registry.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { pickAdapter } from './registry';
 import { beerrepublic } from './beerrepublic';
 import { onemorebeer } from './onemorebeer';
+import { beerfreak } from './beerfreak';
 
 describe('pickAdapter', () => {
   it('selects beerrepublic for beerrepublic.eu', () => {
@@ -12,6 +13,10 @@ describe('pickAdapter', () => {
     expect(pickAdapter(new URL('https://onemorebeer.pl/piwa'))).toBe(onemorebeer);
   });
 
+  it('selects beerfreak for beerfreak.org', () => {
+    expect(pickAdapter(new URL('https://beerfreak.org/beer/'))).toBe(beerfreak);
+  });
+
   it('returns null for an unknown host', () => {
     expect(pickAdapter(new URL('https://example.com/'))).toBeNull();
   });
@@ -19,8 +24,8 @@ describe('pickAdapter', () => {
 
 describe('adapter ids', () => {
   it('every adapter has a unique non-empty id', () => {
-    const ids = [beerrepublic, onemorebeer].map((a) => a.id);
-    expect(ids).toEqual(['beerrepublic', 'onemorebeer']);
+    const ids = [beerrepublic, onemorebeer, beerfreak].map((a) => a.id);
+    expect(ids).toEqual(['beerrepublic', 'onemorebeer', 'beerfreak']);
     expect(new Set(ids).size).toBe(ids.length);
     for (const id of ids) expect(id.length).toBeGreaterThan(0);
   });

--- a/extension/src/sites/registry.ts
+++ b/extension/src/sites/registry.ts
@@ -1,8 +1,9 @@
 import type { SiteAdapter } from './types';
 import { beerrepublic } from './beerrepublic';
 import { onemorebeer } from './onemorebeer';
+import { beerfreak } from './beerfreak';
 
-export const ADAPTERS: SiteAdapter[] = [beerrepublic, onemorebeer];
+export const ADAPTERS: SiteAdapter[] = [beerrepublic, onemorebeer, beerfreak];
 
 export function pickAdapter(url: URL): SiteAdapter | null {
   return ADAPTERS.find((a) => a.hostMatch(url)) ?? null;

--- a/extension/tests/fixtures/beerfreak.html
+++ b/extension/tests/fixtures/beerfreak.html
@@ -1,0 +1,6964 @@
+<!DOCTYPE html>
+<html prefix="og: https://ogp.me/ns# article: https://ogp.me/ns/article# product: https://ogp.me/ns/product#" lang="uk">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width">
+    <title>Крафтове пиво всіх стилів з доставкою по Україні</title>
+<meta name="robots" content="all">
+<meta name="description" content="Краща ціна на ⭐крафтовое пиво⭐ у BeerFreak! Швидка доставка✅ Гарантія якості✅ Зручна оплата замовлення✅ ">
+<link rel="canonical" href="https://beerfreak.org/beer/">
+<link rel="next" href="https://beerfreak.org/beer/filter/page=2/">
+<link rel="alternate" hreflang="uk" href="https://beerfreak.org/beer/">
+<link rel="alternate" hreflang="en" href="https://beerfreak.org/en/beer/">
+    <meta property="og:locale" content="ua_UA">
+<meta property="og:site_name" content="BEERFREAK">
+<meta property="og:title" content="Крафтове пиво всіх стилів з доставкою по Україні">
+<meta property="og:url" content="https://beerfreak.org/beer/">
+<meta property="og:description" content="Краща ціна на ⭐крафтовое пиво⭐ у BeerFreak! Швидка доставка✅ Гарантія якості✅ Зручна оплата замовлення✅ ">
+<meta property="og:type" content="product.group">
+    <link rel='preload' as='image' href='/content/images/44/310x310l85nn0/volta-brewery-smoothie-beast-red-currant-yuzu-blueberry-raspberry-bergamot-80226971166628.png'><link rel='preload' as='image' href='/content/images/45/310x310l85nn0/volta-brewery-jamaica-blues-62064743510517.png'>    
+<script>
+(function (w) {
+    w.GLOBAL = {
+        SYSTEM_LANGUAGE: 3,
+        FIRST_LANGUAGE: 3,
+        DOMAIN: "beerfreak.org",
+        SITE_NAME: "BEERFREAK",
+        URI_PREFIX: "/",
+        URI_SUFFIX: "/",
+        theme: "horoshop_default",
+        currency: {"id":"1","i18n_language":"0","title":"UAH","abbr":" грн","position":"2","sortorder":"1","iso":"UAH","abbr_penny":"коп.","enabled_in_front":"0","sign":"₴"},
+        round_to: "0",
+        isGuest: true,
+        USER_ID: null,
+        open_cart_on_add: false,
+        cart_animation: false,
+        phone_mask: "+38 (099) 999-99-99",
+        use_countries: false,
+        enable_phone_mask_on_input: true,
+        marketingEvents: {"cart_creation":[function (model, eventId) {
+            try {
+                var products = model.Cart.products,
+    ids = [],
+    totalPrice = model.Cart.total.sum;
+
+for (key in products) {
+    ids.push(products[key].article + '');
+}
+
+gtag('event', 'Создание корзины', {
+    'event_category'  : 'Корзина',
+    'event_label'     : 'GLOBAL.DOMAIN',
+    'ecomm_prodid'    : ids,
+    'ecomm_pagetype'  : 'cart',
+    'ecomm_totalvalue': totalPrice
+});
+            } catch(e) {
+                console.error(e);
+            }
+        }],"cart_product_add":[function (model, eventId) {
+            try {
+                (function () {
+    var products = null;
+    
+    fbq('track', 'AddToCart', {
+            contents: [
+                {
+                    'id': model.article,
+                    'quantity': model.quantity * 1,
+                    'item_price': model.price * 1
+                }
+            ],
+            content_type: 'product',
+            currency: GLOBAL.currency.iso,
+            value: model.quantity * model.price 
+        },
+        {eventID: eventId}
+   );
+})();
+            } catch(e) {
+                console.error(e);
+            }
+        },function (model, eventId) {
+            try {
+                var products = model.Cart.products,
+    ids = [],
+    totalPrice = model.Cart.total.sum;
+
+for (key in products) {
+    ids.push(products[key].article + '');
+}
+
+gtag('event', 'add_to_cart', {
+    'currency': GLOBAL.currency.iso,
+    'value': totalPrice,
+    'items': [
+        {
+            'item_id': model.article + '',
+            'item_name': model.title,
+            'quantity': model.quantity * 1,
+            'price': model.price * 1
+        }
+    ],
+    'ecomm_prodid': ids,
+    'ecomm_pagetype': 'cart',
+    'ecomm_totalvalue': totalPrice
+});
+            } catch(e) {
+                console.error(e);
+            }
+        }],"cart_product_update":[],"cart_product_remove":[function (model, eventId) {
+            try {
+                var products = model.Cart.products,
+    ids = [],
+    totalPrice = model.Cart.total.sum;
+
+for (key in products) {
+    ids.push(products[key].article + '');
+}
+
+gtag('event', 'remove_from_cart', {
+    'currency': GLOBAL.currency.iso,
+    'value': totalPrice,
+    'items': [
+        {
+            'item_id': model.article + '',
+            'item_name': model.title,
+            'quantity': model.quantity * 1,
+            'price': model.price * 1
+        }
+    ],
+    'ecomm_prodid': ids,
+    'ecomm_pagetype': 'cart',
+    'ecomm_totalvalue': totalPrice
+});
+            } catch(e) {
+                console.error(e);
+            }
+        }],"quick_search":[],"checkout_success":[function (order_id, cart, name, email, phone, eventId) {
+            try {
+                var products = cart.products, contents = [];
+
+for (var i = 0, l = products.length; i < l; ++i) {
+    var product = products[i];
+    contents.push({
+        'id': product.article,
+        'quantity': product.quantity * 1,
+        'item_price': product.price * 1
+    });
+}
+
+fbq('track', 'Purchase', {
+    contents: contents,
+    content_type: 'product',
+    value: cart.total.total.sum,
+    currency: GLOBAL.currency.iso},
+    {eventID: eventId}
+);
+            } catch(e) {
+                console.error(e);
+            }
+        },function (order_id, cart, name, email, phone, eventId) {
+            try {
+                var items = [],
+    products = cart.products,
+    ids = [];
+
+for (var i = 0, l = products.length; i < l; ++i) {
+    var product = products[i];
+
+    items.push({
+        'item_id': product.article,
+        'item_name': product.title + ' (артикул: ' + product.article_for_display + ')',
+        'quantity': product.quantity * 1,
+        'price': product.price * 1
+    });
+
+    ids.push(product.article);
+}
+
+gtag('event', 'purchase', {
+    'transaction_id': order_id,
+    'affiliation': GLOBAL.SITE_NAME,
+    'value': cart.total.total.sum,
+    'currency': GLOBAL.currency.iso,
+    'tax': 0,
+    'shipping': cart.delivery_price,
+    'coupon': cart.total.coupon_data.code,
+    'items': items,
+    'ecomm_prodid': ids,
+    'ecomm_pagetype': 'purchase',
+    'ecomm_totalvalue': cart.total.total.sum
+});
+            } catch(e) {
+                console.error(e);
+            }
+        }],"newsletter_subscription":[function (model, eventId) {
+            try {
+                fbq('track', 'Lead');
+            } catch(e) {
+                console.error(e);
+            }
+        },function (model, eventId) {
+            try {
+                gtag('event', 'Подписка на рассылку', {
+        'event_category': 'Рассылка',
+        'event_label'   : 'GLOBAL.DOMAIN'
+    });
+            } catch(e) {
+                console.error(e);
+            }
+        }],"callback_submit":[function (model, eventId) {
+            try {
+                fbq('track', 'Lead', {}, {eventID: eventId});
+            } catch(e) {
+                console.error(e);
+            }
+        },function (model, eventId) {
+            try {
+                gtag('event', 'Запрос обратного звонка', {
+        'event_category': 'Обратный звонок',
+        'event_label'   : 'GLOBAL.DOMAIN'
+    });
+            } catch(e) {
+                console.error(e);
+            }
+        },function (model, eventId) {
+            try {
+                dataLayer.push({'event': 'callbackRequest'})
+            } catch(e) {
+                console.error(e);
+            }
+        }],"registration_success":[function (model, eventId) {
+            try {
+                fbq('track', 'CompleteRegistration', {}, {eventID: eventId});
+            } catch(e) {
+                console.error(e);
+            }
+        }],"authorization_success":[],"ajax_page_view":[function (model, eventId) {
+            try {
+                gtag('config', 'G-4YM69D6ZY0', {
+  'page_path': model
+});
+            } catch(e) {
+                console.error(e);
+            }
+        }],"add_to_wishlist":[function (model, eventId) {
+            try {
+                fbq('track', 'AddToWishlist', {
+content_ids: [model.article],
+content_type: 'product',
+currency: GLOBAL.currency.iso,
+value: model.price
+},
+{eventID: eventId}
+);
+            } catch(e) {
+                console.error(e);
+            }
+        }],"hover_phones":[function (model, eventId) {
+            try {
+                gtag('event', 'hover_phones');
+            } catch(e) {
+                console.error(e);
+            }
+        }],"call_phones":[function (model, eventId) {
+            try {
+                gtag('event', 'call_phones');
+            } catch(e) {
+                console.error(e);
+            }
+        }]},
+        content_copy_protection: false,
+        GLOBAL_CSRF_TOKEN: 'ad1bf52c23a48d21b915c567e6236c37bd5fccbc',
+        isMobile: false    };
+    w.dataLayer = w.dataLayer || [];
+})(window);
+</script><link href='/assets/default/production/styles.aac666c38006e6f652a63e74032b4148.css' type='text/css' rel='stylesheet'>
+<link href='/assets/default/production/client.1047d1b6baed2922d27686dd5f89a7b9.css' type='text/css' rel='stylesheet'>
+    <script src="/globals.js/?version=58e6184bb1182bb611c04b1b10ee9d78"></script>
+
+<script src='/assets/cache/horoshop_default_main.js?1772272946'></script>
+
+    <link rel="shortcut icon" href="/assets/favicon.ico" type="image/x-icon">
+    <script>
+  (function (window, document) {
+    'use strict';
+
+    const file = '/frontend/themes/horoshop_default/layout/img/icons-default.svg';
+    const revision = 'e85b8045f8fada8a6afb0eb18c4ef3ea';
+    const isLocalStorage = 'localStorage' in window && window['localStorage'] !== null;
+
+    let cachedData;
+
+    const insertSVG = () => {
+      const template = document.createElement('template');
+      template.innerHTML = cachedData;
+      document.body.prepend(template.content.firstChild);
+    };
+
+    const insert = () => {
+      if (document.body) {
+        insertSVG();
+      } else {
+        document.addEventListener('DOMContentLoaded', insertSVG);
+      }
+    };
+
+    const updateCache = (svgData) => {
+      if (isLocalStorage) {
+        localStorage.setItem('inlineSVGdata', svgData);
+        localStorage.setItem('inlineSVGrev', revision);
+      }
+    };
+
+    const loadSVG = async () => {
+      try {
+        const response = await fetch(file);
+        if (!response.ok) {
+          console.error('Error loading SVG:', response.status);
+          if (cachedData) insert();
+
+          return;
+        }
+        
+        const serverData = await response.text();
+        
+        if (cachedData !== serverData) {
+          cachedData = serverData;
+          insert();
+          updateCache(cachedData);
+        } else {
+          insert();
+        }
+      } catch (error) {
+        console.error('Error loading SVG:', error);
+        if (cachedData) insert();
+        
+        return;
+      }
+    };
+
+    const init = async () => {
+      if (isLocalStorage) {
+        const cachedRev = localStorage.getItem('inlineSVGrev');
+        if (cachedRev === revision) {
+          cachedData = localStorage.getItem('inlineSVGdata');
+          insert();
+          
+          return;
+        }
+      }
+      
+      await loadSVG();
+    };
+
+    if (document.body) {
+      init();
+    } else {
+      document.addEventListener('DOMContentLoaded', init);
+    }
+
+  }(window, document));
+</script>        <!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-M62JZL4');</script>
+<!-- End Google Tag Manager --><!-- Facebook Pixel Code -->
+<script>
+  !function(f,b,e,v,n,t,s)
+  {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+  n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+  if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';n.agent='plhoroshop';
+  n.queue=[];t=b.createElement(e);t.async=!0;
+  t.src=v;s=b.getElementsByTagName(e)[0];
+  s.parentNode.insertBefore(t,s)}(window, document,'script',
+  'https://connect.facebook.net/en_US/fbevents.js');
+  fbq('init', '2200686503365161');
+  fbq('track', 'PageView');
+</script>
+<noscript><img height="1" width="1" style="display:none"
+  src="https://www.facebook.com/tr?id=2200686503365161&ev=PageView&noscript=1"
+/></noscript>
+<!-- End Facebook Pixel Code -->
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src='https://www.googletagmanager.com/gtag/js?id=G-4YM69D6ZY0'></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-4YM69D6ZY0');
+</script><script>var items = [],
+    products = [{"id":10493,"article":"07652","brand_title":"VOLTA BREWERY (Україна)","title":"Volta Brewery SMOOTHIE BEAST: RED CURRANT, YUZU, BLUEBERRY, RASPBERRY, BERGAMOT","price":169,"url":"https:\/\/beerfreak.org\/volta-brewery-smoothie-beast-red-currant-yuzu-blueberry-raspberry-bergamot\/","category_string":"Пиво","article_for_display":"07652","in_stock":true},{"id":10494,"article":"07653","brand_title":"VOLTA BREWERY (Україна)","title":"Volta Brewery JAMAICA BLUES","price":149,"url":"https:\/\/beerfreak.org\/volta-brewery-jamaica-blues\/","category_string":"Пиво","article_for_display":"07653","in_stock":true},{"id":10495,"article":"07654","brand_title":"VOLTA BREWERY (Україна)","title":"Volta Brewery MODERN PILSNER","price":129,"url":"https:\/\/beerfreak.org\/volta-brewery-modern-pilsner\/","category_string":"Пиво","article_for_display":"07654","in_stock":true},{"id":10496,"article":"07655","brand_title":"VOLTA BREWERY (Україна)","title":"Volta Brewery MODERN STOUT","price":129,"url":"https:\/\/beerfreak.org\/volta-brewery-modern-stout\/","category_string":"Пиво","article_for_display":"07655","in_stock":true},{"id":10497,"article":"07656","brand_title":"HOPPY HOG BREWERY (Україна)","title":"Hoppy Hog Family Brewery Tropical Veil NEIPA","price":159,"url":"https:\/\/beerfreak.org\/hoppy-hog-family-brewery-tropical-veil-neipa\/","category_string":"Пиво","article_for_display":"07656","in_stock":true},{"id":10498,"article":"07657","brand_title":"HOPPY HOG BREWERY (Україна)","title":"Hoppy Hog Family Brewery Charred Memory","price":179,"url":"https:\/\/beerfreak.org\/hoppy-hog-family-brewery-charred-memory\/","category_string":"Пиво","article_for_display":"07657","in_stock":true},{"id":7579,"article":"04952","brand_title":"REBREW (Україна)","title":"Rebrew Труханів острів Session IPA","price":139,"url":"https:\/\/beerfreak.org\/rebrew-trukhaniv-ostriv-session-ipa\/","category_string":"Пиво","article_for_display":"04952","in_stock":true},{"id":9106,"article":"06375","brand_title":"REBREW (Україна)","title":"Rebrew ТРАМВАЙ НА СИХІВ NEIPA З АПЕЛЬСИНОВИМ СОКОМ","price":159,"url":"https:\/\/beerfreak.org\/rebrew-tramvai-na-sykhiv-neipa-z-apelsynovym-sokom\/","category_string":"Пиво","article_for_display":"06375","in_stock":true},{"id":10027,"article":"07201","brand_title":"BROKREACJA BREWERY (Польща)","title":"Browar Brokreacja NAFCIARZ 19","price":249,"url":"https:\/\/beerfreak.org\/browar-brokreacja-nafciarz-19\/","category_string":"Пиво","article_for_display":"07201","in_stock":true},{"id":10028,"article":"07202","brand_title":"BROKREACJA BREWERY (Польща)","title":"Browar Brokreacja Duotaur","price":299,"url":"https:\/\/beerfreak.org\/browar-brokreacja-duotaur\/","category_string":"Пиво","article_for_display":"07202","in_stock":true},{"id":10029,"article":"07203","brand_title":"BROKREACJA BREWERY (Польща)","title":"Browar Brokreacja Lord of the Pils","price":229,"url":"https:\/\/beerfreak.org\/browar-brokreacja-lord-of-the-pils\/","category_string":"Пиво","article_for_display":"07203","in_stock":true},{"id":10031,"article":"07205","brand_title":"BROKREACJA BREWERY (Польща)","title":"Browar Brokreacja Starling","price":269,"url":"https:\/\/beerfreak.org\/browar-brokreacja-starling\/","category_string":"Пиво","article_for_display":"07205","in_stock":true},{"id":10270,"article":"07441","brand_title":"BROKREACJA BREWERY (Польща)","title":"Browar Brokreacja Under Pressure","price":259,"url":"https:\/\/beerfreak.org\/browar-brokreacja-under-pressure\/","category_string":"Пиво","article_for_display":"07441","in_stock":true},{"id":10456,"article":"07624","brand_title":"PINTA (Польща)","title":"PINTA\/Folkingebrew Hazy Discovery Groningen","price":349,"url":"https:\/\/beerfreak.org\/pinta-folkingebrew-hazy-discovery-groningen\/","category_string":"Пиво","article_for_display":"07624","in_stock":true},{"id":10457,"article":"07625","brand_title":"PINTA (Польща)","title":"PINTA\/Varietal Beer Company Hazy Discovery Sunnyside","price":349,"url":"https:\/\/beerfreak.org\/pinta-varietal-beer-company-hazy-discovery-sunnyside\/","category_string":"Пиво","article_for_display":"07625","in_stock":true},{"id":10460,"article":"07634","brand_title":"BROKREACJA BREWERY (Польща)","title":"Browar Brokreacja BRO HERO: JERRY","price":229,"url":"https:\/\/beerfreak.org\/browar-brokreacja-bro-hero-jerry\/","category_string":"Пиво","article_for_display":"07634","in_stock":true},{"id":10461,"article":"07635","brand_title":"BROKREACJA BREWERY (Польща)","title":"Browar Brokreacja Polaron Prime","price":269,"url":"https:\/\/beerfreak.org\/browar-brokreacja-polaron-prime\/","category_string":"Пиво","article_for_display":"07635","in_stock":true},{"id":10462,"article":"07636","brand_title":"BROKREACJA BREWERY (Польща)","title":"Browar Brokreacja Wolfgang","price":219,"url":"https:\/\/beerfreak.org\/browar-brokreacja-wolfgang\/","category_string":"Пиво","article_for_display":"07636","in_stock":true},{"id":10463,"article":"07637","brand_title":"BROKREACJA BREWERY (Польща)","title":"Browar Brokreacja Stargazer","price":259,"url":"https:\/\/beerfreak.org\/browar-brokreacja-stargazer\/","category_string":"Пиво","article_for_display":"07637","in_stock":true},{"id":10478,"article":"07639","brand_title":"REBREW (Україна)","title":"Rebrew KOTOMATO GINGER TOMATO GOSE","price":159,"url":"https:\/\/beerfreak.org\/rebrew-kotomato-ginger-tomato-gose\/","category_string":"Пиво","article_for_display":"07639","in_stock":true},{"id":10479,"article":"07640","brand_title":"REBREW (Україна)","title":"Rebrew KOTOMATO WASABI TOMATO GOSE","price":159,"url":"https:\/\/beerfreak.org\/rebrew-kotomato-wasabi-tomato-gose\/","category_string":"Пиво","article_for_display":"07640","in_stock":true},{"id":10480,"article":"07641","brand_title":"REBREW (Україна)","title":"Rebrew REBREW X MAX KIDRUK","price":159,"url":"https:\/\/beerfreak.org\/rebrew-rebrew-x-max-kidruk\/","category_string":"Пиво","article_for_display":"07641","in_stock":true},{"id":10481,"article":"07642","brand_title":"REBREW (Україна)","title":"Rebrew\/Efir Brewery HOME REBREWING 2. VOLUME 3: EFIR BREWERY MANGO & PASSION FRUIT SOUR MILKSHAKE IPA","price":179,"url":"https:\/\/beerfreak.org\/rebrew-efir-brewery-home-rebrewing-2.-volume-3-efir-brewery-mango-passion-fruit-sour-milkshake-ipa\/","category_string":"Пиво","article_for_display":"07642","in_stock":true},{"id":10482,"article":"07643","brand_title":"HOPPY HOG BREWERY (Україна)","title":"Hoppy Hog Family Brewery Krow Moskala Kondari","price":159,"url":"https:\/\/beerfreak.org\/hoppy-hog-family-brewery-krow-moskala-kondari\/","category_string":"Пиво","article_for_display":"07643","in_stock":true},{"id":10483,"article":"07644","brand_title":"HOPPY HOG BREWERY (Україна)","title":"Hoppy Hog Family Brewery Krow Moskala Pico De Gallo","price":159,"url":"https:\/\/beerfreak.org\/hoppy-hog-family-brewery-krow-moskala-pico-de-gallo\/","category_string":"Пиво","article_for_display":"07644","in_stock":true},{"id":10484,"article":"07646","brand_title":"HOPPY HOG BREWERY (Україна)","title":"Hoppy Hog Family Brewery Real Jam Fruit BOOM","price":169,"url":"https:\/\/beerfreak.org\/hoppy-hog-family-brewery-real-jam-fruit-boom\/","category_string":"Пиво","article_for_display":"07646","in_stock":true},{"id":10488,"article":"07647","brand_title":"SHO BREWERY (Україна)","title":"SHO Brewery (IIIO) Narcissus","price":159,"url":"https:\/\/beerfreak.org\/sho-brewery-iiio-narcissus\/","category_string":"Пиво","article_for_display":"07647","in_stock":true},{"id":10489,"article":"07648","brand_title":"SHO BREWERY (Україна)","title":"SHO Brewery (IIIO) Nebula Juice","price":169,"url":"https:\/\/beerfreak.org\/sho-brewery-iiio-nebula-juice\/","category_string":"Пиво","article_for_display":"07648","in_stock":true},{"id":10490,"article":"07649","brand_title":"SHO BREWERY (Україна)","title":"SHO Brewery (IIIO) Gozel 2.0","price":139,"url":"https:\/\/beerfreak.org\/sho-brewery-iiio-gozel-2.0\/","category_string":"Пиво","article_for_display":"07649","in_stock":true},{"id":10491,"article":"07650","brand_title":"SHO BREWERY (Україна)","title":"SHO Brewery (IIIO) Hellь","price":139,"url":"https:\/\/beerfreak.org\/sho-brewery-iiio-hell\/","category_string":"Пиво","article_for_display":"07650","in_stock":true},{"id":10492,"article":"07651","brand_title":"KYIV LOCAL BREWERY (Україна)","title":"Kyiv Local Brewery Alco Free Dark","price":109,"url":"https:\/\/beerfreak.org\/kyiv-local-brewery-alco-free-dark\/","category_string":"Пиво","article_for_display":"07651","in_stock":true},{"id":10403,"article":"07571","brand_title":"LA SUPERBE (Франція)","title":"La Superbe MASTERMIND","price":499,"url":"https:\/\/beerfreak.org\/la-superbe-mastermind\/","category_string":"Пиво","article_for_display":"07571","in_stock":true},{"id":10404,"article":"07572","brand_title":"LA SUPERBE (Франція)","title":"La Superbe BUG.EXE","price":499,"url":"https:\/\/beerfreak.org\/la-superbe-bug.exe\/","category_string":"Пиво","article_for_display":"07572","in_stock":true},{"id":10405,"article":"07573","brand_title":null,"title":"Popihn\/Brasserie Cambier DIPA DDH - DOLCITA","price":499,"url":"https:\/\/beerfreak.org\/popihn-brasserie-cambier-dipa-ddh-dolcita\/","category_string":"Пиво","article_for_display":"07573","in_stock":true},{"id":10406,"article":"07574","brand_title":" SPARKLE ✨(Франція)","title":"Sparkle ✨ Sunset Boulevard DDH Nectaron","price":549,"url":"https:\/\/beerfreak.org\/sparkle-sunset-boulevard-ddh-nectaron\/","category_string":"Пиво","article_for_display":"07574","in_stock":true},{"id":10407,"article":"07575","brand_title":" SPARKLE ✨(Франція)","title":"Sparkle ✨ Infiniment Nectaron (2026)","price":649,"url":"https:\/\/beerfreak.org\/sparkle-infiniment-nectaron-2026\/","category_string":"Пиво","article_for_display":"07575","in_stock":true},{"id":10408,"article":"07576","brand_title":" SPARKLE ✨(Франція)","title":"Sparkle ✨ Degen Dotcom","price":699,"url":"https:\/\/beerfreak.org\/sparkle-degen-dotcom\/","category_string":"Пиво","article_for_display":"07576","in_stock":true},{"id":10409,"article":"07577","brand_title":" SPARKLE ✨(Франція)","title":"Sparkle ✨ Birthday #1 Riwaka (2026)","price":699,"url":"https:\/\/beerfreak.org\/sparkle-birthday-1-riwaka-2026\/","category_string":"Пиво","article_for_display":"07577","in_stock":true},{"id":10410,"article":"07578","brand_title":" SPARKLE ✨(Франція)","title":"Sparkle ✨ Birthday #2 Peacharine (2026)","price":699,"url":"https:\/\/beerfreak.org\/sparkle-birthday-2-peacharine-2026\/","category_string":"Пиво","article_for_display":"07578","in_stock":true},{"id":10411,"article":"07579","brand_title":" SPARKLE ✨(Франція)","title":"Sparkle ✨ Birthday #3 Nectaron (2026)","price":699,"url":"https:\/\/beerfreak.org\/sparkle-birthday-3-nectaron-2026\/","category_string":"Пиво","article_for_display":"07579","in_stock":true}],
+    ids = [],
+    total = 0,
+    productsPerEvent = 5,
+
+    sendEvent = function(items, ids, total) {
+        gtag('event', 'view_item_list', {
+            'item_list_name': 'Catalog Page',
+            'items': items,
+            'ecomm_prodid': ids,
+            'ecomm_pagetype': 'category',
+            'ecomm_totalvalue': total
+        });
+    };
+
+for (var i = 0, l = products.length; i < l; ++i) {
+    var product = products[i];
+
+    items.push({
+        'item_id': product.article + '',
+        'item_name': product.title,
+        'item_category': product.category_string,
+        'item_brand': product.brand_title,
+        'item_list_id': i + 1,
+        'price': product.price
+    });
+
+    ids.push(product.article + '');
+    total = total + product.price;
+
+    if (items.length === productsPerEvent) {
+        sendEvent(items, ids, total);
+
+        items = [];
+        ids = [];
+        total = 0;
+    }
+}
+
+if (items.length > 0) {
+    sendEvent(items, ids, total);
+}</script>
+<!-- Hotjar Tracking Code for beerfreak.org -->
+<script>
+    (function(h,o,t,j,a,r){
+        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+        h._hjSettings={hjid:1668970,hjsv:6};
+        a=o.getElementsByTagName('head')[0];
+        r=o.createElement('script');r.async=1;
+        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+        a.appendChild(r);
+    })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+</script>
+
+<!-- Install this snippet AFTER the Hotjar tracking code. -->
+<script>
+var userId = your_user_id || null; // Replace your_user_id with your own if available.
+window.hj('identify', userId, {
+    'Signed up': '2019—06-20Z', // Signup date in ISO-8601 format.
+    // Add your own custom attributes here. Some examples:
+    // 'Last purchase category': 'Electronics', // Send strings with quotes around them.
+    // 'Total purchases': 15, // Send numbers without quotes.
+    // 'Last purchase date': '2019-06-20Z', // Send dates in ISO-8601 format. 
+    // 'Last refund date': null, // Send null when no value exists for a user.
+});
+</script>                    </head>
+<body class=" ua-UA" itemscope itemtype="https://schema.org/WebPage">
+    <!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-4YM69D6ZY0"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-4YM69D6ZY0');
+</script>            <div class="session-messages" id="j-sm" style="display:none;"></div>
+    <div class="container">
+                
+<div class="header ">
+    <div class="header__container">
+                    <div class="header__top">
+                <div class="header__wrapper">
+                    <div class="header__layout header__layout--top">
+                                                    <div class="header__column header__column--left header__column--side">
+                                                                        <div class="header__section">
+        <div class="social-icons"><!--
+            --><a class="social-icons__item" data-fake-href="https://www.instagram.com/beerfreakorg" rel="nofollow" target="_blank" title="Мы в инстаграмме"><svg class="social-icons__img icon-ig"><use xlink:href="#icon-ig"></use></svg></a><!--
+            --><a class="social-icons__item" data-fake-href="https://t.me/beerfreakorg" rel="nofollow" target="_blank" title="Telegram"><svg class="social-icons__img icon-tg"><use xlink:href="#icon-tg"></use></svg></a><!--
+        --></div>    </div>     
+                                                            </div>
+                                                                            <div class="header__column header__column--center">
+                                                                    <div class="header__section">
+    <div class="header__slogan">ВІДПРАВКИ ЗДІЙСНЮЮТЬСЯ В БУДНІ ДНІ з 10 до 18. БЕЗКОШТОВНА ДОСТАВКА від 4000 ГРН</div></div>                                                            </div>
+                                                                            <div class="header__column header__column--right header__column--side">
+                                                                    <div class="header__section">
+    <ul class="lang-menu" data-widget="lang_menu" data-skin="header " data-show-icon=" ">
+                                            <li class="lang-menu__item is-active">
+                    <span class="lang-menu__link">Укр</span>
+                </li>
+                                                <li class="lang-menu__item">
+                    <a
+                                                href="/en/beer/"
+                        class="lang-menu__link"
+                    >
+                        Eng                    </a>
+                </li>
+                        </ul></div>                                                            </div>
+                                            </div>
+                </div>
+            </div>
+                <div class="header__middle">
+            <div class="header__wrapper">
+                <div class="header__layout header__layout--middle">
+                                            <div class="header__column header__column--left header__column--side">
+                                                            <div class="header__section header__section--search">
+    <div class="search j-search">
+        <form method="get" data-action="/catalog/search/">
+            <input class="search__input" id="search_uid4f1320c136d7f6222104ec6462f00bba" type="text" name="q"
+                   placeholder="пошук товарів" autocomplete="off" value="">
+            <button type="submit" class="search__button" disabled>
+                <svg class="icon icon--search">
+                    <use xlink:href="#icon-search"></use>
+                </svg>
+            </button>
+        </form>
+    </div>
+    <div class="search__results" id="search_uid4f1320c136d7f6222104ec6462f00bba-search-results"></div>
+    <script>
+      (function (w) {
+        w.INIT.add(function () {
+          init_search_widget('#search_uid4f1320c136d7f6222104ec6462f00bba', {
+            hideQuery: true,
+          });
+        }, w.init_search_widget);
+      })(window);
+    </script></div>                                                    </div>
+                                                                                    <div class="header__column header__column--center">
+                                                            <div class="header__section">
+    <div class="header__logo">
+                    <a class="header__logo-link" href='/'>
+                <img alt='BEERFREAK'  class='header-logo-img' width='163' height='100' src='/content/images/2/163x100l90nn0/80381316113904.jpg'  
+                                    srcset="
+                                    /content/images/2/163x100l90nn0/80381316113904.jpg 1x,
+                                    /content/images/2/325x200l50nn0/80381316113904.jpg 2x
+                                    ">            </a>
+            </div></div>                                                    </div>
+                                                                <div class="header__column header__column--right header__column--side">
+                                                            <div class="header__section">
+    <div class="basket is-empty j-basket-header"
+         data-widget="mini_cart"
+         data-skin="default"
+         data-icon="basket-outline"
+         data-elements="icon"
+    >
+                    <div class="basket__icon basket__icon--basket-outline j-basket-icon">
+                <svg class="icon icon--basket-outline">
+                    <use xlink:href="#icon-basket-outline"></use>
+                </svg>
+                <div class="basket__items j-basket-quantity">
+                    0                </div>
+            </div>
+            </div></div>                                                            <div class="header__section">
+    <div class="favorites-view" id="uid63a8111d891195c86a92a507c29b6bc4">
+    <a href="/profile/favorites/" class="favorites-view__button j-favorite-link  is-disabled">
+        <div class="favorites-view__icon">
+            <div class="favorites-view__icon-container">
+                <span class="favorites-view__count  j-count" style="display: none;">0</span>
+                                    <svg class="icon icon--heart-outline"><use xlink:href="#icon-heart-outline"></use></svg>
+                            </div>
+        </div>
+            </a>
+    <div class="favorites-view__tooltip j-tooltip" >
+        Додайте товари до списку бажань    </div>
+</div>
+<script>
+    (function (w) {
+        w.INIT.add(function () {
+            var container = $('#uid63a8111d891195c86a92a507c29b6bc4'),
+                allow = false,
+                link = container.find('.j-favorite-link'),
+                count = container.find('.j-count'),
+                tooltip = container.find('.j-tooltip');
+
+            link.off('click').on('click', function (e) {
+                if ($(this).hasClass('is-disabled')) {
+                    e.preventDefault();
+                }
+
+            });
+            FavoritesList.attachEventHandlers({
+                onChange: function () {
+                    var countVal = this.count * 1;
+                    allow = countVal !== 0;
+                    if (countVal === 0) {
+                        link.addClass('is-disabled');
+                        count.hide();
+                        tooltip.show();
+                    } else {
+                        link.removeClass('is-disabled');
+                        count.show();
+                        tooltip.hide();
+                    }
+                    count.html(countVal);
+                }
+            });
+            $(function() {
+                $('.favorites-view__tooltip').dropdown({
+                    trigger: '.favorites-view__button',
+                    visibleClass: 'is-visible',
+                    hoverClass: 'is-hover'
+                });
+            })
+        }, w.FavoritesList)
+    })(window);
+</script></div>                                                            <div class="header__section">
+    <div data-widget="userbar" data-skin="default">
+            <div class="userbar j-user-tabs">
+            <a class="userbar__button" data-fake-href="#j-popup-tab-auth" data-modal="#sign-in">
+                                    <svg class="icon icon--user-outline">
+                        <use xlink:href="#icon-user-outline"></use>
+                    </svg>
+                                            </a>
+        </div>
+        <script>
+            (function(w) {
+                w.INIT.add(function() {
+                    initTabs('.j-user-tabs a', {triggerMap: true});
+                })
+            })(window);
+        </script>
+    </div>
+
+<script>
+    (function(w) {
+        w.INIT.add(function() {
+            $('.userbar__dropdown').dropdown({
+                trigger: '.userbar__button',
+                parentNode: null,
+                visibleClass: 'is-visible',
+                hoverClass: 'is-hover'
+            });
+        }, w.$)
+    })(window);
+</script></div>                                                    </div>
+                                    </div>
+            </div>
+        </div>
+                    <div class="header__bottom">
+                <div class="header__wrapper">
+                    <div class="header__layout header__layout--bottom">
+                                                                            <div class="header__column header__column--center ">
+                                                                    <div class="header__section header__section--catalog-menu">
+    <div class="products-menu j-products-menu">
+    <ul class="products-menu__container">
+                    <li class="products-menu__item __active j-submenu-item">
+                <div class="products-menu__title">
+                    <a class="products-menu__title-link" href="/beer/">
+                                                Пиво                    </a>
+                </div>
+                                    <div class="productsMenu-submenu __fluidGrid">
+        <ul class="productsMenu-submenu-w">
+        <!--
+                    --><li class="productsMenu-submenu-i ">
+                <a class="productsMenu-submenu-a" href="/classic-traditional/">
+                                        <span class="productsMenu-submenu-t">Classic & Traditional</span>
+                </a>
+                                    <ul class="productsMenu-list">
+                                                    <li class="productsMenu-list-i "><a href="/barleywine-strong-ale/">Barleywine & Strong Ale</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/red-amber-brown-ale/">Red, Amber & Brown Ale</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/english-scotch-ale/">English & Scotch Ale</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/fruit-spiced-beer/">Fruit & Spiced Beer</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/belgian-ale/">Belgian Ale</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/trappist-beer/">Trappist Beer</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/pilsner-lager-beer/">Pilsner & Lager Beer</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/smoked-beer/">Smoked Beer</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/wheat-beer/">Wheat Beer</a></li>
+                        
+                    </ul>
+                            </li><!--
+                    --><li class="productsMenu-submenu-i ">
+                <a class="productsMenu-submenu-a" href="/india-pale-ale/">
+                                        <span class="productsMenu-submenu-t">IPA</span>
+                </a>
+                                    <ul class="productsMenu-list">
+                                                    <li class="productsMenu-list-i "><a href="/ipa/">India Pale Ale</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/pale-ale-ipl/">Pale Ale & IPL</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/micro-session-ipa/">Micro & Session IPA</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/red-black-ipa/">Red & Black IPA</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/dipa-imperial-ipa/">DIPA & Imperial IPA</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/hazy-new-england-ipa/">Hazy & New England IPA </a></li>
+                                                    <li class="productsMenu-list-i "><a href="/milkshake-fruit-ipa/">Milkshake & Fruit IPA</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/ipa-other/">IPA - Other</a></li>
+                        
+                    </ul>
+                            </li><!--
+                    --><li class="productsMenu-submenu-i ">
+                <a class="productsMenu-submenu-a" href="/sour-wild-ale/">
+                                        <span class="productsMenu-submenu-t">Sour & Wild Ale</span>
+                </a>
+                                    <ul class="productsMenu-list">
+                                                    <li class="productsMenu-list-i "><a href="/geuze/">Geuze & Lambic</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/fruit-lambic/">Fruit Lambic</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/flemish-ale/">Flemish Ale</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/fruited-sour-ale/">Fruited Sour Ale</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/berliner-weisse-gose/">Berliner Weisse & Gose</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/wild-ale/">Wild Ale</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/smoothie-pastry-sour/">Smoothie & Pastry Sour</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/tomato-vegetable-gose/">Tomato & Vegetable Gose</a></li>
+                        
+                    </ul>
+                            </li><!--
+                    --><li class="productsMenu-submenu-i ">
+                <a class="productsMenu-submenu-a" href="/stout-porter/">
+                                        <span class="productsMenu-submenu-t">Stout & Porter</span>
+                </a>
+                                    <ul class="productsMenu-list">
+                                                    <li class="productsMenu-list-i "><a href="/stout/">Stout</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/porter-baltic-porter/">Porter & Baltic Porter</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/imperial-stout-porter/">Imperial Stout & Porter</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/sweet-pastry-stout/">Sweet & Pastry Stout</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/spiced-stout-porter/">Spiced Stout & Porter</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/barrel-aged-stout-porter/">Barrel Aged Stout & Porter</a></li>
+                        
+                    </ul>
+                            </li><!--
+                    --><li class="productsMenu-submenu-i ">
+                <a class="productsMenu-submenu-a" href="/experimental-beer/">
+                                        <span class="productsMenu-submenu-t">Experimental Beer</span>
+                </a>
+                            </li><!--
+                    -->
+        </ul>
+    </div>                    
+            </li>
+                    <li class="products-menu__item j-submenu-item">
+                <div class="products-menu__title">
+                    <a class="products-menu__title-link" href="/cider-mead-other/">
+                                                Сидр та Мед                    </a>
+                </div>
+                                    <div class="productsMenu-submenu __fluidGrid">
+        <ul class="productsMenu-submenu-w">
+        <!--
+                    --><li class="productsMenu-submenu-i ">
+                <a class="productsMenu-submenu-a" href="/dry-brut-cider/">
+                                        <span class="productsMenu-submenu-t">Сухий сидр</span>
+                </a>
+                            </li><!--
+                    --><li class="productsMenu-submenu-i ">
+                <a class="productsMenu-submenu-a" href="/sweet-semi-sweet-cider/">
+                                        <span class="productsMenu-submenu-t">Солодкий та напівсолодкий сидр</span>
+                </a>
+                            </li><!--
+                    --><li class="productsMenu-submenu-i ">
+                <a class="productsMenu-submenu-a" href="/fruit-cider/">
+                                        <span class="productsMenu-submenu-t">Фруктовий сидр</span>
+                </a>
+                            </li><!--
+                    --><li class="productsMenu-submenu-i ">
+                <a class="productsMenu-submenu-a" href="/mead/">
+                                        <span class="productsMenu-submenu-t">Мед</span>
+                </a>
+                            </li><!--
+                    -->
+        </ul>
+    </div>                    
+            </li>
+                    <li class="products-menu__item j-submenu-item">
+                <div class="products-menu__title">
+                    <a class="products-menu__title-link" href="/beer-collections/">
+                                                Колекцiї                    </a>
+                </div>
+                                    <div class="productsMenu-submenu __fluidGrid">
+        <ul class="productsMenu-submenu-w">
+        <!--
+                    --><li class="productsMenu-submenu-i ">
+                <a class="productsMenu-submenu-a" href="/beer-sets/">
+                                        <span class="productsMenu-submenu-t">Подарунковi набори</span>
+                </a>
+                                    <ul class="productsMenu-list">
+                                                    <li class="productsMenu-list-i "><a href="/gift-certificates/">Подарункові сертифікати</a></li>
+                        
+                    </ul>
+                            </li><!--
+                    --><li class="productsMenu-submenu-i ">
+                <a class="productsMenu-submenu-a" href="/countries/">
+                                        <span class="productsMenu-submenu-t">Країни</span>
+                </a>
+                                    <ul class="productsMenu-list">
+                                                    <li class="productsMenu-list-i "><a href="/austria/">Австрія</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/england/">Англія</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/belgium/">Бельгiя </a></li>
+                                                    <li class="productsMenu-list-i "><a href="/bulgaria/">Болгарія </a></li>
+                                                    <li class="productsMenu-list-i "><a href="/brazil/">Бразилія</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/denmark/">Данія</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/estonia/">Естонія</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/ireland/">Ірландія</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/italy/">Італія</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/spain/">Іспанія</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/latvia/">Латвія</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/netherlands/">Нідерланди</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/germany/">Німеччина</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/norway/">Норвегія</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/poland/">Польща </a></li>
+                                                    <li class="productsMenu-list-i "><a href="/slovakia/">Словаччина</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/usa/">США</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/ukraine/">Український крафт</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/sweden/">Швеція</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/scotland/">Шотландія</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/romania/">Румунія</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/france/">Франція</a></li>
+                                                    <li class="productsMenu-list-i "><a href="/sroatia/">Хорватія</a></li>
+                        
+                    </ul>
+                            </li><!--
+                    --><li class="productsMenu-submenu-i ">
+                <a class="productsMenu-submenu-a" href="/beer-sets-bundles/">
+                                        <span class="productsMenu-submenu-t">Сети пива</span>
+                </a>
+                            </li><!--
+                    --><li class="productsMenu-submenu-i ">
+                <a class="productsMenu-submenu-a" href="/sommelier-recommends/">
+                                        <span class="productsMenu-submenu-t">Pекомендація сомельє</span>
+                </a>
+                            </li><!--
+                    --><li class="productsMenu-submenu-i ">
+                <a class="productsMenu-submenu-a" href="/german-traditional/">
+                                        <span class="productsMenu-submenu-t">Традиційне німецьке</span>
+                </a>
+                            </li><!--
+                    --><li class="productsMenu-submenu-i ">
+                <a class="productsMenu-submenu-a" href="/belgian-traditional/">
+                                        <span class="productsMenu-submenu-t">Традиційне бельгійське</span>
+                </a>
+                            </li><!--
+                    --><li class="productsMenu-submenu-i ">
+                <a class="productsMenu-submenu-a" href="/british-traditional/">
+                                        <span class="productsMenu-submenu-t">Традиційне британське</span>
+                </a>
+                            </li><!--
+                    --><li class="productsMenu-submenu-i ">
+                <a class="productsMenu-submenu-a" href="/barrel-aged/">
+                                        <span class="productsMenu-submenu-t">Barrel Aged & BBA</span>
+                </a>
+                            </li><!--
+                    --><li class="productsMenu-submenu-i ">
+                <a class="productsMenu-submenu-a" href="/strong-imperial/">
+                                        <span class="productsMenu-submenu-t">Strong & Imperial</span>
+                </a>
+                            </li><!--
+                    --><li class="productsMenu-submenu-i ">
+                <a class="productsMenu-submenu-a" href="/untappd-4.20/">
+                                        <span class="productsMenu-submenu-t">Untappd 4.20+</span>
+                </a>
+                            </li><!--
+                    --><li class="productsMenu-submenu-i ">
+                <a class="productsMenu-submenu-a" href="/beer-glasses-merch/">
+                                        <span class="productsMenu-submenu-t">Келихи для пива і Мерч</span>
+                </a>
+                            </li><!--
+                    --><li class="productsMenu-submenu-i ">
+                <a class="productsMenu-submenu-a" href="/video-degustation/">
+                                        <span class="productsMenu-submenu-t">Відео дегустації</span>
+                </a>
+                            </li><!--
+                    --><li class="productsMenu-submenu-i ">
+                <a class="productsMenu-submenu-a" href="/last-call/">
+                                        <span class="productsMenu-submenu-t">Last Call!</span>
+                </a>
+                            </li><!--
+                    -->
+        </ul>
+    </div>                    
+            </li>
+                    <li class="products-menu__item j-submenu-item">
+                <div class="products-menu__title">
+                    <a class="products-menu__title-link" href="/non-alcohol/">
+                                                Non-Alcohol                    </a>
+                </div>
+                                    <div class="productsMenu-submenu __fluidGrid">
+        <ul class="productsMenu-submenu-w">
+        <!--
+                    --><li class="productsMenu-submenu-i ">
+                <a class="productsMenu-submenu-a" href="/beer-and-hop-water/">
+                                        <span class="productsMenu-submenu-t">Пиво та Hop Water</span>
+                </a>
+                            </li><!--
+                    --><li class="productsMenu-submenu-i ">
+                <a class="productsMenu-submenu-a" href="/lemonades-and-sparkling-water/">
+                                        <span class="productsMenu-submenu-t">Лимонади та газована вода</span>
+                </a>
+                            </li><!--
+                    -->
+        </ul>
+    </div>                    
+            </li>
+                    <li class="products-menu__item j-submenu-item">
+                <div class="products-menu__title">
+                    <a class="products-menu__title-link" href="/new-arrivals/">
+                                                Новинки                    </a>
+                </div>
+                                                        
+            </li>
+                    <li class="products-menu__item j-submenu-item">
+                <div class="products-menu__title">
+                    <a class="products-menu__title-link" href="/craft-up-to-199/">
+                                                Імпорт до 199                    </a>
+                </div>
+                                                        
+            </li>
+                    <li class="products-menu__item j-submenu-item">
+                <div class="products-menu__title">
+                    <a class="products-menu__title-link" href="/sale/">
+                                                SALE!                    </a>
+                </div>
+                                                        
+            </li>
+            </ul>
+</div>
+<script>
+  (function (w) {
+    w.INIT.add(function () {
+      $('.j-products-menu').productsMenu({
+        parent: $('.header__layout'),
+        onHover: function (e, $item) {
+          var $item = $item,
+              itemWidth = $item.width(),
+              $arrow = $item.find('.productsMenu-submenuArrow'),
+              $submenu = $item.find('.productsMenu-submenu');
+
+          if (!$submenu.length) {
+            return;
+          }
+
+          if (!$arrow.length) {
+            $arrow = $('<div class="productsMenu-submenuArrow" />').appendTo($submenu);
+          }
+
+          $arrow.css('left', $item.offset().left - $submenu.offset().left + itemWidth / 2);
+        }
+      });
+    }, w.$)
+  })(window);
+</script></div>                                                            </div>
+                                                                    </div>
+                </div>
+            </div>
+            </div>
+</div>        <main id="main" class="main">
+            <div class="wrapper">
+    <div class="catalog">
+                            <div class="catalog__top-row">
+                                    <div class="catalog__top-col catalog__top-col--side">
+                                            </div>
+                                                    <div class="catalog__top-col catalog__top-col--center">
+                                                    <nav class="breadcrumbs" itemscope itemtype="https://schema.org/BreadcrumbList">
+                        <div class="breadcrumbs-i" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <a itemprop="item" href="https://beerfreak.org/"><span
+                        itemprop="name">Головна</span></a>
+            <meta itemprop="position" content="1">
+                            <svg class="icon icon--breadcrumbs-arrow"><use xlink:href="#icon-breadcrumbs-arrow"></use></svg>
+            
+        </div>
+                        <div class="breadcrumbs-i" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <span itemprop="item" content="https://beerfreak.org/beer/"><span
+                    itemprop="name">Пиво</span></span>
+            <meta itemprop="position" content="2">
+        </div>
+    </nav>                                                    <h1 class="main-h" id="j-catalog-header" data-catalog-view-block="heading">Пиво</h1>                                            </div>
+                                                    <div class="catalog__top-col catalog__top-col--right">
+                                                    <div class="catalog__controls" data-catalog-view-block="controls">
+            <div class="catalog__controls-item" data-catalog-view-block="sorting-controls">
+            <div class="catalog-sorting">
+    <div class="catalog-sorting__title j-ajax-ignore">Сортування:</div>
+    <div class="catalog-sorting__list" id="uidbde903dd77450fcc28029b92d743f742">
+
+                                    <span
+                    class="catalog-sorting__item is-active j-catalog-sorting-button"
+                    role="button"
+                >за популярністю</span>
+                                                <span
+                    class="catalog-sorting__item j-catalog-sorting-button"
+                    role="button"
+                    data-sort-href="/beer/filter/sort_price+=ASC/"
+                >Цiна &#x2191</span>
+                                                <span
+                    class="catalog-sorting__item j-catalog-sorting-button"
+                    role="button"
+                    data-sort-href="/beer/filter/sort_price1+=DESC/"
+                >Цiна &#x2193</span>
+                                                <span
+                    class="catalog-sorting__item j-catalog-sorting-button"
+                    role="button"
+                    data-sort-href="/beer/filter/sort_title=ASC/"
+                >за назвою</span>
+                        </div>
+</div>        </div>
+                <div class="catalog__controls-item" data-catalog-view-block="viewType-controls">
+            <div class="catalog-type">
+        <div class="catalog-type__title j-ajax-ignore">Відображення:</div>
+        <div class="catalog-type__list" id="uidfc0e6c9eada1ff29f889139f44877263">
+                            <span
+                    role="button"
+                    data-layout-href="/beer/filter/view_type=grid_view/"
+                    class="catalog-type__item is-active j-layout-toggle-button"
+                >
+                                    <svg class="icon icon--sort-grid">
+                        <use xlink:href="#icon-sort-grid"></use>
+                    </svg>
+                                </span>
+                            <span
+                    role="button"
+                    data-layout-href="/beer/filter/view_type=list_view/"
+                    class="catalog-type__item j-layout-toggle-button"
+                >
+                                    <svg class="icon icon--sort-list">
+                        <use xlink:href="#icon-sort-list"></use>
+                    </svg>
+                                </span>
+                    </div>
+    </div>        </div>
+    </div>                                            </div>
+                            </div>
+                <div class="catalog__middle j-catalog-sticker-parent">
+            <div class="catalog-loader" id="j-catalog-loader"></div>
+            <script>
+              (function(w) {
+                w.INIT.add(function() {
+                  CatalogBuilder.loaderSelector = '#j-catalog-loader';
+                }, w.CatalogBuilder)
+              })(window);
+            </script>
+
+                        <div class="catalog__middle-col catalog__middle-col--content catalog__middle-col--shifted-right">
+                <div class="catalog__content">
+                        <div data-catalog-view-block="seoText"></div>
+    <ul class="catalogGrid catalog-grid catalog-grid--s catalog-grid--sidebar" 
+        id="uide387e235ca38f9ffb6a939487e19c6be" 
+        data-catalog-view-block="products" 
+        itemscope itemtype="https://schema.org/ItemList">
+        <!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="10493">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/volta-brewery-smoothie-beast-red-currant-yuzu-blueberry-raspberry-bergamot/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='Volta Brewery SMOOTHIE BEAST: RED CURRANT, YUZU, BLUEBERRY, RASPBERRY, BERGAMOT'  class='catalogCard-img' width='310' height='310' src='/content/images/44/310x310l85nn0/volta-brewery-smoothie-beast-red-currant-yuzu-blueberry-raspberry-bergamot-80226971166628.png' >
+                                                    </div>
+                                                                                                </a>
+                                            <div class="productSticker __flag">
+                    <div class="productSticker-item __new_auto" data-tooltip="hint-uidf63c64c74f96b0c7a0b4fe70ffad99a8"
+            style="color: #289c1c"        >
+            <div class="productSticker-container">
+                <div class="productSticker-content"
+                    style="color: #fff"                >
+                    Новинка                </div>
+            </div>
+                    </div>            </div>
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/volta-brewery-smoothie-beast-red-currant-yuzu-blueberry-raspberry-bergamot/'
+                           title="Volta Brewery SMOOTHIE BEAST: RED CURRANT, YUZU, BLUEBERRY, RASPBERRY, BERGAMOT">
+                            Volta Brewery SMOOTHIE BEAST: RED CURRANT, YUZU, BLUEBERRY, RASPBERRY, BERGAMOT                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        169 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-10493"
+    data-id="10493"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="24"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-10493"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="1" />
+            <meta itemprop="url" content="/volta-brewery-smoothie-beast-red-currant-yuzu-blueberry-raspberry-bergamot/" />
+        </li><!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="10494">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/volta-brewery-jamaica-blues/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='Volta Brewery JAMAICA BLUES'  class='catalogCard-img' width='310' height='310' src='/content/images/45/310x310l85nn0/volta-brewery-jamaica-blues-62064743510517.png' >
+                                                    </div>
+                                                                                                </a>
+                                            <div class="productSticker __flag">
+                    <div class="productSticker-item __new_auto" data-tooltip="hint-uid6cdcdc734d63f9a2134b10ad22e445fb"
+            style="color: #289c1c"        >
+            <div class="productSticker-container">
+                <div class="productSticker-content"
+                    style="color: #fff"                >
+                    Новинка                </div>
+            </div>
+                    </div>            </div>
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/volta-brewery-jamaica-blues/'
+                           title="Volta Brewery JAMAICA BLUES">
+                            Volta Brewery JAMAICA BLUES                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        149 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-10494"
+    data-id="10494"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="24"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-10494"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="2" />
+            <meta itemprop="url" content="/volta-brewery-jamaica-blues/" />
+        </li><!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="10495">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/volta-brewery-modern-pilsner/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='Volta Brewery MODERN PILSNER'  class='catalogCard-img' width='310' height='310' src='/content/images/46/310x310l85nn0/volta-brewery-modern-pilsner-24194306578252.png' >
+                                                    </div>
+                                                                                                </a>
+                                            <div class="productSticker __flag">
+                    <div class="productSticker-item __new_auto" data-tooltip="hint-uidf3e2d13b71a2ac7ca36380c12f0950a6"
+            style="color: #289c1c"        >
+            <div class="productSticker-container">
+                <div class="productSticker-content"
+                    style="color: #fff"                >
+                    Новинка                </div>
+            </div>
+                    </div>            </div>
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/volta-brewery-modern-pilsner/'
+                           title="Volta Brewery MODERN PILSNER">
+                            Volta Brewery MODERN PILSNER                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        129 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-10495"
+    data-id="10495"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="24"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-10495"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="3" />
+            <meta itemprop="url" content="/volta-brewery-modern-pilsner/" />
+        </li><!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="10496">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/volta-brewery-modern-stout/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='Volta Brewery MODERN STOUT'  class='catalogCard-img' width='310' height='310' src='/content/images/47/310x310l85nn0/volta-brewery-modern-stout-88133217070394.png' >
+                                                    </div>
+                                                                                                </a>
+                                            <div class="productSticker __flag">
+                    <div class="productSticker-item __new_auto" data-tooltip="hint-uid84657c6d82a0a28827fa8455a33382d2"
+            style="color: #289c1c"        >
+            <div class="productSticker-container">
+                <div class="productSticker-content"
+                    style="color: #fff"                >
+                    Новинка                </div>
+            </div>
+                    </div>            </div>
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/volta-brewery-modern-stout/'
+                           title="Volta Brewery MODERN STOUT">
+                            Volta Brewery MODERN STOUT                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        129 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-10496"
+    data-id="10496"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="24"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-10496"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="4" />
+            <meta itemprop="url" content="/volta-brewery-modern-stout/" />
+        </li><!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="10497">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/hoppy-hog-family-brewery-tropical-veil-neipa/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='Hoppy Hog Family Brewery Tropical Veil NEIPA'  class='catalogCard-img' width='310' height='310' src='/content/images/48/310x310l85nn0/hoppy-hog-family-brewery-tropical-veil-neipa-42794371820356.png' >
+                                                    </div>
+                                                                                                </a>
+                                            <div class="productSticker __flag">
+                    <div class="productSticker-item __new_auto" data-tooltip="hint-uidf974dbeb7f82c3c5eed3f57e06c1bb72"
+            style="color: #289c1c"        >
+            <div class="productSticker-container">
+                <div class="productSticker-content"
+                    style="color: #fff"                >
+                    Новинка                </div>
+            </div>
+                    </div>            </div>
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/hoppy-hog-family-brewery-tropical-veil-neipa/'
+                           title="Hoppy Hog Family Brewery Tropical Veil NEIPA">
+                            Hoppy Hog Family Brewery Tropical Veil NEIPA                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        159 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-10497"
+    data-id="10497"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="22"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-10497"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="5" />
+            <meta itemprop="url" content="/hoppy-hog-family-brewery-tropical-veil-neipa/" />
+        </li><!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="10498">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/hoppy-hog-family-brewery-charred-memory/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='Hoppy Hog Family Brewery Charred Memory'  class='catalogCard-img' width='310' height='310' src='/content/images/49/310x310l85nn0/hoppy-hog-family-brewery-charred-memory-94733623484542.png' >
+                                                    </div>
+                                                                                                </a>
+                                            <div class="productSticker __flag">
+                    <div class="productSticker-item __new_auto" data-tooltip="hint-uida8e5299953626ef3fa1dfcdc7e43537d"
+            style="color: #289c1c"        >
+            <div class="productSticker-container">
+                <div class="productSticker-content"
+                    style="color: #fff"                >
+                    Новинка                </div>
+            </div>
+                    </div>            </div>
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/hoppy-hog-family-brewery-charred-memory/'
+                           title="Hoppy Hog Family Brewery Charred Memory">
+                            Hoppy Hog Family Brewery Charred Memory                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        179 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-10498"
+    data-id="10498"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="22"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-10498"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="6" />
+            <meta itemprop="url" content="/hoppy-hog-family-brewery-charred-memory/" />
+        </li><!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="7579">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/rebrew-trukhaniv-ostriv-session-ipa/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='Rebrew Труханів острів Session IPA'  class='catalogCard-img' width='310' height='310' src='/content/images/30/310x310l85nn0/rebrew-trukhaniv-ostriv-session-ipa-26026192670532.png' >
+                                                    </div>
+                                                                                                </a>
+                                            
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/rebrew-trukhaniv-ostriv-session-ipa/'
+                           title="Rebrew Труханів острів Session IPA">
+                            Rebrew Труханів острів Session IPA                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        139 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-7579"
+    data-id="7579"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="18"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-7579"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="7" />
+            <meta itemprop="url" content="/rebrew-trukhaniv-ostriv-session-ipa/" />
+        </li><!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="9106">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/rebrew-tramvai-na-sykhiv-neipa-z-apelsynovym-sokom/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='Rebrew ТРАМВАЙ НА СИХІВ NEIPA З АПЕЛЬСИНОВИМ СОКОМ'  class='catalogCard-img' width='310' height='310' src='/content/images/7/310x310l85nn0/rebrew-tramvai-na-sykhiv-neipa-z-apelsynovym-sokom-27570489245347.png' >
+                                                    </div>
+                                                                                                </a>
+                                            
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/rebrew-tramvai-na-sykhiv-neipa-z-apelsynovym-sokom/'
+                           title="Rebrew ТРАМВАЙ НА СИХІВ NEIPA З АПЕЛЬСИНОВИМ СОКОМ">
+                            Rebrew ТРАМВАЙ НА СИХІВ NEIPA З АПЕЛЬСИНОВИМ СОКОМ                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        159 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-9106"
+    data-id="9106"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="18"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-9106"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="8" />
+            <meta itemprop="url" content="/rebrew-tramvai-na-sykhiv-neipa-z-apelsynovym-sokom/" />
+        </li><!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="10027">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/browar-brokreacja-nafciarz-19/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='Browar Brokreacja NAFCIARZ 19'  class='catalogCard-img' width='310' height='310' src='/content/images/28/310x310l85nn0/browar-brokreacja-nafciarz-19-25103669659808.png' >
+                                                    </div>
+                                                                                                </a>
+                                            
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/browar-brokreacja-nafciarz-19/'
+                           title="Browar Brokreacja NAFCIARZ 19">
+                            Browar Brokreacja NAFCIARZ 19                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        249 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-10027"
+    data-id="10027"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="11"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-10027"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="9" />
+            <meta itemprop="url" content="/browar-brokreacja-nafciarz-19/" />
+        </li><!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="10028">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/browar-brokreacja-duotaur/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='Browar Brokreacja Duotaur'  class='catalogCard-img' width='310' height='310' src='/content/images/29/310x310l85nn0/browar-brokreacja-duotaur-61934027235549.png' >
+                                                    </div>
+                                                                                                </a>
+                                            
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/browar-brokreacja-duotaur/'
+                           title="Browar Brokreacja Duotaur">
+                            Browar Brokreacja Duotaur                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        299 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-10028"
+    data-id="10028"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="6"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-10028"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="10" />
+            <meta itemprop="url" content="/browar-brokreacja-duotaur/" />
+        </li><!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="10029">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/browar-brokreacja-lord-of-the-pils/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='Browar Brokreacja Lord of the Pils'  class='catalogCard-img' width='310' height='310' src='/content/images/30/310x310l85nn0/browar-brokreacja-lord-of-the-pils-41845913559038.png' >
+                                                    </div>
+                                                                                                </a>
+                                            
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/browar-brokreacja-lord-of-the-pils/'
+                           title="Browar Brokreacja Lord of the Pils">
+                            Browar Brokreacja Lord of the Pils                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        229 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-10029"
+    data-id="10029"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="4"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-10029"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="11" />
+            <meta itemprop="url" content="/browar-brokreacja-lord-of-the-pils/" />
+        </li><!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="10031">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/browar-brokreacja-starling/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='Browar Brokreacja Starling'  class='catalogCard-img' width='310' height='310' src='/content/images/32/310x310l85nn0/browar-brokreacja-starling-92610986464633.png' >
+                                                    </div>
+                                                                                                </a>
+                                            
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/browar-brokreacja-starling/'
+                           title="Browar Brokreacja Starling">
+                            Browar Brokreacja Starling                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        269 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-10031"
+    data-id="10031"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="7"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-10031"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="12" />
+            <meta itemprop="url" content="/browar-brokreacja-starling/" />
+        </li><!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="10270">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/browar-brokreacja-under-pressure/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='Browar Brokreacja Under Pressure'  class='catalogCard-img' width='310' height='310' src='/content/images/21/310x310l85nn0/browar-brokreacja-under-pressure-22480973266308.png' >
+                                                    </div>
+                                                                                                </a>
+                                            
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/browar-brokreacja-under-pressure/'
+                           title="Browar Brokreacja Under Pressure">
+                            Browar Brokreacja Under Pressure                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        259 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-10270"
+    data-id="10270"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="10"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-10270"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="13" />
+            <meta itemprop="url" content="/browar-brokreacja-under-pressure/" />
+        </li><!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="10456">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/pinta-folkingebrew-hazy-discovery-groningen/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='PINTA/Folkingebrew Hazy Discovery Groningen'  class='catalogCard-img' width='310' height='310' src='/content/images/7/310x310l85nn0/pinta-folkingebrew-hazy-discovery-groningen-59952073047479.png' >
+                                                    </div>
+                                                                                                </a>
+                                            <div class="productSticker __flag">
+                    <div class="productSticker-item __new_auto" data-tooltip="hint-uid1f6047ac78e0adcb71671a2085b4783f"
+            style="color: #289c1c"        >
+            <div class="productSticker-container">
+                <div class="productSticker-content"
+                    style="color: #fff"                >
+                    Новинка                </div>
+            </div>
+                    </div>            </div>
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/pinta-folkingebrew-hazy-discovery-groningen/'
+                           title="PINTA/Folkingebrew Hazy Discovery Groningen">
+                            PINTA/Folkingebrew Hazy Discovery Groningen                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        349 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-10456"
+    data-id="10456"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="4"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-10456"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="14" />
+            <meta itemprop="url" content="/pinta-folkingebrew-hazy-discovery-groningen/" />
+        </li><!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="10457">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/pinta-varietal-beer-company-hazy-discovery-sunnyside/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='PINTA/Varietal Beer Company Hazy Discovery Sunnyside'  class='catalogCard-img' width='310' height='310' src='/content/images/8/310x310l85nn0/pinta-varietal-beer-company-hazy-discovery-sunnyside-44165557969585.png' >
+                                                    </div>
+                                                                                                </a>
+                                            <div class="productSticker __flag">
+                    <div class="productSticker-item __new_auto" data-tooltip="hint-uide0d547534a8df50c34858180d1f13538"
+            style="color: #289c1c"        >
+            <div class="productSticker-container">
+                <div class="productSticker-content"
+                    style="color: #fff"                >
+                    Новинка                </div>
+            </div>
+                    </div>            </div>
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/pinta-varietal-beer-company-hazy-discovery-sunnyside/'
+                           title="PINTA/Varietal Beer Company Hazy Discovery Sunnyside">
+                            PINTA/Varietal Beer Company Hazy Discovery Sunnyside                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        349 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-10457"
+    data-id="10457"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="4"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-10457"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="15" />
+            <meta itemprop="url" content="/pinta-varietal-beer-company-hazy-discovery-sunnyside/" />
+        </li><!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="10460">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/browar-brokreacja-bro-hero-jerry/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='Browar Brokreacja BRO HERO: JERRY'  class='catalogCard-img' width='310' height='310' src='/content/images/11/310x310l85nn0/browar-brokreacja-bro-hero-jerry-89145776112775.png' >
+                                                    </div>
+                                                                                                </a>
+                                            <div class="productSticker __flag">
+                    <div class="productSticker-item __new_auto" data-tooltip="hint-uid6df920fc7d37d9b01e8d9cddfc700871"
+            style="color: #289c1c"        >
+            <div class="productSticker-container">
+                <div class="productSticker-content"
+                    style="color: #fff"                >
+                    Новинка                </div>
+            </div>
+                    </div>            </div>
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/browar-brokreacja-bro-hero-jerry/'
+                           title="Browar Brokreacja BRO HERO: JERRY">
+                            Browar Brokreacja BRO HERO: JERRY                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        229 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-10460"
+    data-id="10460"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="2"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-10460"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="16" />
+            <meta itemprop="url" content="/browar-brokreacja-bro-hero-jerry/" />
+        </li><!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="10461">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/browar-brokreacja-polaron-prime/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='Browar Brokreacja Polaron Prime'  class='catalogCard-img' width='310' height='310' src='/content/images/12/310x310l85nn0/browar-brokreacja-polaron-prime-99677905673073.png' >
+                                                    </div>
+                                                                                                </a>
+                                            <div class="productSticker __flag">
+                    <div class="productSticker-item __new_auto" data-tooltip="hint-uidfa6fba32753e26e8a7db06361b63184c"
+            style="color: #289c1c"        >
+            <div class="productSticker-container">
+                <div class="productSticker-content"
+                    style="color: #fff"                >
+                    Новинка                </div>
+            </div>
+                    </div>            </div>
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/browar-brokreacja-polaron-prime/'
+                           title="Browar Brokreacja Polaron Prime">
+                            Browar Brokreacja Polaron Prime                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        269 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-10461"
+    data-id="10461"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="1"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-10461"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="17" />
+            <meta itemprop="url" content="/browar-brokreacja-polaron-prime/" />
+        </li><!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="10462">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/browar-brokreacja-wolfgang/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='Browar Brokreacja Wolfgang'  class='catalogCard-img' width='310' height='310' src='/content/images/13/310x310l85nn0/browar-brokreacja-wolfgang-67051374574748.png' >
+                                                    </div>
+                                                                                                </a>
+                                            <div class="productSticker __flag">
+                    <div class="productSticker-item __new_auto" data-tooltip="hint-uid424d6454237a5be326d5f1868827ef08"
+            style="color: #289c1c"        >
+            <div class="productSticker-container">
+                <div class="productSticker-content"
+                    style="color: #fff"                >
+                    Новинка                </div>
+            </div>
+                    </div>            </div>
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/browar-brokreacja-wolfgang/'
+                           title="Browar Brokreacja Wolfgang">
+                            Browar Brokreacja Wolfgang                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        219 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-10462"
+    data-id="10462"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="2"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-10462"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="18" />
+            <meta itemprop="url" content="/browar-brokreacja-wolfgang/" />
+        </li><!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="10463">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/browar-brokreacja-stargazer/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='Browar Brokreacja Stargazer'  class='catalogCard-img' width='310' height='310' src='/content/images/14/310x310l85nn0/browar-brokreacja-stargazer-95068498943030.png' >
+                                                    </div>
+                                                                                                </a>
+                                            <div class="productSticker __flag">
+                    <div class="productSticker-item __new_auto" data-tooltip="hint-uidd62c4dfb5b3f98b1b8fe317c8e1bbe82"
+            style="color: #289c1c"        >
+            <div class="productSticker-container">
+                <div class="productSticker-content"
+                    style="color: #fff"                >
+                    Новинка                </div>
+            </div>
+                    </div>            </div>
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/browar-brokreacja-stargazer/'
+                           title="Browar Brokreacja Stargazer">
+                            Browar Brokreacja Stargazer                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        259 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-10463"
+    data-id="10463"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="6"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-10463"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="19" />
+            <meta itemprop="url" content="/browar-brokreacja-stargazer/" />
+        </li><!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="10478">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/rebrew-kotomato-ginger-tomato-gose/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='Rebrew KOTOMATO GINGER TOMATO GOSE'  class='catalogCard-img' width='310' height='310' src='/content/images/29/310x310l85nn0/rebrew-kotomato-ginger-tomato-gose-56628068729229.png' >
+                                                    </div>
+                                                                                                </a>
+                                            <div class="productSticker __flag">
+                    <div class="productSticker-item __new_auto" data-tooltip="hint-uidc1f1c2b1baf03e130729703dc436bd7b"
+            style="color: #289c1c"        >
+            <div class="productSticker-container">
+                <div class="productSticker-content"
+                    style="color: #fff"                >
+                    Новинка                </div>
+            </div>
+                    </div>            </div>
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/rebrew-kotomato-ginger-tomato-gose/'
+                           title="Rebrew KOTOMATO GINGER TOMATO GOSE">
+                            Rebrew KOTOMATO GINGER TOMATO GOSE                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        159 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-10478"
+    data-id="10478"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="16"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-10478"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="20" />
+            <meta itemprop="url" content="/rebrew-kotomato-ginger-tomato-gose/" />
+        </li><!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="10479">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/rebrew-kotomato-wasabi-tomato-gose/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='Rebrew KOTOMATO WASABI TOMATO GOSE'  class='catalogCard-img' width='310' height='310' src='/content/images/30/310x310l85nn0/rebrew-kotomato-wasabi-tomato-gose-48248149848744.png' >
+                                                    </div>
+                                                                                                </a>
+                                            <div class="productSticker __flag">
+                    <div class="productSticker-item __new_auto" data-tooltip="hint-uide767b66b94398c135708a05bf3349352"
+            style="color: #289c1c"        >
+            <div class="productSticker-container">
+                <div class="productSticker-content"
+                    style="color: #fff"                >
+                    Новинка                </div>
+            </div>
+                    </div>            </div>
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/rebrew-kotomato-wasabi-tomato-gose/'
+                           title="Rebrew KOTOMATO WASABI TOMATO GOSE">
+                            Rebrew KOTOMATO WASABI TOMATO GOSE                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        159 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-10479"
+    data-id="10479"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="24"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-10479"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="21" />
+            <meta itemprop="url" content="/rebrew-kotomato-wasabi-tomato-gose/" />
+        </li><!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="10480">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/rebrew-rebrew-x-max-kidruk/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='Rebrew REBREW X MAX KIDRUK'  class='catalogCard-img' width='310' height='310' src='/content/images/31/310x310l85nn0/rebrew-rebrew-x-max-kidruk-75816003658151.png' >
+                                                    </div>
+                                                                                                </a>
+                                            <div class="productSticker __flag">
+                    <div class="productSticker-item __new_auto" data-tooltip="hint-uid9a431ffea32cdbcff5066e55341808a2"
+            style="color: #289c1c"        >
+            <div class="productSticker-container">
+                <div class="productSticker-content"
+                    style="color: #fff"                >
+                    Новинка                </div>
+            </div>
+                    </div>            </div>
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/rebrew-rebrew-x-max-kidruk/'
+                           title="Rebrew REBREW X MAX KIDRUK">
+                            Rebrew REBREW X MAX KIDRUK                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        159 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-10480"
+    data-id="10480"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="18"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-10480"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="22" />
+            <meta itemprop="url" content="/rebrew-rebrew-x-max-kidruk/" />
+        </li><!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="10481">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/rebrew-efir-brewery-home-rebrewing-2.-volume-3-efir-brewery-mango-passion-fruit-sour-milkshake-ipa/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='Rebrew/Efir Brewery HOME REBREWING 2. VOLUME 3: EFIR BREWERY MANGO &amp; PASSION FRUIT SOUR MILKSHAKE IPA'  class='catalogCard-img' width='310' height='310' src='/content/images/32/310x310l85nn0/rebrew-efir-brewery-home-rebrewing-2.-volume-3-efir-brewery-mango-passion-fruit-sour-milkshake-ipa-56711194513186.png' >
+                                                    </div>
+                                                                                                </a>
+                                            <div class="productSticker __flag">
+                    <div class="productSticker-item __new_auto" data-tooltip="hint-uida5abaa76f6269ae88212dcd79f34e5e4"
+            style="color: #289c1c"        >
+            <div class="productSticker-container">
+                <div class="productSticker-content"
+                    style="color: #fff"                >
+                    Новинка                </div>
+            </div>
+                    </div>            </div>
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/rebrew-efir-brewery-home-rebrewing-2.-volume-3-efir-brewery-mango-passion-fruit-sour-milkshake-ipa/'
+                           title="Rebrew/Efir Brewery HOME REBREWING 2. VOLUME 3: EFIR BREWERY MANGO &amp; PASSION FRUIT SOUR MILKSHAKE IPA">
+                            Rebrew/Efir Brewery HOME REBREWING 2. VOLUME 3: EFIR BREWERY MANGO & PASSION FRUIT SOUR MILKSHAKE IPA                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        179 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-10481"
+    data-id="10481"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="26"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-10481"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="23" />
+            <meta itemprop="url" content="/rebrew-efir-brewery-home-rebrewing-2.-volume-3-efir-brewery-mango-passion-fruit-sour-milkshake-ipa/" />
+        </li><!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="10482">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/hoppy-hog-family-brewery-krow-moskala-kondari/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='Hoppy Hog Family Brewery Krow Moskala Kondari'  class='catalogCard-img' width='310' height='310' src='/content/images/33/310x310l85nn0/hoppy-hog-family-brewery-krow-moskala-kondari-69117151235883.png' >
+                                                    </div>
+                                                                                                </a>
+                                            <div class="productSticker __flag">
+                    <div class="productSticker-item __new_auto" data-tooltip="hint-uid8d608f8227be10c753ef6d87a3b964f1"
+            style="color: #289c1c"        >
+            <div class="productSticker-container">
+                <div class="productSticker-content"
+                    style="color: #fff"                >
+                    Новинка                </div>
+            </div>
+                    </div>            </div>
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/hoppy-hog-family-brewery-krow-moskala-kondari/'
+                           title="Hoppy Hog Family Brewery Krow Moskala Kondari">
+                            Hoppy Hog Family Brewery Krow Moskala Kondari                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        159 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-10482"
+    data-id="10482"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="17"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-10482"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="24" />
+            <meta itemprop="url" content="/hoppy-hog-family-brewery-krow-moskala-kondari/" />
+        </li><!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="10483">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/hoppy-hog-family-brewery-krow-moskala-pico-de-gallo/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='Hoppy Hog Family Brewery Krow Moskala Pico De Gallo'  class='catalogCard-img' width='310' height='310' src='/content/images/34/310x310l85nn0/hoppy-hog-family-brewery-krow-moskala-pico-de-gallo-63907792423578.png' >
+                                                    </div>
+                                                                                                </a>
+                                            <div class="productSticker __flag">
+                    <div class="productSticker-item __new_auto" data-tooltip="hint-uid21b9eda7f296413b96bce673acb50b55"
+            style="color: #289c1c"        >
+            <div class="productSticker-container">
+                <div class="productSticker-content"
+                    style="color: #fff"                >
+                    Новинка                </div>
+            </div>
+                    </div>            </div>
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/hoppy-hog-family-brewery-krow-moskala-pico-de-gallo/'
+                           title="Hoppy Hog Family Brewery Krow Moskala Pico De Gallo">
+                            Hoppy Hog Family Brewery Krow Moskala Pico De Gallo                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        159 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-10483"
+    data-id="10483"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="18"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-10483"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="25" />
+            <meta itemprop="url" content="/hoppy-hog-family-brewery-krow-moskala-pico-de-gallo/" />
+        </li><!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="10484">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/hoppy-hog-family-brewery-real-jam-fruit-boom/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='Hoppy Hog Family Brewery Real Jam Fruit BOOM'  class='catalogCard-img' width='310' height='310' src='/content/images/35/310x310l85nn0/hoppy-hog-family-brewery-real-jam-fruit-boom-68878593100656.png' >
+                                                    </div>
+                                                                                                </a>
+                                            <div class="productSticker __flag">
+                    <div class="productSticker-item __new_auto" data-tooltip="hint-uid5d7186b2a7228560a8ba8e90c96c1556"
+            style="color: #289c1c"        >
+            <div class="productSticker-container">
+                <div class="productSticker-content"
+                    style="color: #fff"                >
+                    Новинка                </div>
+            </div>
+                    </div>            </div>
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/hoppy-hog-family-brewery-real-jam-fruit-boom/'
+                           title="Hoppy Hog Family Brewery Real Jam Fruit BOOM">
+                            Hoppy Hog Family Brewery Real Jam Fruit BOOM                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        169 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-10484"
+    data-id="10484"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="21"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-10484"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="26" />
+            <meta itemprop="url" content="/hoppy-hog-family-brewery-real-jam-fruit-boom/" />
+        </li><!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="10488">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/sho-brewery-iiio-narcissus/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='SHO Brewery (IIIO) Narcissus'  class='catalogCard-img' width='310' height='310' src='/content/images/39/310x310l85nn0/sho-brewery-iiio-narcissus-82271353730866.png' >
+                                                    </div>
+                                                                                                </a>
+                                            <div class="productSticker __flag">
+                    <div class="productSticker-item __new_auto" data-tooltip="hint-uid765810aab3a292733e7d90b8816aa449"
+            style="color: #289c1c"        >
+            <div class="productSticker-container">
+                <div class="productSticker-content"
+                    style="color: #fff"                >
+                    Новинка                </div>
+            </div>
+                    </div>            </div>
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/sho-brewery-iiio-narcissus/'
+                           title="SHO Brewery (IIIO) Narcissus">
+                            SHO Brewery (IIIO) Narcissus                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        159 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-10488"
+    data-id="10488"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="23"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-10488"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="27" />
+            <meta itemprop="url" content="/sho-brewery-iiio-narcissus/" />
+        </li><!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="10489">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/sho-brewery-iiio-nebula-juice/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='SHO Brewery (IIIO) Nebula Juice'  class='catalogCard-img' width='310' height='310' src='/content/images/40/310x310l85nn0/sho-brewery-iiio-nebula-juice-16179357851383.png' >
+                                                    </div>
+                                                                                                </a>
+                                            <div class="productSticker __flag">
+                    <div class="productSticker-item __new_auto" data-tooltip="hint-uidc9af83504ce9365f564f3866c110b604"
+            style="color: #289c1c"        >
+            <div class="productSticker-container">
+                <div class="productSticker-content"
+                    style="color: #fff"                >
+                    Новинка                </div>
+            </div>
+                    </div>            </div>
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/sho-brewery-iiio-nebula-juice/'
+                           title="SHO Brewery (IIIO) Nebula Juice">
+                            SHO Brewery (IIIO) Nebula Juice                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        169 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-10489"
+    data-id="10489"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="22"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-10489"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="28" />
+            <meta itemprop="url" content="/sho-brewery-iiio-nebula-juice/" />
+        </li><!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="10490">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/sho-brewery-iiio-gozel-2.0/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='SHO Brewery (IIIO) Gozel 2.0'  class='catalogCard-img' width='310' height='310' src='/content/images/41/310x310l85nn0/sho-brewery-iiio-gozel-2.0-93387543694352.png' >
+                                                    </div>
+                                                                                                </a>
+                                            <div class="productSticker __flag">
+                    <div class="productSticker-item __new_auto" data-tooltip="hint-uid7a3b008556dee03323d2b12177934470"
+            style="color: #289c1c"        >
+            <div class="productSticker-container">
+                <div class="productSticker-content"
+                    style="color: #fff"                >
+                    Новинка                </div>
+            </div>
+                    </div>            </div>
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/sho-brewery-iiio-gozel-2.0/'
+                           title="SHO Brewery (IIIO) Gozel 2.0">
+                            SHO Brewery (IIIO) Gozel 2.0                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        139 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-10490"
+    data-id="10490"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="24"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-10490"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="29" />
+            <meta itemprop="url" content="/sho-brewery-iiio-gozel-2.0/" />
+        </li><!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="10491">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/sho-brewery-iiio-hell/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='SHO Brewery (IIIO) Hellь'  class='catalogCard-img' width='310' height='310' src='/content/images/42/310x310l85nn0/sho-brewery-iiio-hell-56910118037567.png' >
+                                                    </div>
+                                                                                                </a>
+                                            <div class="productSticker __flag">
+                    <div class="productSticker-item __new_auto" data-tooltip="hint-uid356e78787d8e5115d95c04941d8d9d03"
+            style="color: #289c1c"        >
+            <div class="productSticker-container">
+                <div class="productSticker-content"
+                    style="color: #fff"                >
+                    Новинка                </div>
+            </div>
+                    </div>            </div>
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/sho-brewery-iiio-hell/'
+                           title="SHO Brewery (IIIO) Hellь">
+                            SHO Brewery (IIIO) Hellь                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        139 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-10491"
+    data-id="10491"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="23"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-10491"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="30" />
+            <meta itemprop="url" content="/sho-brewery-iiio-hell/" />
+        </li><!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="10492">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/kyiv-local-brewery-alco-free-dark/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='Kyiv Local Brewery Alco Free Dark'  class='catalogCard-img' width='310' height='310' src='/content/images/43/310x310l85nn0/kyiv-local-brewery-alco-free-dark-74758911373569.png' >
+                                                    </div>
+                                                                                                </a>
+                                            <div class="productSticker __flag">
+                    <div class="productSticker-item __new_auto" data-tooltip="hint-uid82464d39e6564bf390bc11e25dcb8e88"
+            style="color: #289c1c"        >
+            <div class="productSticker-container">
+                <div class="productSticker-content"
+                    style="color: #fff"                >
+                    Новинка                </div>
+            </div>
+                    </div>            </div>
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/kyiv-local-brewery-alco-free-dark/'
+                           title="Kyiv Local Brewery Alco Free Dark">
+                            Kyiv Local Brewery Alco Free Dark                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        109 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-10492"
+    data-id="10492"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="15"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-10492"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="31" />
+            <meta itemprop="url" content="/kyiv-local-brewery-alco-free-dark/" />
+        </li><!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="10403">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/la-superbe-mastermind/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='La Superbe MASTERMIND'  class='catalogCard-img' width='310' height='310' src='/content/images/4/310x310l85nn0/la-superbe-mastermind-90506707812487.png' >
+                                                    </div>
+                                                                                                </a>
+                                            <div class="productSticker __flag">
+                    <div class="productSticker-item __new_auto" data-tooltip="hint-uid2a8f47d2277105ddf3bf4ffe79bf321a"
+            style="color: #289c1c"        >
+            <div class="productSticker-container">
+                <div class="productSticker-content"
+                    style="color: #fff"                >
+                    Новинка                </div>
+            </div>
+                    </div>            </div>
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/la-superbe-mastermind/'
+                           title="La Superbe MASTERMIND">
+                            La Superbe MASTERMIND                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        499 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-10403"
+    data-id="10403"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="7"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-10403"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="32" />
+            <meta itemprop="url" content="/la-superbe-mastermind/" />
+        </li><!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="10404">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/la-superbe-bug.exe/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='La Superbe BUG.EXE'  class='catalogCard-img' width='310' height='310' src='/content/images/5/310x310l85nn0/la-superbe-bug.exe-50169222475659.png' >
+                                                    </div>
+                                                                                                </a>
+                                            <div class="productSticker __flag">
+                    <div class="productSticker-item __new_auto" data-tooltip="hint-uidd83a1ac71cf0d0c3996ddf54db49ca3b"
+            style="color: #289c1c"        >
+            <div class="productSticker-container">
+                <div class="productSticker-content"
+                    style="color: #fff"                >
+                    Новинка                </div>
+            </div>
+                    </div>            </div>
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/la-superbe-bug.exe/'
+                           title="La Superbe BUG.EXE">
+                            La Superbe BUG.EXE                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        499 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-10404"
+    data-id="10404"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="2"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-10404"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="33" />
+            <meta itemprop="url" content="/la-superbe-bug.exe/" />
+        </li><!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="10405">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/popihn-brasserie-cambier-dipa-ddh-dolcita/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='Popihn/Brasserie Cambier DIPA DDH - DOLCITA'  class='catalogCard-img' width='310' height='310' src='/content/images/6/310x310l85nn0/popihn-brasserie-cambier-dipa-ddh-dolcita-82640642897045.png' >
+                                                    </div>
+                                                                                                </a>
+                                            <div class="productSticker __flag">
+                    <div class="productSticker-item __new_auto" data-tooltip="hint-uidf4fe71267a1ed253aa053843a2071971"
+            style="color: #289c1c"        >
+            <div class="productSticker-container">
+                <div class="productSticker-content"
+                    style="color: #fff"                >
+                    Новинка                </div>
+            </div>
+                    </div>            </div>
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/popihn-brasserie-cambier-dipa-ddh-dolcita/'
+                           title="Popihn/Brasserie Cambier DIPA DDH - DOLCITA">
+                            Popihn/Brasserie Cambier DIPA DDH - DOLCITA                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        499 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-10405"
+    data-id="10405"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="4"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-10405"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="34" />
+            <meta itemprop="url" content="/popihn-brasserie-cambier-dipa-ddh-dolcita/" />
+        </li><!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="10406">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/sparkle-sunset-boulevard-ddh-nectaron/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='Sparkle ✨ Sunset Boulevard DDH Nectaron'  class='catalogCard-img' width='310' height='310' src='/content/images/7/310x310l85nn0/sparkle-sunset-boulevard-ddh-nectaron-83868641884686.png' >
+                                                    </div>
+                                                                                                </a>
+                                            <div class="productSticker __flag">
+                    <div class="productSticker-item __new_auto" data-tooltip="hint-uid92e734b8449984ace08ee729c8e14602"
+            style="color: #289c1c"        >
+            <div class="productSticker-container">
+                <div class="productSticker-content"
+                    style="color: #fff"                >
+                    Новинка                </div>
+            </div>
+                    </div>            </div>
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/sparkle-sunset-boulevard-ddh-nectaron/'
+                           title="Sparkle ✨ Sunset Boulevard DDH Nectaron">
+                            Sparkle ✨ Sunset Boulevard DDH Nectaron                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        549 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-10406"
+    data-id="10406"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="5"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-10406"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="35" />
+            <meta itemprop="url" content="/sparkle-sunset-boulevard-ddh-nectaron/" />
+        </li><!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="10407">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/sparkle-infiniment-nectaron-2026/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='Sparkle ✨ Infiniment Nectaron (2026)'  class='catalogCard-img' width='310' height='310' src='/content/images/8/310x310l85nn0/sparkle-infiniment-nectaron-2026-90691473953177.png' >
+                                                    </div>
+                                                                                                </a>
+                                            <div class="productSticker __flag">
+                    <div class="productSticker-item __new_auto" data-tooltip="hint-uidcf2307f2fea62534e54e6447d6cad21b"
+            style="color: #289c1c"        >
+            <div class="productSticker-container">
+                <div class="productSticker-content"
+                    style="color: #fff"                >
+                    Новинка                </div>
+            </div>
+                    </div>            </div>
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/sparkle-infiniment-nectaron-2026/'
+                           title="Sparkle ✨ Infiniment Nectaron (2026)">
+                            Sparkle ✨ Infiniment Nectaron (2026)                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        649 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-10407"
+    data-id="10407"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="1"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-10407"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="36" />
+            <meta itemprop="url" content="/sparkle-infiniment-nectaron-2026/" />
+        </li><!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="10408">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/sparkle-degen-dotcom/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='Sparkle ✨ Degen Dotcom'  class='catalogCard-img' width='310' height='310' src='/content/images/9/310x310l85nn0/sparkle-degen-dotcom-44537518039984.png' >
+                                                    </div>
+                                                                                                </a>
+                                            <div class="productSticker __flag">
+                    <div class="productSticker-item __new_auto" data-tooltip="hint-uidfbe96aaba3ebb982ec2ad38da7855930"
+            style="color: #289c1c"        >
+            <div class="productSticker-container">
+                <div class="productSticker-content"
+                    style="color: #fff"                >
+                    Новинка                </div>
+            </div>
+                    </div>            </div>
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/sparkle-degen-dotcom/'
+                           title="Sparkle ✨ Degen Dotcom">
+                            Sparkle ✨ Degen Dotcom                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        699 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-10408"
+    data-id="10408"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="5"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-10408"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="37" />
+            <meta itemprop="url" content="/sparkle-degen-dotcom/" />
+        </li><!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="10409">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/sparkle-birthday-1-riwaka-2026/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='Sparkle ✨ Birthday #1 Riwaka (2026)'  class='catalogCard-img' width='310' height='310' src='/content/images/10/310x310l85nn0/sparkle-birthday-1-riwaka-2026-41989880503041.png' >
+                                                    </div>
+                                                                                                </a>
+                                            <div class="productSticker __flag">
+                    <div class="productSticker-item __new_auto" data-tooltip="hint-uida6e6f7b7f5f0bd6ae327b22a6adc9d1c"
+            style="color: #289c1c"        >
+            <div class="productSticker-container">
+                <div class="productSticker-content"
+                    style="color: #fff"                >
+                    Новинка                </div>
+            </div>
+                    </div>            </div>
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/sparkle-birthday-1-riwaka-2026/'
+                           title="Sparkle ✨ Birthday #1 Riwaka (2026)">
+                            Sparkle ✨ Birthday #1 Riwaka (2026)                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        699 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-10409"
+    data-id="10409"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="3"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-10409"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="38" />
+            <meta itemprop="url" content="/sparkle-birthday-1-riwaka-2026/" />
+        </li><!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="10410">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/sparkle-birthday-2-peacharine-2026/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='Sparkle ✨ Birthday #2 Peacharine (2026)'  class='catalogCard-img' width='310' height='310' src='/content/images/11/310x310l85nn0/sparkle-birthday-2-peacharine-2026-22562707846539.png' >
+                                                    </div>
+                                                                                                </a>
+                                            <div class="productSticker __flag">
+                    <div class="productSticker-item __new_auto" data-tooltip="hint-uidd7e7a3d36ef042557f55fa16d17a01a2"
+            style="color: #289c1c"        >
+            <div class="productSticker-container">
+                <div class="productSticker-content"
+                    style="color: #fff"                >
+                    Новинка                </div>
+            </div>
+                    </div>            </div>
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/sparkle-birthday-2-peacharine-2026/'
+                           title="Sparkle ✨ Birthday #2 Peacharine (2026)">
+                            Sparkle ✨ Birthday #2 Peacharine (2026)                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        699 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-10410"
+    data-id="10410"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="3"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-10410"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="39" />
+            <meta itemprop="url" content="/sparkle-birthday-2-peacharine-2026/" />
+        </li><!--
+            --><li class="catalog-grid__item" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+            <div class="catalogCard j-catalog-card">
+                <div class="catalogCard-box j-product-container" data-id="10411">
+        <div class="catalogCard-main">
+            <div class="catalogCard-main-b">
+                <div class="catalogCard-view">
+                                        <a href='/sparkle-birthday-3-nectaron-2026/'
+                       class="catalogCard-image ">
+                        <div class="catalogCard-image-i">
+                                                                                        <img alt='Sparkle ✨ Birthday #3 Nectaron (2026)'  class='catalogCard-img' width='310' height='310' src='/content/images/12/310x310l85nn0/sparkle-birthday-3-nectaron-2026-24110114685778.png' >
+                                                    </div>
+                                                                                                </a>
+                                            <div class="productSticker __flag">
+                    <div class="productSticker-item __new_auto" data-tooltip="hint-uid30c7db36652396d50be32b2d44daa47d"
+            style="color: #289c1c"        >
+            <div class="productSticker-container">
+                <div class="productSticker-content"
+                    style="color: #fff"                >
+                    Новинка                </div>
+            </div>
+                    </div>            </div>
+                                    </div>
+                <div class="catalogCard-info">
+                                                            <div class="catalogCard-title">
+                        <a href='/sparkle-birthday-3-nectaron-2026/'
+                           title="Sparkle ✨ Birthday #3 Nectaron (2026)">
+                            Sparkle ✨ Birthday #3 Nectaron (2026)                        </a>
+                    </div>
+                    <div class="catalogCard-purchase  ">
+                            <div class="catalogCard-price">
+        699 грн    </div>                                        <div class="catalogCard-order">
+                                                                        <div
+    class="counter counter j-buy-button-counter"
+    id="j-buy-button-counter-10411"
+    data-id="10411"
+    data-skin="small"
+    data-gift="0"
+>
+    <div class="counter__container">
+        <button class="counter-btn __minus
+                    j-product-decrease __disabled"
+        >
+            <svg class="icon icon--minus"><use xlink:href="#icon-minus"></use></svg>
+        </button>
+        <div class="counter-input">
+            <input
+                class="counter-field j-product-counter
+                    "
+                type="number"
+                value="1"
+                data-max="1"
+                data-step="1"
+                data-min="1"
+            >
+        </div>
+        <button class="counter-btn __plus
+                    j-product-increase                    "
+        >
+            <svg class="icon icon--plus"><use xlink:href="#icon-plus"></use></svg>
+        </button>
+    </div>
+</div>                            <a
+        class="btn __special j-buy-button-add"
+        data-skin="small"
+        data-quantity="1"
+        id="j-buy-button-widget-10411"
+        data-gift="0"
+        data-cartProductType="product"
+        href="javascript:void(0);"
+    >
+        <span class="btn-content">
+            <svg class="icon icon--basket"><use xlink:href="#icon-basket"></use></svg>
+        </span>
+    </a>                                                                                </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+                                    <div class="catalogCard-extra j-download-required __loading">
+                    <div class="loader"></div>
+                </div>
+                        </div>            </div>
+            <meta itemprop="position" content="40" />
+            <meta itemprop="url" content="/sparkle-birthday-3-nectaron-2026/" />
+        </li><!--
+        -->
+    </ul>
+<div class="pagination-container" data-catalog-view-block="pagination">
+    <script>
+  (function (w) {
+    w.INIT.add(function() {
+      CatalogBuilder.paginationSelector && CatalogBuilder.paginationSelector.push('#uid8c76cd1c9a50ae51b5a5e0e3ee59b328');
+    }, w.CatalogBuilder)
+  })(window);
+</script>
+
+    <nav class="pager" id="uid8c76cd1c9a50ae51b5a5e0e3ee59b328">
+        <div class="pager__container">
+                                        <span class="pager__item pager__item--back is-disabled j-catalog-pagination-btn">
+                    <span class="pager__item-text">
+                        <svg class="icon icon--arrow-left"><use xlink:href="#icon-arrow-left"></use></svg>
+                        Назад                    </span>
+                </span>
+                                                                                                    <span class="pager__item is-active j-catalog-pagination-btn">
+                            <span class="pager__item-text">1</span>
+                        </span>
+                                                                                                                            <a class="pager__item j-catalog-pagination-btn" href="/beer/filter/page=2/"
+                           title="Сторінка 2">
+                            <span class="pager__item-text">2</span>
+                        </a>
+                                                                                                                            <a class="pager__item j-catalog-pagination-btn" href="/beer/filter/page=3/"
+                           title="Сторінка 3">
+                            <span class="pager__item-text">3</span>
+                        </a>
+                                                                                                                            <a class="pager__item j-catalog-pagination-btn" href="/beer/filter/page=4/"
+                           title="Сторінка 4">
+                            <span class="pager__item-text">4</span>
+                        </a>
+                                                                                                                            <a class="pager__item j-catalog-pagination-btn" href="/beer/filter/page=5/"
+                           title="Сторінка 5">
+                            <span class="pager__item-text">5</span>
+                        </a>
+                                                                                                                            <a class="pager__item j-catalog-pagination-btn" href="/beer/filter/page=6/"
+                           title="Сторінка 6">
+                            <span class="pager__item-text">6</span>
+                        </a>
+                                                                <span class="pager__item pager__item--gap">
+                            <span class="pager__item-text">...</span>
+                        </span>
+                                                                                                                                                                                                                                                        <a class="pager__item j-catalog-pagination-btn" href="/beer/filter/page=7/"
+                           title="Сторінка 7">
+                            <span class="pager__item-text">7</span>
+                        </a>
+                                                                                                                    <a class="pager__item pager__item--forth j-catalog-pagination-btn"
+                   href="/beer/filter/page=2/"
+                   title="Сторінка 2">
+                    <span class="pager__item-text">
+                        Вперед                        <svg class="icon icon--arrow-right"><use xlink:href="#icon-arrow-right"></use></svg>
+                    </span>
+                </a>
+                                </div>
+    </nav>
+    <nav class="pager">
+    </nav></div>
+                </div>
+            </div><!-- /.layout-main-->
+                            <div class="catalog__middle-col catalog__middle-col--left j-catalog-sticker-column">
+                    <aside class="catalog__sidebar ">
+                                                    <div class="catalog__group catalog__group--sidebar">
+            <nav class="filterMenu">
+                <ul class="filterMenu-container">
+                                                <li class="filterMenu-i"><a class="filterMenu-a" href="/classic-traditional/">Classic & Traditional</a></li>
+                                                                <li class="filterMenu-i"><a class="filterMenu-a" href="/india-pale-ale/">IPA</a></li>
+                                                                <li class="filterMenu-i"><a class="filterMenu-a" href="/sour-wild-ale/">Sour & Wild Ale</a></li>
+                                                                <li class="filterMenu-i"><a class="filterMenu-a" href="/stout-porter/">Stout & Porter</a></li>
+                                                                <li class="filterMenu-i"><a class="filterMenu-a" href="/experimental-beer/">Experimental Beer</a></li>
+                                    </ul>
+    </nav>            <div class="filter-container" data-catalog-view-block="group.2">
+    <section class="filter __listScroll" id="uid342bd1556049bbbb8039d15eee64b49b" data-scroll-visible="15">
+                            <div
+        class="filter-section j-filter-section j-filter-collapsing"
+        data-filter-id="6213"
+    >
+        <div class="filter-section-h">
+                            <div class="filter-section-trigger j-filter-collapse-trigger">
+                    <svg class="icon icon--arrow-down"><use xlink:href="#icon-arrow-down"></use></svg>
+                    Країна                </div>
+                                </div>
+        <div class="filter-list  pretty-scroll j-filter-list">
+            <ul class="filter-lv1">
+                                                            <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/strana=27/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">Румунія</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">5</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/strana=28/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">Хорватія</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">2</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/strana=30/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">Бразилія</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">5</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/strana=11/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">Англія</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">5</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/strana=2/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">Бельгія</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">5</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/strana=25/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">Болгарія</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">2</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/strana=16/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">Естонія</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">7</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/strana=20/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">Іспанія</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">7</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/strana=21/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">Латвія</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">3</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/strana=4/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">Нідерланди</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">25</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/strana=10/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">Польща</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">53</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/strana=14/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">Україна</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">108</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/strana=19/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">Франція</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">17</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/strana=12/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">Чехія</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">4</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/strana=15/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">Швеція</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">2</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/strana=8/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">Шотландія</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                </ul>
+        </div>
+    </div>                    <div class="filter-section">
+    <form class="j-number-form" data-url="/beer/filter/abv=min-max/" data-filer-name="abv">
+        
+        <div class="filter-section-h">
+            Міцність                    </div>
+        <div class="filter-price">
+            <div class="filter-price-inputs">
+                <input
+                    name="filter[abv][min]"
+                    type="number"
+                    value="0"
+                    min="0"
+                    max="15"
+                    class="filter-price-field field"
+                    id="uid788d9b09b8bf663755ec2cd5d9897cdb_min"
+                >
+                <i class="filter-price-sep"></i>
+                <input
+                    name="filter[abv][max]"
+                    type="number"
+                    value="15"
+                    min="0"
+                    max="15"
+                    class="filter-price-field field"
+                    id="uid788d9b09b8bf663755ec2cd5d9897cdb_max"
+                >
+                <button class="btn __small" type="submit"><span class="btn-content">ОК</span></button>
+            </div>
+            <div class="filter-price-tracker" id="uid788d9b09b8bf663755ec2cd5d9897cdb"></div>
+        </div>
+    </form>
+</div>
+<script>
+  (function(w) {
+    w.INIT.add(function() {
+      init_number_filter(
+        "uid788d9b09b8bf663755ec2cd5d9897cdb",
+        0,
+        15,
+        0,
+        15,
+        false      );
+    }, w.init_number_filter)
+  })(window);
+</script>                    <div class="filter-section">
+    <form class="j-number-form" data-url="/beer/filter/price=min-max/" data-filer-name="price">
+        
+        <div class="filter-section-h">
+            Ціна, грн                    </div>
+        <div class="filter-price">
+            <div class="filter-price-inputs">
+                <input
+                    name="filter[price][min]"
+                    type="number"
+                    value="59"
+                    min="59"
+                    max="1499"
+                    class="filter-price-field field"
+                    id="uid519c71f8159e73837e7bc8bf3c15534f_min"
+                >
+                <i class="filter-price-sep"></i>
+                <input
+                    name="filter[price][max]"
+                    type="number"
+                    value="1499"
+                    min="59"
+                    max="1499"
+                    class="filter-price-field field"
+                    id="uid519c71f8159e73837e7bc8bf3c15534f_max"
+                >
+                <button class="btn __small" type="submit"><span class="btn-content">ОК</span></button>
+            </div>
+            <div class="filter-price-tracker" id="uid519c71f8159e73837e7bc8bf3c15534f"></div>
+        </div>
+    </form>
+</div>
+<script>
+  (function(w) {
+    w.INIT.add(function() {
+      init_number_filter(
+        "uid519c71f8159e73837e7bc8bf3c15534f",
+        59,
+        1499,
+        59,
+        1499,
+        false      );
+    }, w.init_number_filter)
+  })(window);
+</script>                    <div
+        class="filter-section j-filter-section j-filter-collapsing"
+        data-filter-id="6205"
+    >
+        <div class="filter-section-h">
+                            <div class="filter-section-trigger j-filter-collapse-trigger">
+                    <svg class="icon icon--arrow-down"><use xlink:href="#icon-arrow-down"></use></svg>
+                    Об'єм                </div>
+                                </div>
+        <div class="filter-list  pretty-scroll j-filter-list">
+            <ul class="filter-lv1">
+                                                            <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/obem=1/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">0.33</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">98</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/obem=2/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">0.355</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">3</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/obem=3/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">0.375</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">17</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/obem=8/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">0.44</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">42</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/obem=5/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">0.5</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">76</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/obem=4/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">0.75</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">13</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                </ul>
+        </div>
+    </div>                    <div
+        class="filter-section j-filter-section j-filter-collapsing"
+        data-filter-id="5382"
+    >
+        <div class="filter-section-h">
+                            <div class="filter-section-trigger j-filter-collapse-trigger">
+                    <svg class="icon icon--arrow-down"><use xlink:href="#icon-arrow-down"></use></svg>
+                    Бренд                </div>
+                                </div>
+        <div class="filter-list  pretty-scroll j-filter-list">
+            <ul class="filter-lv1">
+                                                            <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=108/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3 FONTEINEN BROUWERIJ (Бельгія)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=242/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">ДІДЬКО (Україна)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">6</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=540/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">ЦИПА - TSYPA BREWERY (Україна)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">7</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=88/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">ALVINNE (Бельгія)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">2</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=476/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">ANDERSON'S CRAFT BEER (Естонія)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">7</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=334/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">ĀRPUS BREWING CO. (Латвія)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">3</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=340/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">BEERFREAK (Україна)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=528/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">BERETA BREWING CO. (Румунія)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">4</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=516/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">BREWART (Україна)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">2</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=245/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">BROKREACJA BREWERY (Польща)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">10</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=556/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">BROUWERIJ HALVE TAMME (Нідерланди)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=529/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">BROUWERIJ LOST (Нідерланди)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">3</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=589/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">REALIST (Україна)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">2</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=587/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">BROWAR AMBER (Польща)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=411/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">BROWAR ARTEZAN (Польща)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=498/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">BROWAR CZTERY ŚCIANY(Польща)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=576/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">BURGOMISTR (Україна)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">6</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=559/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">CERVEJARIA ESCAFANDRISTA (Бразилія)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=543/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">CITADEL Brewpub (Україна)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">2</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=547/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">CLANDESTIN (Румунія)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=588/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">CROMA (Бразилія)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">3</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=518/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">DIYSNO BREWERY (Україна)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=554/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">DOSKIWIS (Іспанія)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">4</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=557/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">FERMENTERARNA (Швеція)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">2</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=447/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">FUNKY FLUID (Польща)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">11</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=263/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">HOPPY HOG BREWERY (Україна)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">6</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=287/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">KYIV LOCAL BREWERY (Україна)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">3</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=561/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">LA SUPERBE (Франція)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">6</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=544/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">LUBROW BREWERY (Польща)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">2</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=475/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">MALLE (Україна)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=578/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">MARYENSZTADT (Польща)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=456/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">NEPO BREWING (Польща)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">12</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=542/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">NEVEL (Нідерланди)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">11</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=404/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">PINTA (Польща)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">4</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=519/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">PIWNE PODZIEMIE / BEER UNDERGROUND (Польща)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">5</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=539/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">PULFER BREWERY (Хорватія)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">2</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=240/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">REBREW (Україна)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">18</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=365/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">RED CAT (Україна)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">10</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=495/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">RODINNÝ PIVOVAR ZICHOVEC (Чехія)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">4</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=562/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">SALVADOR BREWING CO. (Бразилія)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=283/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">SHO BREWERY (Україна)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">8</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=423/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">SOFIA ELECTRIC BREWING (Болгарія)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">2</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=577/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title"> SPARKLE ✨(Франція)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">6</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=583/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">SPARKLE ✨(Франція)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=121/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">STU MOSTOW (Польща)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">3</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=230/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">TEN MEN (Україна)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">4</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=536/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">THE PIGGY BREWING COMPANY (Франція)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=347/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">TRACK BREWING CO. (Англія)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">5</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=244/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">UNDERWOOD BREWERY (Україна)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">11</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=208/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">VARVAR BREW (Україна)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">13</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=350/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">VAULT CITY BREWING (Шотландія)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=255/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">VOLTA BREWERY (Україна)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">10</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/brand=549/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">WHITE DOG BREWERY (Нідерланди)</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">3</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                </ul>
+        </div>
+    </div>                    <div
+        class="filter-section j-filter-section j-filter-collapsing"
+        data-filter-id="6421"
+    >
+        <div class="filter-section-h">
+                            <div class="filter-section-trigger j-filter-collapse-trigger">
+                    <svg class="icon icon--arrow-down"><use xlink:href="#icon-arrow-down"></use></svg>
+                    Банка/Пляшка                </div>
+                                </div>
+        <div class="filter-list  pretty-scroll j-filter-list">
+            <ul class="filter-lv1">
+                                                            <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/bankapljashka=1/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">Банка</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">192</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/bankapljashka=2/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">Пляшка</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">57</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                </ul>
+        </div>
+    </div>                    <div
+        class="filter-section j-filter-section j-filter-collapsing"
+        data-filter-id="6212"
+    >
+        <div class="filter-section-h">
+                            <div class="filter-section-trigger j-filter-collapse-trigger">
+                    <svg class="icon icon--arrow-down"><use xlink:href="#icon-arrow-down"></use></svg>
+                    Untappd                </div>
+                        <button class="btn __clear __hint" data-tooltip="filter-hint-1-6" id="widget-hint-filter-1-6">
+        <svg class="icon-hint"><use xlink:href="#icon-hint"></use></svg>
+    </button>
+            <div class="tooltip tooltip--textual" data-id="filter-tooltip-1-6">
+        <div class="tooltip__wrap">
+            <div class="tooltip__text">
+                <div class="text j-hint-text">
+                                            <div class="loader"></div>
+                                    </div>
+            </div>
+        </div>
+    </div>
+    <script>
+      (function(w) {
+        w.INIT.add(function() {
+          $('[data-tooltip=filter-hint-1-6]').tooltip({
+            content: $('[data-id="filter-tooltip-1-6"]'),
+            container: $('body > .container'),
+            trigger: 'click',
+            placement: 'top',
+            delay: 0,
+            hideOnClick: true
+          });
+        }, w.$)
+      })(window);
+    </script>                <script>
+          (function (w) {
+            w.INIT.add(function () {
+              w.Horoshop.Widgets.Hint.initHintContentLoader(
+                "filter",
+                0,
+                1,
+                6212,
+                6              );
+            }, w.Horoshop)
+          })(window);
+        </script>        </div>
+        <div class="filter-list  pretty-scroll j-filter-list">
+            <ul class="filter-lv1">
+                                                            <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=86/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.39</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=98/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.47</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=91/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.52</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">3</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=20/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.53</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=96/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.55</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=92/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.57</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=60/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.58</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=99/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.6</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">2</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=35/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.61</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=84/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.62</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=18/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.63</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">4</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=34/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.64</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">2</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=38/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.66</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">4</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=61/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.67</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">2</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=85/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.68</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">5</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=56/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.69</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=47/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.70</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=19/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.71</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=28/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.72</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">4</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=39/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.74</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">5</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=103/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.75</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">3</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=13/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.76</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">2</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=15/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.77</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=2/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.78</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">3</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=3/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.79</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=46/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.80</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=66/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.81</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">5</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=50/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.82</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">3</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=32/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.83</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">5</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=6/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.84</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=37/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.85</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">3</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=82/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.86</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">3</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=31/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.87</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">6</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=5/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.88</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">6</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=165/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3,89</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=7/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.89</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">4</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=69/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.9</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">3</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=30/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.91</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">3</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=10/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.92</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">3</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=16/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.93</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">5</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=73/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.94</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">3</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=12/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.95</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">6</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=54/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.96</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">3</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=23/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.97</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">6</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=11/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.98</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">3</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=22/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">3.99</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">8</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=63/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">4</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">8</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=58/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">4.01</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">8</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=24/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">4.02</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">2</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=40/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">4.03</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">5</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=67/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">4.04</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">2</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=65/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">4.05</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">5</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=75/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">4.06</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">3</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=14/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">4.07</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">6</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=36/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">4.08</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">2</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=104/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">4.09</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">4</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=158/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">4.1</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=79/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">4.10</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=8/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">4.11</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">5</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=62/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">4.12</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">2</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=55/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">4.13</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">4</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=41/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">4.14</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">3</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=76/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">4.15</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">3</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=77/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">4.16</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">2</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=33/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">4.17</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">4</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=68/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">4.18</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">4</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=57/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">4.19</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">2</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=155/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">4.2</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=9/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">4.21</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">3</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=115/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">4.22</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=133/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">4.23</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">2</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=64/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">4.24</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">2</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=112/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">4.25</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">3</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=88/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">4.26</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=126/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">4.27</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=134/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">4.28</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=132/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">4.3</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=80/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">4.32</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">2</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=72/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">4.33</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=144/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">4.35</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">2</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=21/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">4.36</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=152/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">4.37</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                                                <li class="filter-lv1-i">
+                            <a class="filter-check"
+                                rel="nofollow" data-fake-href="/beer/filter/untappd=135/"                            >
+                                <span class="checkbox"></span>
+                                <span class="label">
+                                    <span class="filter-title">4.39</span><!--
+                                 --><!--
+                                    --><sup class="filter-count">1</sup>
+                                                                    </span>
+                            </a>
+                        </li>
+                                                </ul>
+        </div>
+    </div>            </section>
+
+    <script>
+      (function (w) {
+        w.INIT.add(function () {
+          CatalogBuilder.filterSelector = '#uid342bd1556049bbbb8039d15eee64b49b';
+          CatalogBuilder.attachEventHandler('onFilterLinkClick', function (obj) {
+            if (obj.is('.filter-check') && !obj.data('loading')) {
+              obj.data('loading', true);
+              obj.append('<div class="loader"></div>');
+            }
+          });
+        }, w.CatalogBuilder)
+      })(window);
+    </script></div>
+    </div>
+                                            </aside>
+                </div>
+                                </div><!-- /.layout-->
+                  <script>
+            (function(w) {
+              w.INIT.add(function() {
+                const stickySidebar = new StickySidebar('.j-catalog-sticker-column', {
+                  containerSelector: '.j-catalog-sticker-parent',
+                  innerWrapperSelector: '.catalog__sidebar',
+                  topSpacing: 20,
+                  bottomSpacing: 20
+                });
+
+                const updateStickySidebar = function () {
+                  stickySidebar.updateSticky();
+                }
+
+                const attachExpandEvents = function () {
+                  $('.j-filter-section').on('opened closed toggled', updateStickySidebar);
+                  $('.j-seo-text-expander').on('transitionend', updateStickySidebar);
+                }
+
+                CatalogBuilder.attachEventHandlers({
+                  onChange: function () {
+                    updateStickySidebar();
+                    attachExpandEvents();
+                  }
+                });
+
+                attachExpandEvents();
+              }, w.StickySidebar)
+            })(window);
+          </script>
+        
+    </div>
+    </div><!-- /.wrapper-->
+
+                    <div id="uid8b1c67baa27fa2b380111299a04e2f02"></div>
+        <script>
+            document.addEventListener('DOMContentLoaded', function () {
+                sendAjax("\/_widget\/seen_items\/default\/", null, function (status, response) {
+                    var obj = document.getElementById('uid8b1c67baa27fa2b380111299a04e2f02');
+                    if (status === 'OK') {
+                        var fragment = document
+                            .createRange()
+                            .createContextualFragment(response.html);
+                        obj.replaceWith(fragment);
+                    }
+                });
+            });
+        </script>
+            
+<script>
+  (function(w) {
+    w.INIT.add(function() {
+      CatalogBuilder.init();
+    }, w.CatalogBuilder)
+  })(window);
+</script>        </main>
+        <footer class="footer">
+    <div class="footer__container">
+        <div class="footer__wrapper wrapper">
+            <div class="footer__columns">
+                                    <div class="footer__col footer__col--double">
+                        <div class="footer__col-wrap">
+                                                            <div class="footer__logo">
+                    <a class="footer__logo-link" href='/'>
+                <img alt='BEERFREAK'  class='footer__logo-img' width='342' height='200' src='/content/images/2/342x200l90nn0/24077375232849.jpg'  srcset="
+                                /content/images/2/342x200l90nn0/24077375232849.jpg 1x,
+                                /content/images/2/464x271l90nn0/24077375232849.jpg 2x
+                                ">            </a>
+            </div>                                                            <div class="footer__copyright">
+    </div>                                                                                                                        <div class="footer__mobile-version">
+    <a href="https://beerfreak.org/beer/.?v=mobile" class="footer__link" rel="nofollow">
+        <svg class="icon icon--mobile"><use xlink:href="#icon-mobile"></use></svg>
+        Мобільна версія    </a>
+</div>                                                    </div>
+                    </div>
+                                                                    <div class="footer__col ">
+                        <div class="footer__col-wrap">
+                                                            <div class="footer__block">
+    <div class="footer__heading">Каталог</div>
+    <ul class="footer__menu">
+        <li class="footer__menu-item __active"><a href="/beer/" class="footer__link">Пиво</a></li><li class="footer__menu-item "><a href="/cider-mead-other/" class="footer__link">Сидр та Мед</a></li><li class="footer__menu-item "><a href="/beer-collections/" class="footer__link">Колекцiї</a></li><li class="footer__menu-item "><a href="/non-alcohol/" class="footer__link">Non-Alcohol</a></li><li class="footer__menu-item "><a href="/new-arrivals/" class="footer__link">Новинки</a></li><li class="footer__menu-item "><a href="/craft-up-to-199/" class="footer__link">Імпорт до 199</a></li><li class="footer__menu-item "><a href="/sale/" class="footer__link">SALE!</a></li>    </ul></div>                                                    </div>
+                    </div>
+                                                    <div class="footer__col ">
+                        <div class="footer__col-wrap">
+                                                            <div class="footer__block">
+    <div class="footer__heading">Клієнтам</div>
+    <ul class="footer__menu">
+        <li class="footer__menu-item "><a href="#" class="footer__link"  data-modal="#sign-in">Вхід до кабінету</a></li><li class="footer__menu-item "><a href="/catalog/" class="footer__link">Каталог</a></li><li class="footer__menu-item "><a href="/information/" class="footer__link">Iнформація</a></li><li class="footer__menu-item "><a href="/about/" class="footer__link">Про нас</a></li>    </ul></div>                                                            <div class="footer__block">
+    Ми в соцмережах    <div class="footer__social">
+        <a class="footer__social-icon" data-fake-href="https://www.instagram.com/beerfreakorg" rel="nofollow" target="_blank" title="Мы в инстаграмме"><svg class="icon-ig"><use xlink:href="#icon-ig"></use></svg></a>
+            <a class="footer__social-icon" data-fake-href="https://t.me/beerfreakorg" rel="nofollow" target="_blank" title="Telegram"><svg class="icon-tg"><use xlink:href="#icon-tg"></use></svg></a>    </div>
+</div>                                                    </div>
+                    </div>
+                                                    <div class="footer__col footer__col--double">
+                        <div class="footer__col-wrap">
+                                                            <div class="footer__heading">Контактна інформація</div>
+<div class="footer__contacts footer__contacts--columns">
+    <div class="footer__contacts-group">
+                    <svg class="icon icon--phone">
+                <use xlink:href="#icon-phone"></use>
+            </svg>
+                            <div class="footer__contacts-item">
+                                <a data-fake-href="tel:098-64-55-991" class="footer__contacts-item-link j-phone-item"
+                   data-index="1">
+                    098-64-55-991                </a>
+            </div>
+                            <a class="footer__link" href="#" data-modal="#call-me">Передзвонити вам?</a>
+            <section id="call-me" class="popup __password" style="display: none;">
+    <div class="popup-block login">
+        <a class="popup-close" onclick="Modal.close();" href="javascript:;">
+            <svg class="icon icon--cross">
+                <use xlink:href="#icon-cross"></use>
+            </svg>
+        </a>
+        <div class="popup-header">
+            <div class="popup-title">Передзвонити вам?</div>
+        </div>
+        <div class="popup-body j-text">
+            <div
+                class="popup-msg j-callback-message">Вкажіть ваш номер телефону та ім'я. Ми зателефонуємо вам найближчим часом.</div>
+            <form method="post" data-action="/_widget/contacts/submit-callback/">
+                <dl class="form">
+                    <dt class="form-head">Ім'я</dt>
+                    <dd class="form-item">
+                        <input
+                            type="text"
+                            value=""
+                            class="field j-focus" name="form[title]"
+                        >
+                    </dd>
+                    <dt class="form-head">Телефон</dt>
+                    <dd class="form-item">
+                        <input type="text" value="" class="field j-phone"
+                               name="form[phone]">
+                        <input type="hidden" value="/beer/" name="form[url]">
+                    </dd>
+                    <dd class="form-item __submit">
+                        <span class="btn __special">
+                            <span class="btn-content">Надіслати</span>
+                            <input type="submit" value="Надіслати" class="btn-input">
+                        </span>
+                    </dd>
+                </dl>
+                <script>(function(w) {w.INIT.add(function() {(function ($) {var i=$('<input>').attr({name:"CSRFToken",type:'hidden'}).val("cdd72730bd1884729e561c162b25a1eb118f6777");$("#call-me form").append(i);})(jQuery)}, 'jQuery' in window)})(window)</script>            </form>
+        </div>
+    </div>
+</section>
+<script>
+    (function (w) {
+        w.INIT.add(function () {
+            ActiveForm.init($('#call-me').find('form'), {
+                'submitSuccess': function (response) {
+                    $('#call-me').find('.j-text').html(response.message);
+                    triggerMarketingEvent('callback_submit', [null, response.eventId]);
+                }
+            }, 'form');
+        }, w.ActiveForm)
+    })(window);
+</script>            </div>
+    <div class="footer__contacts-group">
+                                                    <div class="footer__contacts-item">
+                                            <svg class="icon icon--telegram">
+                            <use xlink:href="#icon-telegram"></use>
+                        </svg>
+                                        <a data-fake-href="tg://resolve?domain=Beer_Freak_Bot" class="footer__link">
+                        Написати нам                    </a>
+                </div>
+                                                                <div class="footer__contacts-item">
+                                            <svg class="icon icon--email">
+                            <use xlink:href="#icon-email"></use>
+                        </svg>
+                                        <a data-fake-href="mailto:hello%40beerfreak.org" class="footer__link">
+                        <span class="__cf_email__" data-cfemail="d3bbb6bfbfbc93b1b6b6a1b5a1b6b2b8fdbca1b4">[email&#160;protected]</span>                    </a>
+                </div>
+                        </div>
+    <div class="footer__contacts-group">
+        <svg class="icon icon--location">
+            <use xlink:href="#icon-location"></use>
+        </svg>
+                    <div class="footer__address">Львів, Україна
+</div>
+                            <a class="footer__link" href="/contacts/">Мапа проїзду</a>
+            </div></div>                                                    </div>
+                    </div>
+                                            </div>
+        </div>
+    </div>
+</footer>
+
+<div class="upButton" id="upButton">
+    <a class="upButton-btn" href="#">
+        <span class="upButton-btn__hint">Вгору</span>
+        <svg class="icon icon--arrow-up"><use xlink:href="#icon-arrow-up"></use></svg>
+    </a>
+</div>
+    </div>
+        <section id="sign-in" class="popup __login" style="display: none;">
+        <div class="popup-block login">
+            <a class="popup-close" onclick="Modal.close();" href="javascript:;">
+                <svg class="icon icon--cross"><use xlink:href="#icon-cross"></use></svg>
+            </a>
+            <div class="login-header">
+                <div class="login-tabs j-auth-tabs">
+                    <a href="#j-popup-tab-auth" class="login-tabs-i __active">
+                        <span class="login-tabs-txt">Вхід</span>
+                    </a>
+                    <a href="#j-popup-tab-signup" class="login-tabs-i">
+                        <span class="login-tabs-txt">Реєстрація</span>
+                    </a>
+                </div>
+                <div class="socLogin">
+    <div class="socLogin-h">Увійти за допомогою</div>
+    <div class="socLogin-b">
+                                                <a rel="nofollow"
+                   data-fake-href="/security/OAuthRedirect/?soc=facebook&saveCart=0"
+                   onclick="OAuth.setScenario('default'); showPopup(this.href, 997, 490); return false;"
+                   class="socialIcon">
+                    <svg class="icon icon--fb">
+                        <use xlink:href="#icon-fb"></use>
+                    </svg>
+                </a>
+                                                                                                <a rel="nofollow"
+                   data-fake-href="/security/OAuthRedirect/?soc=google&saveCart=0"
+                   onclick="OAuth.setScenario('default'); showPopup(this.href, 997, 490); return false;"
+                   class="socialIcon">
+                    <svg class="icon icon--gp">
+                        <use xlink:href="#icon-gp"></use>
+                    </svg>
+                </a>
+                                                                                                <a rel="nofollow"
+                   data-fake-href="/security/OAuthRedirect/?soc=linked_in&saveCart=0"
+                   onclick="OAuth.setScenario('default'); showPopup(this.href, 997, 490); return false;"
+                   class="socialIcon">
+                    <svg class="icon icon--li">
+                        <use xlink:href="#icon-li"></use>
+                    </svg>
+                </a>
+                        </div>
+</div>            </div>
+            <div class="login-body">
+                <div class="login-tabs-content" data-content-id="j-popup-tab-auth">
+                    <form method="post" id="login_form_id" data-action="/security/login/" onsubmit="submit_authorization(this); return false;">
+    <div class="j-login-info-message"></div>
+    <dl class="form">
+        <dt class="form-head">Е-пошта</dt>
+        <dd class="form-item">
+            <input type="email" name="user[email]" class="field j-focus" tabindex="1" autocapitalize="off">
+        </dd>
+        <dt class="form-head">Пароль</dt>
+        <dd class="form-item">
+            <input type="password" name="user[pass]" class="field" tabindex="2">
+        </dd>
+        <dd class="form-item __submit">
+            <span class="btn __special">
+                <span class="btn-content">Увійти</span>
+                <input type="submit" value="Увійти" class="btn-input" tabindex="3">
+            </span>
+            <span class="form-passRecover">
+                <a
+                    href="javascript:void(0);"
+                    class="a-pseudo"
+                    data-modal="#password-recovery"
+                >
+                    Забули пароль?                </a>
+            </span>
+        </dd>
+    </dl>
+    <script data-cfasync="false" src="/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"></script><script>(function(w) {w.INIT.add(function() {(function ($) {var i=$('<input>').attr({name:"CSRFToken",type:'hidden'}).val("4eea7a5cfc7955f6300699fe71b252b14454c675");$("#login_form_id").append(i);})(jQuery)}, 'jQuery' in window)})(window)</script></form>                </div>
+                <div class="login-tabs-content" data-content-id="j-popup-tab-signup">
+                    <form method="post" id="signup-form" data-action="/security/sign_up/" onsubmit="submit_new_registration(this); return false;" novalidate>
+    <div class="j-signup-info-message"></div>
+    <dl class="form">
+        <dt class="form-head __name">Ім'я та прізвище</dt>
+        <dd class="form-item">
+            <input type="text" name="user[title]" class="field" value="" tabindex="1">
+        </dd>
+        <dt class="form-head">Е-пошта</dt>
+        <dd class="form-item">
+            <input type="text" autocapitalize="off" name="user[email]" class="field" value="" tabindex="2">
+        </dd>
+                <dt class="form-head">Пароль</dt>
+        <dd class="form-item">
+            <input type="password" name="user[pass]" class="field" value="" tabindex="3">
+        </dd>
+                <dd class="form-item __submit">
+                                    <span class="btn __special j-submit ">
+                <span class="btn-content">Зареєструватись</span>
+                <input type="submit" value="Зареєструватись" class="btn-input" tabindex="7">
+            </span>
+                                                </dd>
+    </dl>
+    <script>(function(w) {w.INIT.add(function() {(function ($) {var i=$('<input>').attr({name:"CSRFToken",type:'hidden'}).val("eb501e37bf4dbb82f1a19cca4d4cf29818e0db2d");$("#signup-form").append(i);})(jQuery)}, 'jQuery' in window)})(window)</script></form>
+
+<script>
+  (function (w) {
+    w.INIT.add(function () {
+          }, w.Face)
+  })(window);
+</script>
+                </div>
+            </div>
+        </div>
+        <script>
+          (function (w) {
+            w.INIT.add(function () {
+              initTabs('#sign-in .j-auth-tabs a', {
+                onChange: function (currentBtn, currentTabContainer, tabContainers) {
+                  $(tabContainers).find('.popup-msg').empty();
+                  $(tabContainers).find('form').reset();
+                  $(currentTabContainer).find(':input').errorBox().filter(':first').focus();
+                }
+              });
+            }, w.initTabs)
+          })(window);
+        </script>
+    </section>
+
+    <section id="password-recovery" class="popup __password" style="display: none;">
+        <div class="popup-block login">
+            <a class="popup-close" onclick="Modal.close();" href="javascript:;">
+                <svg class="icon icon--cross"><use xlink:href="#icon-cross"></use></svg>
+            </a>
+            <div class="popup-header">
+                <div class="popup-title">Відновлення пароля</div>
+            </div>
+            <div class="popup-body">
+                <div class="popup-msg j-recovery-message">
+                    Введіть адресу електронної пошти, яку ви вказали під час реєстрації. Ми надішлемо листа з інформацією для відновлення пароля                </div>
+                <form id="password-recovery-form" method="post"
+      data-action="/security/password-recovery/"
+      onsubmit="password_recovery_submit(this); return false;">
+    <dl class="form">
+        <dt class="form-head">Е-пошта</dt>
+        <dd class="form-item">
+            <input type="email" autocapitalize="off" value="" class="field j-focus" name="user[email]">
+        </dd>
+        <dd class="form-item __submit">
+                            <span class="btn __special">
+                                <span class="btn-content">Відновити</span>
+                                <input type="submit" value="Відновити" class="btn-input">
+                            </span>
+        </dd>
+    </dl>
+    <script>(function(w) {w.INIT.add(function() {(function ($) {var i=$('<input>').attr({name:"CSRFToken",type:'hidden'}).val("948a547bd164c7982cf071cc09ae4e89f92303a1");$("#password-recovery-form").append(i);})(jQuery)}, 'jQuery' in window)})(window)</script></form>            </div>
+        </div>
+    </section>
+    <section id="age-confirmation" class="popup __age-confirmation">
+    <div class="popup-block">
+        <div class="popup-header">
+            <div class="popup-alert">
+                18+            </div>
+            <div class="popup-title">
+                Вам вже виповнилося 18 років?            </div>
+        </div>
+        <div class="popup-body">
+            <p>Цей інтернет-магазин містить товари для повнолітніх осіб. Щоб продовжити, підтвердіть свій вік</p>
+        </div>
+        <div class="popup-buttons">
+            <button class="btn __special __block j-age-confirm">
+                <span class="btn-content">Так, мені виповнилося 18 років</span>
+            </button>
+            <button class="btn __block j-age-decline">
+                <span class="btn-content">Ні, мені не виповнилося 18 років</span>
+            </button>
+        </div>
+    </div>
+</section>        <div id="modal-overlay" class="overlay"></div>
+    <script src='/bundles/default/production/main-2b4841d6.9992377e13eac0fb4f81.js'></script>
+<script src='/bundles/default/production/runtime.7120c8df6a0509f52a92.js'></script>
+<script src='/bundles/default/production/npm.spritespin.ae06fb361a59b14f6252.js'></script>
+<script src='/bundles/default/production/npm.inputmask.711c890d9833df84dc83.js'></script>
+<script src='/bundles/default/production/npm.jquery-13d81934.3f02b0283ddee7920906.js'></script>
+<script src='/bundles/default/production/npm.sticky-sidebar.9b1aed998b438a0502a9.js'></script>
+<script src='/bundles/default/production/npm.sourcebuster.190de06c3cb5f9541d9a.js'></script>
+<script src='/bundles/default/production/npm.popper.js.46626cd1331d2ebd1e93.js'></script>
+<script src='/bundles/default/production/npm.css-element-queries.e72e021709f421f869d0.js'></script>
+<script src='/bundles/default/production/npm.horoshop.547e29850f08ee21ece5.js'></script>
+<script src='/bundles/default/production/main-44867c3a.8364ddf8261767dd1ec7.js'></script>
+<script src='/bundles/default/production/main-e498c03b.29e90bd188df160e7d82.js'></script>
+<script src='/bundles/default/production/main-12f89153.cd01738afedb5681f77e.js'></script>
+<script src='/bundles/default/production/main-7199fefb.db9b7cd3f41130c605da.js'></script>
+<script src='/bundles/default/production/main-2d8f051b.b78618e8dd0fe6bc2eab.js'></script>
+<script src='/bundles/default/production/main-5ae6720c.ac7652bbe2552d46a5d5.js'></script>
+<script src='/bundles/default/production/main-886f090d.998d71870c275b9cbf2a.js'></script>
+<script src='/bundles/default/production/main-47f80845.129eaa2b04df61472e50.js'></script>
+<script src='/bundles/default/production/npm.jquery-b59a2ec2.c32010b03ac8c4e981f5.js'></script>
+
+<script>
+  (function (w) {
+    w.INIT.execute();
+  })(window)
+</script>
+        <script>
+if (window.location.href.includes('/checkout/complete/')) {
+  gtag('event', 'purchase', {
+    value: 1000,
+    currency: 'UAH'
+  });
+}
+</script>                <section
+    id="cart"
+    class="popup __cart"
+    style="display: none;"
+>
+    <div class="popup-block">
+        <a class="popup-close" onclick="Modal.close(); return false;" href="javascript:;">
+            <svg class="icon icon--cross"><use xlink:href="#icon-cross"></use></svg>
+        </a>
+        <div class="popup-title">Кошик</div>
+        <div class="cart">
+            <div class="cart-content">
+                <div class="loader-container j-cart-loader">
+                    <div class="loader-spinner loader-spinner--block"></div>
+                </div>
+                <table class="cart-items">
+                    <thead>
+                    <tr>
+                        <td></td>
+                        <td></td>
+                        <td class="cart-header">
+                            <div class="cart-header-b"><span
+                                        class="cart-header-content">Кількість</span></div>
+                        </td>
+                        <td class="cart-header __cost">
+                            <div class="cart-header-b"><span
+                                        class="cart-header-content">Вартість</span></div>
+                        </td>
+                    </tr>
+                    </thead>
+                                                                                <tfoot class="cart-foot">
+                                            <tr>
+                            <td class="cart-cell __image"></td>
+                            <td class="cart-cell" colspan="3">
+                                                                                                                                                        <div class="cart-discount">
+                                                <div class="cart-discount-l">
+                                                    <div class="cart-discount-info j-coupon-add-container">
+                                                        <a
+                                                            class="link link--pseudo j-coupon-add"
+                                                            href="#"
+                                                        >
+                                                            <span class="link__text">
+                                                        Є купон зі знижкою?                                                    </span></a>
+                                                </div>
+                                                <div
+                                                    class="cart-discount-coupon j-coupon-add-form"
+                                                    style="display: none;"
+                                                >
+                                                    <div class="coupon">
+                                                        <div class="coupon-input">
+                                                            <input
+                                                                class="coupon-field field errorBox-popup j-coupon-input"
+                                                                value=""
+                                                                autocomplete="off"
+                                                                placeholder="код купона чи сертифікату"
+                                                                type="text"
+                                                            >
+                                                            <div class="coupon-cancel j-coupon-cancel">
+                                                                <svg class="icon icon--cross-bold"><use xlink:href="#icon-cross-bold"></use></svg>
+                                                            </div>
+                                                        </div>
+                                                        <div class="coupon-submit">
+                                                            <button class="btn __small j-coupon-submit">
+                                                                <span class="btn-content">OK</span>
+                                                            </button>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                                                                                </td>
+                        </tr>
+                                        <tr>
+                        <td class="cart-footer" colspan="4">
+                            <div class="cart-summary">
+                                <div class="cart-footer-h">Всього</div>
+                                <div class="cart-footer-b cart-cost j-total-sum">
+                                    0 грн                                </div>
+                            </div>
+                            <div class="cart-buttons">
+                                <div class="cart-btnBack">
+                                    <button
+                                        class="btn __clear"
+                                        onclick="Modal.close(); return false;"
+                                    >
+                                        <span class="btn-content">
+                                            <svg class="icon icon--arrow-left2"><use xlink:href="#icon-arrow-left2"></use></svg>
+                                            Повернутись до покупок                                        </span>
+                                    </button>
+                                </div>
+                                <div class="cart-btnOrder">
+                                    <a
+                                        class="btn __special"
+                                        rel="nofollow"
+                                        href="/checkout/"
+                                    >
+                                        <span class="btn-content">Оформити замовлення</span>
+                                    </a>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                    </tfoot>
+                </table>
+            </div>
+            <div class="j-cart-additional">
+                            </div>
+        </div>
+    </div>
+</section>
+<script>
+  (function (w) {
+    w.INIT.add(function () {
+      const ajaxCart = AjaxCart.getInstance();
+
+      ajaxCart.skin = "modal";
+      ajaxCart.remove_product_on_zero = true;
+    }, w.AjaxCart);
+  })(window);
+</script>    <section class="compare" id="uid04bbbfc150db32d74d062a2b1af1b15e" style="display: none;">
+    <div class="compare-container">
+        <div class="compare-close j-close" role="button">
+            <svg class="icon icon--cross"><use xlink:href="#icon-cross"></use></svg>
+        </div>
+        <div class="compare-header">
+            <div class="compare-header-wrp">
+                <div class="compare-h">Порівняння товарів</div>
+                <div class="compare-filter j-tabs"></div>
+            </div>
+        </div>
+        <div class="j-loader" style="position: absolute;top:55px;left:0;right:0;bottom:0; z-index: 1000; background: rgba(255,255,255,.5)"><div class="loader" style="width: 10px; height: 10px; position: absolute; top: 50%;left:50%;margin:-5px 0 0 -5px;"></div></div>
+        <div class="compare-body j-content"></div>
+    </div>
+</section>
+
+<script>
+  (function (w) {
+    w.INIT.add(function () {
+      ComparisonTable.createInstance("default", "#uid04bbbfc150db32d74d062a2b1af1b15e");
+    }, w.ComparisonTable)
+  })(window);
+</script>    </body>
+<!-- Memory: 2 МБ -->
+</html><!-- 1.02s -->

--- a/spec.md
+++ b/spec.md
@@ -709,9 +709,11 @@ test-БД, §3.2 «no `await` ⇒ no race», §3.3 визначення «extern
   `.product-item`/`__vendor`/`__title`, повна навігація `?page=N`), `onemorebeer`
   (Nuxt **SPA** — тайл `.one-product-list-view__tile`, brewery
   `[data-information-type="brand-name"]`, назва `a.product__title`; `°` у тайтлі це
-  Плато, не ABV → `abv` опускається; має `waitForGrid`). `registry.pickAdapter(url)`.
-  Опційний `reRenderContainerSelector` — **звуження скоупу re-parse**, НЕ вмикач
-  re-render (див. нижче). Як додати адаптер: `docs/adapter-authoring.md`.
+  Плато, не ABV → `abv` опускається; має `waitForGrid`), `beerfreak` (Horoshop SSR —
+  `.catalogCard`, brewery/name з embedded `products` metadata, домен
+  `beerfreak.org`). `registry.pickAdapter(url)`. Опційний `reRenderContainerSelector` —
+  **звуження скоупу re-parse**, НЕ вмикач re-render (див. нижче). Як додати
+  адаптер: `docs/adapter-authoring.md`.
 - **Потік:** content script парсить видиму сітку → short-TTL кеш
   (`chrome.storage.local`) → промахи йдуть у background service worker, який
   тримає Bearer-токен (**ніколи** не в контексті сторінки) і б'є `POST /match` →


### PR DESCRIPTION
## Summary
- Add a BeerFreak Horoshop adapter with a real catalog fixture.
- Register beerfreak.org in the adapter registry and extension manifest.
- Update extension changelog and spec adapter list.

## Test Plan
- npm run typecheck (extension)
- npm test (extension)
- npm run build (extension)

Closes #87