### PR TITLE
feat(extension): ⭐ global-rating badge for un-drunk beers + click-to-Untappd

### DIFF
--- a/docs/superpowers/plans/2026-06-09-extension-global-rating-untappd-link.md
+++ b/docs/superpowers/plans/2026-06-09-extension-global-rating-untappd-link.md
@@ -1,0 +1,488 @@
+# Extension ⭐ Global-Rating Badge + Untappd Link Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Badge un-drunk catalog beers with `⭐ <global rating>` and make every badge (drunk `✅` or not) clickable to open the beer's Untappd page in a new tab.
+
+**Architecture:** Thread the existing `beers.untappd_id` (numeric Untappd bid) through the match chain (`loadCatalog → matchBeerList → /match`) into the badge, then rewrite the badge renderer to a three-state machine with a click handler. No new matching logic, no new endpoint, no new permissions.
+
+**Tech Stack:** TypeScript, better-sqlite3, Hono (`/match` route), ts-jest (bot), vitest + jsdom (extension).
+
+**Spec:** `docs/superpowers/specs/2026-06-09-extension-global-rating-untappd-link-design.md`
+
+---
+
+## File structure
+
+| File | Change |
+| --- | --- |
+| `src/storage/beers.ts` | `CatalogRow` + `loadCatalog` SELECT gain `untappd_id` |
+| `src/domain/match-list.ts` | `CatalogBeerWithRating` (optional) + `MatchedBeer` (required) gain `untappd_id`; build passes it through |
+| `src/api/routes/match.ts` | **no change** — propagates automatically once storage + domain carry the field |
+| `extension/src/api/types.ts` | `MatchedBeer` gains `untappd_id: number \| null` |
+| `extension/src/content/badge.ts` | three-state render + click-to-Untappd |
+| `extension/src/cache/store.ts` | bump `PREFIX` to invalidate pre-`untappd_id` cache |
+| `spec.md`, `extension/CHANGELOG.md` | doc updates |
+
+---
+
+## Task 1: Thread `untappd_id` through the server match chain
+
+**Files:**
+- Modify: `src/storage/beers.ts`, `src/domain/match-list.ts`
+- Test: `src/storage/beers.test.ts`, `src/domain/match-list.test.ts`, `src/api/routes/match.test.ts`
+
+- [ ] **Step 1: Update the `loadCatalog` test to expect `untappd_id`**
+
+In `src/storage/beers.test.ts`, the `loadCatalog` test (near the end of the file) currently asserts:
+
+```ts
+    expect(cat).toContainEqual({
+      id, brewery: 'Trzech Kumpli', name: 'Pan IPAni', abv: 6.0, rating_global: 3.85,
+    });
+```
+
+Replace that assertion with (the fixture already sets `untappd_id: 9001`):
+
+```ts
+    expect(cat).toContainEqual({
+      id, brewery: 'Trzech Kumpli', name: 'Pan IPAni', abv: 6.0, rating_global: 3.85,
+      untappd_id: 9001,
+    });
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx jest src/storage/beers.test.ts -t loadCatalog`
+Expected: FAIL — `loadCatalog` does not yet return `untappd_id` (`toContainEqual` sees no matching object).
+
+- [ ] **Step 3: Add `untappd_id` to `CatalogRow` + `loadCatalog`**
+
+In `src/storage/beers.ts`, change the `CatalogRow` interface:
+
+```ts
+export interface CatalogRow {
+  id: number;
+  brewery: string;
+  name: string;
+  abv: number | null;
+  rating_global: number | null;
+  untappd_id: number | null;
+}
+```
+
+and the `loadCatalog` query:
+
+```ts
+export function loadCatalog(db: DB): CatalogRow[] {
+  return db
+    .prepare('SELECT id, brewery, name, abv, rating_global, untappd_id FROM beers')
+    .all() as CatalogRow[];
+}
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Run: `npx jest src/storage/beers.test.ts -t loadCatalog`
+Expected: PASS.
+
+- [ ] **Step 5: Update + add `match-list` tests for `untappd_id`**
+
+In `src/domain/match-list.test.ts`, the first test (`marks a matched, drunk beer with its personal rating`) asserts the full `matched_beer`. Add `untappd_id: null` to it (the fixture catalog beer has no bid):
+
+```ts
+        matched_beer: { id: 105, name: 'Pan IPAni', brewery: 'Trzech Kumpli', rating_global: 3.85, untappd_id: null },
+```
+
+Then add a new test (place it inside the first `describe('matchBeerList', ...)` block):
+
+```ts
+  it('passes untappd_id through to matched_beer', async () => {
+    const cat: CatalogBeerWithRating[] = [
+      { id: 300, brewery: 'PINTA', name: 'Viva la Wit', abv: 4.8, rating_global: 3.6, untappd_id: 555 },
+    ];
+    const res = await matchBeerList(cat, new Set(), new Map(), [
+      { brewery: 'PINTA', name: 'Viva la Wit' },
+    ]);
+    expect(res[0].matched_beer).toEqual({
+      id: 300, name: 'Viva la Wit', brewery: 'PINTA', rating_global: 3.6, untappd_id: 555,
+    });
+  });
+```
+
+- [ ] **Step 6: Run them to verify they fail**
+
+Run: `npx jest src/domain/match-list.test.ts`
+Expected: FAIL — `matched_beer` has no `untappd_id` field yet (the updated `toEqual` and the new test both mismatch).
+
+- [ ] **Step 7: Add `untappd_id` to the domain types + build**
+
+In `src/domain/match-list.ts`, extend `CatalogBeerWithRating` (input, optional — existing fixtures and callers omit it):
+
+```ts
+export interface CatalogBeerWithRating extends CatalogBeer {
+  rating_global: number | null;
+  untappd_id?: number | null;
+}
+```
+
+extend `MatchedBeer` (output, required):
+
+```ts
+export interface MatchedBeer {
+  id: number;
+  name: string;
+  brewery: string;
+  rating_global: number | null;
+  untappd_id: number | null;
+}
+```
+
+and add the field where `matched_beer` is built (in the `else` branch of the `for (const item of items)` loop):
+
+```ts
+        matched_beer: {
+          id: beer.id,
+          name: beer.name,
+          brewery: beer.brewery,
+          rating_global: beer.rating_global,
+          untappd_id: beer.untappd_id ?? null,
+        },
+```
+
+- [ ] **Step 8: Run them to verify they pass**
+
+Run: `npx jest src/domain/match-list.test.ts`
+Expected: PASS (all tests, including the unchanged equivalence/yield ones).
+
+- [ ] **Step 9: Add a route test asserting `untappd_id` propagates**
+
+In `src/api/routes/match.test.ts`, add this test inside `describe('POST /match', ...)`:
+
+```ts
+  it('includes the matched beer untappd_id in the response', async () => {
+    const { appAs } = setup();
+    const res = await post(appAs(1), { beers: [{ brewery: 'Trzech Kumpli', name: 'Pan IPAni' }] });
+    const body = await res.json();
+    expect(body.results[0].matched_beer.untappd_id).toBe(9001);
+  });
+```
+
+- [ ] **Step 10: Run it to verify it passes**
+
+Run: `npx jest src/api/routes/match.test.ts`
+Expected: PASS — `match.ts` is unchanged; the field propagates automatically through `loadCatalog → matchBeerList`.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/storage/beers.ts src/storage/beers.test.ts src/domain/match-list.ts src/domain/match-list.test.ts src/api/routes/match.test.ts
+git commit -m "feat(match): thread beers.untappd_id through loadCatalog → matchBeerList → /match"
+```
+
+---
+
+## Task 2: Badge ⭐ + click-to-Untappd in the extension
+
+**Files:**
+- Modify: `extension/src/api/types.ts`, `extension/src/content/badge.ts`, `extension/src/cache/store.ts`
+- Test: `extension/src/content/badge.test.ts`
+
+- [ ] **Step 1: Rewrite the badge test for the new behaviour**
+
+Replace the whole contents of `extension/src/content/badge.test.ts` with:
+
+```ts
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderBadge, BADGE_MARKER, markSeen, isSeen, SEEN_MARKER } from './badge';
+import type { MatchResult } from '../api/types';
+
+function el(): HTMLElement {
+  const d = document.createElement('div');
+  document.body.appendChild(d);
+  return d;
+}
+
+const drunk = (userRating: number | null): MatchResult => ({
+  raw: { brewery: 'PINTA', name: 'Hazy Morning' },
+  matched_beer: { id: 1, name: 'Hazy Morning', brewery: 'PINTA', rating_global: 4.1, untappd_id: 111 },
+  is_drunk: true,
+  user_rating: userRating,
+});
+
+const notDrunkRated: MatchResult = {
+  raw: { brewery: 'PINTA', name: 'New One' },
+  matched_beer: { id: 2, name: 'New One', brewery: 'PINTA', rating_global: 3.9, untappd_id: 222 },
+  is_drunk: false,
+  user_rating: null,
+};
+
+const notDrunkOrphan: MatchResult = {
+  raw: { brewery: 'PINTA', name: 'Orphan' },
+  matched_beer: { id: 3, name: 'Orphan', brewery: 'PINTA', rating_global: null, untappd_id: null },
+  is_drunk: false,
+  user_rating: null,
+};
+
+const unmatched: MatchResult = {
+  raw: { brewery: 'Nowhere', name: 'Ghost' },
+  matched_beer: null,
+  is_drunk: false,
+  user_rating: null,
+};
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  vi.restoreAllMocks();
+});
+
+describe('renderBadge', () => {
+  it('adds a ✅ + personal rating badge for a drunk beer', () => {
+    const host = el();
+    renderBadge(host, drunk(4.0));
+    const badge = host.querySelector(`[${BADGE_MARKER}]`);
+    expect(badge).not.toBeNull();
+    expect(badge!.textContent).toContain('✅');
+    expect(badge!.textContent).toContain('4.0');
+  });
+
+  it('shows just ✅ when drunk with no personal rating', () => {
+    const host = el();
+    renderBadge(host, drunk(null));
+    expect(host.querySelector(`[${BADGE_MARKER}]`)!.textContent).toBe('✅');
+  });
+
+  it('adds a ⭐ + global rating badge for a not-drunk catalog beer with a bid', () => {
+    const host = el();
+    renderBadge(host, notDrunkRated);
+    const badge = host.querySelector(`[${BADGE_MARKER}]`);
+    expect(badge!.textContent).toContain('⭐');
+    expect(badge!.textContent).toContain('3.9');
+  });
+
+  it('renders nothing for a not-drunk orphan (no bid / no global rating)', () => {
+    const host = el();
+    renderBadge(host, notDrunkOrphan);
+    expect(host.querySelector(`[${BADGE_MARKER}]`)).toBeNull();
+  });
+
+  it('renders nothing for an unmatched beer', () => {
+    const host = el();
+    renderBadge(host, unmatched);
+    expect(host.querySelector(`[${BADGE_MARKER}]`)).toBeNull();
+  });
+
+  it('opens the Untappd beer page on click and suppresses card navigation', () => {
+    const host = el();
+    const open = vi.spyOn(window, 'open').mockReturnValue(null);
+    renderBadge(host, notDrunkRated);
+    const badge = host.querySelector(`[${BADGE_MARKER}]`) as HTMLElement;
+    const evt = new MouseEvent('click', { bubbles: true, cancelable: true });
+    const notPrevented = badge.dispatchEvent(evt);
+    expect(open).toHaveBeenCalledWith('https://untappd.com/beer/222', '_blank', 'noopener');
+    expect(notPrevented).toBe(false); // preventDefault() was called
+  });
+
+  it('is idempotent — does not double-render', () => {
+    const host = el();
+    renderBadge(host, drunk(4.0));
+    renderBadge(host, drunk(4.0));
+    expect(host.querySelectorAll(`[${BADGE_MARKER}]`).length).toBe(1);
+  });
+});
+
+describe('seen marker', () => {
+  it('marks and detects a processed element', () => {
+    const host = document.createElement('div');
+    expect(isSeen(host)).toBe(false);
+    markSeen(host);
+    expect(host.hasAttribute(SEEN_MARKER)).toBe(true);
+    expect(isSeen(host)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cd extension && npx vitest run src/content/badge.test.ts`
+Expected: FAIL — the fixtures use `matched_beer.untappd_id` (not in the type yet) and the `⭐`/click behaviour isn't implemented.
+
+- [ ] **Step 3: Add `untappd_id` to the extension `MatchedBeer` type**
+
+In `extension/src/api/types.ts`, extend `MatchedBeer`:
+
+```ts
+export interface MatchedBeer {
+  id: number;
+  name: string;
+  brewery: string;
+  rating_global: number | null;
+  untappd_id: number | null;
+}
+```
+
+- [ ] **Step 4: Rewrite `extension/src/content/badge.ts`**
+
+Replace the whole file with:
+
+```ts
+import type { MatchResult } from '../api/types';
+
+export const BADGE_MARKER = 'data-beerbadge';
+export const SEEN_MARKER = 'data-beerseen';
+
+/** Mark a card element as processed by the overlay (badged or not). */
+export function markSeen(el: HTMLElement): void {
+  el.setAttribute(SEEN_MARKER, '');
+}
+
+/** True if the overlay has already processed this card element. */
+export function isSeen(el: HTMLElement): boolean {
+  return el.hasAttribute(SEEN_MARKER);
+}
+
+function untappdUrl(untappdId: number): string {
+  return `https://untappd.com/beer/${untappdId}`;
+}
+
+// The badge label, or null when this result should not be badged.
+// drunk → ✅ (+ personal rating); in-catalog & not drunk with a bid + global
+// rating → ⭐ (global rating); everything else (orphan / unmatched) → no badge.
+function badgeText(result: MatchResult): string | null {
+  const m = result.matched_beer;
+  if (!m) return null;
+  if (result.is_drunk) {
+    return result.user_rating != null ? `✅ ${result.user_rating.toFixed(1)}` : '✅';
+  }
+  if (m.untappd_id != null && m.rating_global != null) {
+    return `⭐ ${m.rating_global.toFixed(1)}`;
+  }
+  return null;
+}
+
+export function renderBadge(host: HTMLElement, result: MatchResult): void {
+  const text = badgeText(result);
+  if (text == null) return;
+  if (host.querySelector(`[${BADGE_MARKER}]`)) return;
+
+  const untappdId = result.matched_beer?.untappd_id ?? null;
+
+  const badge = document.createElement('div');
+  badge.setAttribute(BADGE_MARKER, '');
+  badge.textContent = text;
+  Object.assign(badge.style, {
+    position: 'absolute',
+    top: '4px',
+    right: '4px',
+    zIndex: '2147483647',
+    background: 'rgba(20,20,20,0.82)',
+    color: '#fff',
+    font: '600 12px/1 system-ui, sans-serif',
+    padding: '3px 6px',
+    borderRadius: '6px',
+    pointerEvents: untappdId != null ? 'auto' : 'none',
+    cursor: untappdId != null ? 'pointer' : 'default',
+  } as Partial<CSSStyleDeclaration>);
+
+  if (untappdId != null) {
+    badge.addEventListener('click', (e) => {
+      // The badge sits on top of the product card, which is usually itself a
+      // link — suppress the card's navigation before opening Untappd.
+      e.preventDefault();
+      e.stopPropagation();
+      window.open(untappdUrl(untappdId), '_blank', 'noopener');
+    });
+  }
+
+  if (getComputedStyle(host).position === 'static') host.style.position = 'relative';
+  host.appendChild(badge);
+}
+```
+
+- [ ] **Step 5: Bump the cache prefix to invalidate pre-`untappd_id` entries**
+
+In `extension/src/cache/store.ts`, change:
+
+```ts
+const PREFIX = 'mc:';
+```
+
+to:
+
+```ts
+const PREFIX = 'mc2:';
+```
+
+- [ ] **Step 6: Run the badge test + extension suite + typecheck**
+
+Run: `cd extension && npx vitest run src/content/badge.test.ts`
+Expected: PASS (7 `renderBadge` cases + seen-marker).
+
+Run: `cd extension && npm test && npm run typecheck`
+Expected: all vitest suites green; `tsc --noEmit` exits 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add extension/src/api/types.ts extension/src/content/badge.ts extension/src/content/badge.test.ts extension/src/cache/store.ts
+git commit -m "feat(extension): ⭐ global-rating badge for un-drunk beers + click-to-Untappd"
+```
+
+---
+
+## Task 3: Spec + CHANGELOG
+
+**Files:**
+- Modify: `spec.md`, `extension/CHANGELOG.md`
+
+- [ ] **Step 1: Update `spec.md` §6**
+
+In `spec.md`, find the bullet beginning `- **Збірка — єдине джерело метаданих.**` in the Browser Extension Client section (§6). Immediately **before** it, add a new bullet describing the badge behaviour:
+
+```markdown
+- **Бейджі.** Питі беври — `✅` + особиста оцінка. Каталожні беври, які користувач ще
+  не пив, але які мають `untappd_id` і глобальний рейтинг — `⭐` + глобальна оцінка
+  Untappd. Будь-який бейдж із `untappd_id` клікабельний: відкриває сторінку беври на
+  Untappd (`https://untappd.com/beer/<untappd_id>`) у новій вкладці. Орфани (без
+  `untappd_id`/рейтингу) і незматчені — без бейджа.
+```
+
+- [ ] **Step 2: Add a CHANGELOG entry**
+
+In `extension/CHANGELOG.md`, under the `## [Unreleased]` heading, add:
+
+```markdown
+- Show ⭐ global Untappd rating for catalog beers you haven't drunk yet.
+- Click any rating badge to open that beer on Untappd in a new tab.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add spec.md extension/CHANGELOG.md
+git commit -m "docs: spec + changelog for ⭐ global-rating badge + Untappd link"
+```
+
+---
+
+## Task 4: Full verification
+
+- [ ] **Step 1: Bot suite**
+
+Run: `npm test`
+Expected: all bot/jest suites green, including the updated `beers`/`match-list`/`match` tests.
+
+- [ ] **Step 2: Extension suite + typecheck**
+
+Run: `cd extension && npm test && npm run typecheck`
+Expected: all vitest suites green (incl. `src/content/badge.test.ts`); `tsc --noEmit` exits 0.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** ⭐ badge for un-drunk catalog beers (Task 2), `✅` unchanged (Task 2), click-to-Untappd both badges (Task 2), `untappd_id` data flow storage→domain→api (Task 1) + extension type (Task 2), cache invalidation (Task 2 Step 5), orphan/unmatched → no badge (Task 2 tests), spec §6 + CHANGELOG (Task 3). All spec sections map to a task. Out-of-scope items (background tab, side-by-side window, no-rating badge) untouched.
+- **Type consistency:** `untappd_id: number | null` is the output shape on both `MatchedBeer` types (domain + extension); `CatalogBeerWithRating.untappd_id?` is optional input; `CatalogRow.untappd_id` required (from SELECT). Badge reads `matched_beer.untappd_id`. Names match across tasks.
+- **No placeholders:** every code/command step is complete and runnable.
+- **Execution note:** implement in a worktree (branches from `origin/main`); cherry-pick the spec commit (`93f60ac`) and this plan's commit into the worktree branch, per project convention.
+```

--- a/docs/superpowers/specs/2026-06-09-extension-global-rating-untappd-link-design.md
+++ b/docs/superpowers/specs/2026-06-09-extension-global-rating-untappd-link-design.md
@@ -1,0 +1,117 @@
+# Extension global-rating badge + Untappd link — design
+
+**Date:** 2026-06-09
+**Status:** approved (brainstorming)
+**Builds on:** [browser extension client](2026-06-07-browser-extension-client-design.md), [extension beta distribution](2026-06-08-extension-beta-distribution-design.md)
+
+## Problem
+
+The overlay badges only **drunk** beers (`✅` + the user's rating). A beer the user
+hasn't drunk but that exists in the catalog with a global Untappd rating gets no badge,
+so the shopper sees nothing for it — even though we know its global score. And there is
+no way to jump from a badge to the beer's Untappd page.
+
+## Goal
+
+1. Badge catalog beers the user **hasn't** drunk with `⭐ <global rating>` (distinct from
+   the drunk `✅`).
+2. Make **both** badges clickable — clicking opens that beer's Untappd page in a new
+   foreground tab, without navigating away from the shop.
+
+## Decisions (from brainstorming)
+
+- Drunk badge stays `✅` + `user_rating` (unchanged).
+- New not-drunk badge: `⭐` + `rating_global` (the catalog's global Untappd score).
+- The `⭐` badge appears only when the match has **both** an `untappd_id` (bid) **and** a
+  `rating_global` — without a rating there's nothing to show, and without a bid there's
+  nowhere to link.
+- Both badges clickable when `untappd_id` is present → open
+  `https://untappd.com/beer/<untappd_id>` (verified: the numeric-bid URL resolves to the
+  beer page; no slug needed).
+- New **foreground** tab via `window.open(url, '_blank', 'noopener')`.
+
+## Data flow
+
+`untappd_id` already lives in `beers` but is dropped before reaching the extension.
+Thread it through the existing match chain — no new matching logic:
+
+```
+beers.untappd_id (numeric bid; NULL for orphans)
+ └─ loadCatalog (src/storage/beers.ts)            + untappd_id in SELECT + CatalogRow
+     └─ matchBeerList (src/domain/match-list.ts)  + untappd_id on MatchedBeer
+         └─ POST /match response                   + untappd_id (extension/src/api/types.ts)
+             └─ badge.ts                            new ⭐ branch + click handler
+```
+
+## Components
+
+### 1. Server — propagate `untappd_id` (3 files)
+
+- **`src/storage/beers.ts`** — `loadCatalog` adds `untappd_id` to the `SELECT` and to
+  `CatalogRow`. (The matcher ignores it; it just rides along for output.)
+- **`src/domain/match-list.ts`** — `MatchedBeer` gains `untappd_id: number | null`,
+  populated from the catalog row when building each matched result. `CatalogBeerWithRating`
+  carries `untappd_id` so `byId.get(m.id)` exposes it.
+- **`extension/src/api/types.ts`** — `MatchedBeer` gains `untappd_id: number | null` to
+  mirror the server response.
+
+No new endpoint, no auth/permission change.
+
+### 2. Extension — badge rendering (`extension/src/content/badge.ts`)
+
+Replace the `if (!result.is_drunk) return` early-out with a small state machine:
+
+- `matched_beer == null` → no badge.
+- `is_drunk` → `✅` (+ `user_rating` when present) — current behaviour.
+- not drunk **and** `untappd_id != null` **and** `rating_global != null` →
+  `⭐ <rating_global.toFixed(1)>`.
+- otherwise (matched orphan: no bid / no global rating) → no badge.
+
+### 3. Extension — click to Untappd (`extension/src/content/badge.ts`)
+
+When `matched_beer.untappd_id != null`, the badge is interactive:
+
+- `pointerEvents: 'auto'`, `cursor: 'pointer'`.
+- click handler: `e.preventDefault(); e.stopPropagation();` (the badge sits on top of the
+  product card, which is usually itself a link — suppress the card's navigation), then
+  `window.open('https://untappd.com/beer/' + untappd_id, '_blank', 'noopener')`.
+
+A drunk-but-orphan beer (`untappd_id == null`, rare) still shows `✅` but is not clickable.
+
+### 4. Cache invalidation (`extension/src/cache/store.ts`)
+
+Cached `MatchResult` entries predate `untappd_id`; reading them would yield
+non-clickable badges until they expire. Bump the storage key `PREFIX` (`'mc:'` →
+`'mc2:'`) so stale entries are never read (the old keys also self-expire within the 8h
+TTL). No migration needed.
+
+## Error handling / edge cases
+
+- Missing `untappd_id` or `rating_global` → fall through to "no badge" / "not clickable";
+  never render a dead link.
+- `window.open` returning null (popup blocked) is a no-op from our side; acceptable — the
+  user can retry. `noopener` prevents the opened page from accessing `window.opener`.
+
+## Testing
+
+- **`badge.ts`** (vitest, jsdom): drunk → `✅`; not-drunk + bid + global → `⭐` with the
+  global value; not-drunk orphan (no bid or no rating) → no badge; unmatched → no badge;
+  click on a badge with a bid calls `window.open` with the exact Untappd URL and calls
+  `preventDefault`/`stopPropagation`; a badge without a bid is not clickable.
+- **`src/storage/beers.ts`** — `loadCatalog` returns `untappd_id`.
+- **`src/domain/match-list.ts`** — a matched result carries `matched_beer.untappd_id`.
+- **`src/api/routes/match.ts`** — `/match` response includes `untappd_id`.
+- Existing extension + bot suites stay green.
+
+## Spec / CHANGELOG
+
+- **`spec.md §6`** — add a line: the overlay also badges un-drunk catalog beers with
+  `⭐ <global rating>`, and any badge with an Untappd bid links to the beer's Untappd page.
+- **`extension/CHANGELOG.md`** — entry under `[Unreleased]`. The version bump + release is
+  a separate step (the one-command release flow).
+
+## Out of scope
+
+- Background-tab / side-by-side-window opening (chose foreground tab).
+- Showing a badge for beers with no global rating, or for unmatched beers.
+- Changing the drunk badge's appearance or the matching algorithm.

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- Show ⭐ global Untappd rating for catalog beers you haven't drunk yet.
+- Click any rating badge to open that beer on Untappd in a new tab.
+
 ## [0.2.0] - 2026-06-09
 
 - Added BeerFreak shop support.

--- a/extension/src/api/types.ts
+++ b/extension/src/api/types.ts
@@ -9,6 +9,7 @@ export interface MatchedBeer {
   name: string;
   brewery: string;
   rating_global: number | null;
+  untappd_id: number | null;
 }
 
 export interface MatchResult {

--- a/extension/src/cache/store.test.ts
+++ b/extension/src/cache/store.test.ts
@@ -4,7 +4,7 @@ import type { MatchResult } from '../api/types';
 
 const sample: MatchResult = {
   raw: { brewery: 'PINTA', name: 'Hazy Morning' },
-  matched_beer: { id: 1, name: 'Hazy Morning', brewery: 'PINTA', rating_global: 4.1 },
+  matched_beer: { id: 1, name: 'Hazy Morning', brewery: 'PINTA', rating_global: 4.1, untappd_id: 111 },
   is_drunk: true,
   user_rating: 4.0,
 };

--- a/extension/src/cache/store.ts
+++ b/extension/src/cache/store.ts
@@ -1,7 +1,7 @@
 import type { MatchResult } from '../api/types';
 
 export const CACHE_TTL_MS = 8 * 60 * 60 * 1000; // 8h
-const PREFIX = 'mc:';
+const PREFIX = 'mc2:';
 
 interface Entry {
   result: MatchResult;

--- a/extension/src/content/badge.test.ts
+++ b/extension/src/content/badge.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { renderBadge, BADGE_MARKER, markSeen, isSeen, SEEN_MARKER } from './badge';
 import type { MatchResult } from '../api/types';
 
@@ -10,22 +10,39 @@ function el(): HTMLElement {
 
 const drunk = (userRating: number | null): MatchResult => ({
   raw: { brewery: 'PINTA', name: 'Hazy Morning' },
-  matched_beer: { id: 1, name: 'Hazy Morning', brewery: 'PINTA', rating_global: 4.1 },
+  matched_beer: { id: 1, name: 'Hazy Morning', brewery: 'PINTA', rating_global: 4.1, untappd_id: 111 },
   is_drunk: true,
   user_rating: userRating,
 });
 
-const notDrunk: MatchResult = {
+const notDrunkRated: MatchResult = {
   raw: { brewery: 'PINTA', name: 'New One' },
-  matched_beer: { id: 2, name: 'New One', brewery: 'PINTA', rating_global: 3.9 },
+  matched_beer: { id: 2, name: 'New One', brewery: 'PINTA', rating_global: 3.9, untappd_id: 222 },
   is_drunk: false,
   user_rating: null,
 };
 
-beforeEach(() => { document.body.innerHTML = ''; });
+const notDrunkOrphan: MatchResult = {
+  raw: { brewery: 'PINTA', name: 'Orphan' },
+  matched_beer: { id: 3, name: 'Orphan', brewery: 'PINTA', rating_global: null, untappd_id: null },
+  is_drunk: false,
+  user_rating: null,
+};
+
+const unmatched: MatchResult = {
+  raw: { brewery: 'Nowhere', name: 'Ghost' },
+  matched_beer: null,
+  is_drunk: false,
+  user_rating: null,
+};
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  vi.restoreAllMocks();
+});
 
 describe('renderBadge', () => {
-  it('adds a ✅ + rating badge for a drunk beer', () => {
+  it('adds a ✅ + personal rating badge for a drunk beer', () => {
     const host = el();
     renderBadge(host, drunk(4.0));
     const badge = host.querySelector(`[${BADGE_MARKER}]`);
@@ -34,16 +51,41 @@ describe('renderBadge', () => {
     expect(badge!.textContent).toContain('4.0');
   });
 
-  it('shows just ✅ when no personal rating', () => {
+  it('shows just ✅ when drunk with no personal rating', () => {
     const host = el();
     renderBadge(host, drunk(null));
     expect(host.querySelector(`[${BADGE_MARKER}]`)!.textContent).toBe('✅');
   });
 
-  it('renders nothing for a not-drunk beer (MVP)', () => {
+  it('adds a ⭐ + global rating badge for a not-drunk catalog beer with a bid', () => {
     const host = el();
-    renderBadge(host, notDrunk);
+    renderBadge(host, notDrunkRated);
+    const badge = host.querySelector(`[${BADGE_MARKER}]`);
+    expect(badge!.textContent).toContain('⭐');
+    expect(badge!.textContent).toContain('3.9');
+  });
+
+  it('renders nothing for a not-drunk orphan (no bid / no global rating)', () => {
+    const host = el();
+    renderBadge(host, notDrunkOrphan);
     expect(host.querySelector(`[${BADGE_MARKER}]`)).toBeNull();
+  });
+
+  it('renders nothing for an unmatched beer', () => {
+    const host = el();
+    renderBadge(host, unmatched);
+    expect(host.querySelector(`[${BADGE_MARKER}]`)).toBeNull();
+  });
+
+  it('opens the Untappd beer page on click and suppresses card navigation', () => {
+    const host = el();
+    const open = vi.spyOn(window, 'open').mockReturnValue(null);
+    renderBadge(host, notDrunkRated);
+    const badge = host.querySelector(`[${BADGE_MARKER}]`) as HTMLElement;
+    const evt = new MouseEvent('click', { bubbles: true, cancelable: true });
+    const notPrevented = badge.dispatchEvent(evt);
+    expect(open).toHaveBeenCalledWith('https://untappd.com/beer/222', '_blank', 'noopener');
+    expect(notPrevented).toBe(false); // preventDefault() was called
   });
 
   it('is idempotent — does not double-render', () => {

--- a/extension/src/content/badge.ts
+++ b/extension/src/content/badge.ts
@@ -13,14 +13,35 @@ export function isSeen(el: HTMLElement): boolean {
   return el.hasAttribute(SEEN_MARKER);
 }
 
+function untappdUrl(untappdId: number): string {
+  return `https://untappd.com/beer/${untappdId}`;
+}
+
+// The badge label, or null when this result should not be badged.
+// drunk → ✅ (+ personal rating; the ✅ shows the user's own data, independent of the
+// catalog match); in-catalog & not drunk with a bid + global rating → ⭐ (global
+// rating); everything else (orphan / unmatched) → no badge.
+function badgeText(result: MatchResult): string | null {
+  if (result.is_drunk) {
+    return result.user_rating != null ? `✅ ${result.user_rating.toFixed(1)}` : '✅';
+  }
+  const m = result.matched_beer;
+  if (m && m.untappd_id != null && m.rating_global != null) {
+    return `⭐ ${m.rating_global.toFixed(1)}`;
+  }
+  return null;
+}
+
 export function renderBadge(host: HTMLElement, result: MatchResult): void {
-  if (!result.is_drunk) return; // MVP: only drunk beers get a badge
+  const text = badgeText(result);
+  if (text == null) return;
   if (host.querySelector(`[${BADGE_MARKER}]`)) return;
+
+  const untappdId = result.matched_beer?.untappd_id ?? null;
 
   const badge = document.createElement('div');
   badge.setAttribute(BADGE_MARKER, '');
-  badge.textContent =
-    result.user_rating != null ? `✅ ${result.user_rating.toFixed(1)}` : '✅';
+  badge.textContent = text;
   Object.assign(badge.style, {
     position: 'absolute',
     top: '4px',
@@ -31,8 +52,19 @@ export function renderBadge(host: HTMLElement, result: MatchResult): void {
     font: '600 12px/1 system-ui, sans-serif',
     padding: '3px 6px',
     borderRadius: '6px',
-    pointerEvents: 'none',
+    pointerEvents: untappdId != null ? 'auto' : 'none',
+    cursor: untappdId != null ? 'pointer' : 'default',
   } as Partial<CSSStyleDeclaration>);
+
+  if (untappdId != null) {
+    badge.addEventListener('click', (e) => {
+      // The badge sits on top of the product card, which is usually itself a
+      // link — suppress the card's navigation before opening Untappd.
+      e.preventDefault();
+      e.stopPropagation();
+      window.open(untappdUrl(untappdId), '_blank', 'noopener');
+    });
+  }
 
   if (getComputedStyle(host).position === 'static') host.style.position = 'relative';
   host.appendChild(badge);

--- a/extension/src/content/index.test.ts
+++ b/extension/src/content/index.test.ts
@@ -9,7 +9,7 @@ import type { MatchResult, RawBeer } from '../api/types';
 function drunkResult(brewery: string, name: string): MatchResult {
   return {
     raw: { brewery, name },
-    matched_beer: { id: 1, name, brewery, rating_global: 4.0 },
+    matched_beer: { id: 1, name, brewery, rating_global: 4.0, untappd_id: 111 },
     is_drunk: true,
     user_rating: 4.2,
   };

--- a/spec.md
+++ b/spec.md
@@ -742,6 +742,11 @@ test-БД, §3.2 «no `await` ⇒ no race», §3.3 визначення «extern
 > `docs/superpowers/specs/2026-06-08-extension-beta-distribution-design.md`,
 > рунбук: `docs/extension-release.md`.
 
+- **Бейджі.** Питі беври — `✅` + особиста оцінка. Каталожні беври, які користувач ще
+  не пив, але які мають `untappd_id` і глобальний рейтинг — `⭐` + глобальна оцінка
+  Untappd. Будь-який бейдж із `untappd_id` клікабельний: відкриває сторінку беври на
+  Untappd (`https://untappd.com/beer/<untappd_id>`) у новій вкладці. Орфани (без
+  `untappd_id`/рейтингу) і незматчені — без бейджа.
 - **Збірка — єдине джерело метаданих.** Версія береться з `extension/package.json`
   (маніфест імпортує її; `key` у маніфесті фіксує ID розширення → токен переживає
   переустановку). `npm run release` = build → `RELEASE_NOTES.txt` (тіло секції

--- a/src/api/routes/match.test.ts
+++ b/src/api/routes/match.test.ts
@@ -56,6 +56,13 @@ describe('POST /match', () => {
     });
   });
 
+  it('includes the matched beer untappd_id in the response', async () => {
+    const { appAs } = setup();
+    const res = await post(appAs(1), { beers: [{ brewery: 'Trzech Kumpli', name: 'Pan IPAni' }] });
+    const body = await res.json();
+    expect(body.results[0].matched_beer.untappd_id).toBe(9001);
+  });
+
   it('isolates users — user 2 has not drunk the beer', async () => {
     const { appAs } = setup();
     const res = await post(appAs(2), { beers: [{ brewery: 'Trzech Kumpli', name: 'Pan IPAni' }] });

--- a/src/domain/match-list.test.ts
+++ b/src/domain/match-list.test.ts
@@ -17,11 +17,23 @@ describe('matchBeerList', () => {
     expect(res).toEqual([
       {
         raw: { brewery: 'Trzech Kumpli', name: 'Pan IPAni' },
-        matched_beer: { id: 105, name: 'Pan IPAni', brewery: 'Trzech Kumpli', rating_global: 3.85 },
+        matched_beer: { id: 105, name: 'Pan IPAni', brewery: 'Trzech Kumpli', rating_global: 3.85, untappd_id: null },
         is_drunk: true,
         user_rating: 4.0,
       },
     ]);
+  });
+
+  it('passes untappd_id through to matched_beer', async () => {
+    const cat: CatalogBeerWithRating[] = [
+      { id: 300, brewery: 'PINTA', name: 'Viva la Wit', abv: 4.8, rating_global: 3.6, untappd_id: 555 },
+    ];
+    const res = await matchBeerList(cat, new Set(), new Map(), [
+      { brewery: 'PINTA', name: 'Viva la Wit' },
+    ]);
+    expect(res[0].matched_beer).toEqual({
+      id: 300, name: 'Viva la Wit', brewery: 'PINTA', rating_global: 3.6, untappd_id: 555,
+    });
   });
 
   it('drunk via had-list only → is_drunk true, user_rating null', async () => {

--- a/src/domain/match-list.ts
+++ b/src/domain/match-list.ts
@@ -9,6 +9,7 @@ import {
 
 export interface CatalogBeerWithRating extends CatalogBeer {
   rating_global: number | null;
+  untappd_id?: number | null;
 }
 
 export interface MatchInput {
@@ -22,6 +23,7 @@ export interface MatchedBeer {
   name: string;
   brewery: string;
   rating_global: number | null;
+  untappd_id: number | null;
 }
 
 export interface MatchListResult {
@@ -83,6 +85,7 @@ export async function matchBeerList(
           name: beer.name,
           brewery: beer.brewery,
           rating_global: beer.rating_global,
+          untappd_id: beer.untappd_id ?? null,
         },
         is_drunk: drunkSet.has(m.id),
         user_rating: ratingByBeerId.get(m.id) ?? null,

--- a/src/storage/beers.test.ts
+++ b/src/storage/beers.test.ts
@@ -538,6 +538,7 @@ describe('loadCatalog', () => {
     const cat = loadCatalog(db);
     expect(cat).toContainEqual({
       id, brewery: 'Trzech Kumpli', name: 'Pan IPAni', abv: 6.0, rating_global: 3.85,
+      untappd_id: 9001,
     });
   });
 });

--- a/src/storage/beers.ts
+++ b/src/storage/beers.ts
@@ -62,11 +62,12 @@ export interface CatalogRow {
   name: string;
   abv: number | null;
   rating_global: number | null;
+  untappd_id: number | null;
 }
 
 export function loadCatalog(db: DB): CatalogRow[] {
   return db
-    .prepare('SELECT id, brewery, name, abv, rating_global FROM beers')
+    .prepare('SELECT id, brewery, name, abv, rating_global, untappd_id FROM beers')
     .all() as CatalogRow[];
 }
 


### PR DESCRIPTION
## Summary

The overlay now badges catalog beers the user **hasn't** drunk with `⭐ <global Untappd rating>` (distinct from the drunk `✅` + personal rating), and **every** rating badge becomes clickable — opening that beer's Untappd page in a new tab.

- **Server:** thread `beers.untappd_id` (numeric bid) through `loadCatalog → matchBeerList → /match` into `MatchedBeer`. No new matching logic, no route code change (propagates automatically), no new permissions.
- **Badge:** three-state renderer — `✅` (drunk, checked first so it's independent of the catalog match), `⭐ <global>` (not drunk + has bid + global rating), else no badge (orphan/unmatched). Click → `window.open('https://untappd.com/beer/<bid>', '_blank', 'noopener')` with `preventDefault`/`stopPropagation` so the underlying product-card link doesn't navigate.
- **Cache:** bumped the `chrome.storage` key prefix (`mc:` → `mc2:`) to drop pre-`untappd_id` entries.
- Spec §6 + extension CHANGELOG (`[Unreleased]`) updated. Version bump + release is a separate step.

Untappd URL form verified: the numeric-bid `https://untappd.com/beer/<bid>` resolves to the beer page (no slug needed).

## Test Plan

- [x] `npm test` (bot) — 550/550, incl. `untappd_id` propagation (loadCatalog, matchBeerList, /match)
- [x] `cd extension && npm test` — 87/87, incl. ⭐/orphan/unmatched/click badge cases
- [x] `npm run typecheck` — clean (updated MatchedBeer fixtures in cache/content tests for the new required field)

## Notes for reviewer

`badgeText` checks `is_drunk` **before** `matched_beer`: in production `is_drunk ⟹ matched_beer != null`, but the `✅` shows the user's own rating and shouldn't depend on the catalog row — this also preserves the prior drunk-badge behaviour exercised by `main.test`/`conformance` fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)