### PR TITLE
release(extension): cut 0.3.0 — ⭐ global-rating badge + Untappd link

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-06-09
+
 - Show ⭐ global Untappd rating for catalog beers you haven't drunk yet.
 - Click any rating badge to open that beer on Untappd in a new tab.
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "warsaw-beer-extension",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Що це

Реліз розширення **0.3.0**. Згортає змержену `[Unreleased]` ⭐-фічу (#106) у версіоновану секцію та піднімає `extension/package.json` до 0.3.0.

## Зміни
- `extension/package.json`: `0.2.0` → `0.3.0`
- `extension/CHANGELOG.md`: `[Unreleased]` → `## [0.3.0] - 2026-06-09`

## Реліз-нотатки (0.3.0)
- Show ⭐ global Untappd rating for catalog beers you haven't drunk yet.
- Click any rating badge to open that beer on Untappd in a new tab.

## Перевірка
- `npm run package` ✅ → `warsaw-beer-overlay-0.3.0.zip` (manifest v0.3.0, публічний `key` запінено)
- `RELEASE_NOTES.txt` = тіло секції CHANGELOG 0.3.0 ✅
- `npm test` ✅ 87/87 · `npm run typecheck` ✅

## Далі (поза цим PR — one-command флоу, `docs/extension-release.md`)
1. `cd extension && DATABASE_PATH=/var/lib/warsaw-beer-bot/bot.db npm run release` — детермінований zip + запис рядка `extension_releases` (через привілейований applier) + стейджинг у `~/extension-releases/`.
2. Форвард застейдженого zip боту → 📣 Розіслати.

🤖 Generated with [Claude Code](https://claude.com/claude-code)