### PR TITLE
chore: add VPS trusted Codex profile

### DIFF
--- a/.codex/vps-trusted.config.toml
+++ b/.codex/vps-trusted.config.toml
@@ -1,0 +1,5 @@
+[projects."/home/ysi"]
+trust_level = "trusted"
+
+[tui.model_availability_nux]
+"gpt-5.5" = 3


### PR DESCRIPTION
## Summary
- Add a checked-in Codex profile for the trusted VPS workspace.
- Refresh the profile file with the current trusted project and model availability settings.

## Test Plan
- [x] Read spec.md before change.
- [x] File-level check: verified .codex/vps-trusted.config.toml contains the trusted /home/ysi project entry.
- [ ] npm test -- --runInBand --forceExit (timed out after 120s with no Jest output beyond startup; no pass/fail signal returned).