### PR TITLE
release(extension): cut 0.2.0 — first user-facing release (adds BeerFreak)

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-06-09
+
 - Added BeerFreak shop support.
 
 ## [0.1.0] - 2026-06-08

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "warsaw-beer-extension",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Що це

Перший реліз розширення для розсилки користувачам. Згортає змержений, але ще unreleased адаптер **BeerFreak** (#101) у версіоновану секцію та піднімає єдине джерело версії (`extension/package.json`) до **0.2.0**.

Релізні магазини (3): `beerrepublic.eu`, `onemorebeer.pl`, **BeerFreak**.

## Зміни

- `extension/package.json`: `0.1.0` → `0.2.0`
- `extension/CHANGELOG.md`: `[Unreleased]` → `## [0.2.0] - 2026-06-09`

## Перевірка

- `npm run package` ✅ → `warsaw-beer-overlay-0.2.0.zip` (manifest version `0.2.0`, публічний `key` запінено — стабільний unpacked ID збережено)
- `RELEASE_NOTES.txt` = тіло секції CHANGELOG 0.2.0 ✅
- `npm run typecheck` ✅
- `npm test` ✅ 83/83

## Далі (поза цим PR, за `docs/extension-release.md`)

1. `sudo -u warsaw-beer-bot … npm run release` — запис рядка `extension_releases` у живу БД бота.
2. Форвард zip боту → **📣 Розіслати** (аудиторія: 3 власники токенів).

🤖 Generated with [Claude Code](https://claude.com/claude-code)