### PR TITLE
release(extension): cut 0.4.0 — adds Bierloods22 shop

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-06-10
+
 - Added Bierloods22 shop support.
 
 ## [0.3.0] - 2026-06-09

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "warsaw-beer-extension",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Що це

Реліз розширення **0.4.0**. Згортає змержений `[Unreleased]` адаптер **Bierloods22** (#111) у версіоновану секцію та піднімає `extension/package.json` до 0.4.0.

## Зміни
- `extension/package.json`: `0.3.0` → `0.4.0`
- `extension/CHANGELOG.md`: `[Unreleased]` → `## [0.4.0] - 2026-06-10`

## Реліз-нотатки (0.4.0)
- Added Bierloods22 shop support.

## Перевірка
- `npm run package` ✅ → `warsaw-beer-overlay-0.4.0.zip` (manifest v0.4.0, `key` запінено)
- `RELEASE_NOTES.txt` = тіло секції CHANGELOG 0.4.0 ✅
- `npm test` ✅ 92/92 · `npm run typecheck` ✅

## Далі (поза цим PR — `docs/extension-release.md`)
1. `cd extension && DATABASE_PATH=/var/lib/warsaw-beer-bot/bot.db npm run release`
2. Форвард застейдженого zip боту → 📣 Розіслати.

🤖 Generated with [Claude Code](https://claude.com/claude-code)