### PR TITLE
feat(extension): add WineTime adapter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,8 @@ Superpowers Workflow
 
 Follow the project's Superpowers workflow.
 
+Always set up an isolated worktree when developing a change.
+
 When making changes:
 
 1. Understand the request.

--- a/docs/superpowers/plans/2026-06-10-winetime-shop-adapter.md
+++ b/docs/superpowers/plans/2026-06-10-winetime-shop-adapter.md
@@ -290,10 +290,9 @@ import type { SiteAdapter } from './types';
 import { beerrepublic } from './beerrepublic';
 import { onemorebeer } from './onemorebeer';
 import { beerfreak } from './beerfreak';
-import { bierloods22 } from './bierloods22';
 import { winetime } from './winetime';
 
-export const ADAPTERS: SiteAdapter[] = [beerrepublic, onemorebeer, beerfreak, bierloods22, winetime];
+export const ADAPTERS: SiteAdapter[] = [beerrepublic, onemorebeer, beerfreak, winetime];
 
 export function pickAdapter(url: URL): SiteAdapter | null {
   return ADAPTERS.find((a) => a.hostMatch(url)) ?? null;
@@ -310,7 +309,6 @@ import { pickAdapter } from './registry';
 import { beerrepublic } from './beerrepublic';
 import { onemorebeer } from './onemorebeer';
 import { beerfreak } from './beerfreak';
-import { bierloods22 } from './bierloods22';
 import { winetime } from './winetime';
 
 describe('pickAdapter', () => {
@@ -326,10 +324,6 @@ describe('pickAdapter', () => {
     expect(pickAdapter(new URL('https://beerfreak.org/beer/'))).toBe(beerfreak);
   });
 
-  it('selects bierloods22 for bierloods22.nl', () => {
-    expect(pickAdapter(new URL('https://www.bierloods22.nl/en/all-beers/'))).toBe(bierloods22);
-  });
-
   it('selects winetime for winetime.com.ua', () => {
     expect(pickAdapter(new URL('https://winetime.com.ua/ua/napoyi-slaboalkogolni/pyvo'))).toBe(winetime);
     expect(pickAdapter(new URL('https://www.winetime.com.ua/ua/napoyi-slaboalkogolni/pyvo'))).toBe(winetime);
@@ -342,8 +336,8 @@ describe('pickAdapter', () => {
 
 describe('adapter ids', () => {
   it('every adapter has a unique non-empty id', () => {
-    const ids = [beerrepublic, onemorebeer, beerfreak, bierloods22, winetime].map((a) => a.id);
-    expect(ids).toEqual(['beerrepublic', 'onemorebeer', 'beerfreak', 'bierloods22', 'winetime']);
+    const ids = [beerrepublic, onemorebeer, beerfreak, winetime].map((a) => a.id);
+    expect(ids).toEqual(['beerrepublic', 'onemorebeer', 'beerfreak', 'winetime']);
     expect(new Set(ids).size).toBe(ids.length);
     for (const id of ids) expect(id.length).toBeGreaterThan(0);
   });

--- a/docs/superpowers/plans/2026-06-10-winetime-shop-adapter.md
+++ b/docs/superpowers/plans/2026-06-10-winetime-shop-adapter.md
@@ -1,0 +1,452 @@
+# WineTime Shop Adapter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add WineTime (`winetime.com.ua`) as a supported browser-extension shop adapter for issue #88.
+
+**Architecture:** Follow the existing extension `SiteAdapter` architecture. Capture a WineTime fixture, add a focused SSR adapter that prefers `window.initialData.category.products` metadata with DOM fallback, register it, mirror host matching in the manifest, and document the new supported shop.
+
+**Tech Stack:** TypeScript, MV3 extension, Vitest/jsdom, existing `SiteAdapter` interface.
+
+---
+
+### Task 1: Capture WineTime fixture
+
+**Files:**
+- Create: `extension/tests/fixtures/winetime.html`
+- Test: `extension/src/sites/conformance.test.ts`
+
+- [ ] **Step 1: Capture the WineTime beer category fixture**
+
+Run:
+
+```bash
+curl -L -A 'Mozilla/5.0' 'https://winetime.com.ua/ua/napoyi-slaboalkogolni/pyvo' > extension/tests/fixtures/winetime.html
+```
+
+Expected: `extension/tests/fixtures/winetime.html` exists and contains `a.product-micro`, `data-productkey`, and `window.initialData.category.products`.
+
+- [ ] **Step 2: Inspect fixture anchors**
+
+Run:
+
+```bash
+rg -n "product-micro|data-productkey|window.initialData.category.products" extension/tests/fixtures/winetime.html
+```
+
+Expected: output includes product cards and embedded category product metadata.
+
+---
+
+### Task 2: Add failing WineTime adapter tests
+
+**Files:**
+- Create: `extension/src/sites/winetime.test.ts`
+- Create later: `extension/src/sites/winetime.ts`
+- Test: `extension/src/sites/winetime.test.ts`
+
+- [ ] **Step 1: Write failing adapter tests**
+
+Create `extension/src/sites/winetime.test.ts`:
+
+```ts
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { winetime } from './winetime';
+
+const html = readFileSync(resolve(__dirname, '../../tests/fixtures/winetime.html'), 'utf8');
+const INITIAL_DATA_RE = /window\.initialData\s*=\s*\{[\s\S]*?\n\s*window\.initialData\.category\s*=/;
+
+function withoutInitialData(source: string): string {
+  expect(source).toMatch(INITIAL_DATA_RE);
+  return source.replace(INITIAL_DATA_RE, 'window.initialData = {};\n        window.initialData.category =');
+}
+
+let cards: ReturnType<typeof winetime.parseCards>;
+beforeAll(() => {
+  cards = winetime.parseCards(new DOMParser().parseFromString(html, 'text/html'));
+});
+
+describe('winetime adapter', () => {
+  it('matches WineTime hosts', () => {
+    expect(winetime.hostMatch(new URL('https://winetime.com.ua/ua/napoyi-slaboalkogolni/pyvo'))).toBe(true);
+    expect(winetime.hostMatch(new URL('https://www.winetime.com.ua/ua/napoyi-slaboalkogolni/pyvo'))).toBe(true);
+    expect(winetime.hostMatch(new URL('https://example.com/'))).toBe(false);
+  });
+
+  it('parses WineTime product cards from the fixture', () => {
+    expect(cards.length).toBeGreaterThan(20);
+    for (const card of cards) {
+      expect(card.el).toBeInstanceOf(HTMLElement);
+      expect(card.name.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('uses embedded manufacturer metadata for brewery', () => {
+    expect(cards).toContainEqual(
+      expect.objectContaining({
+        brewery: 'Meteor',
+        name: 'Session IPA',
+      }),
+    );
+  });
+
+  it('cleans Ukrainian category descriptors conservatively', () => {
+    expect(cards).toContainEqual(
+      expect.objectContaining({
+        brewery: 'Underwood Brewery',
+        name: 'Ukrainian Tomato Gose',
+      }),
+    );
+  });
+
+  it('keeps a non-empty name when the title is mostly brewery plus style', () => {
+    expect(cards).toContainEqual(
+      expect.objectContaining({
+        brewery: 'Meteor',
+        name: 'Pils',
+      }),
+    );
+  });
+
+  it('falls back to visible DOM text when initial cart metadata is unavailable', () => {
+    const doc = new DOMParser().parseFromString(withoutInitialData(html), 'text/html');
+    const parsed = winetime.parseCards(doc);
+
+    expect(parsed.length).toBeGreaterThan(20);
+    expect(parsed).toContainEqual(
+      expect.objectContaining({
+        brewery: 'Meteor',
+        name: 'Pils',
+      }),
+    );
+  });
+
+  it('does not define waitForGrid because WineTime renders cards in SSR HTML', () => {
+    expect(winetime.waitForGrid).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify RED**
+
+Run:
+
+```bash
+cd extension && npm test -- src/sites/winetime.test.ts
+```
+
+Expected: FAIL because `extension/src/sites/winetime.ts` does not exist.
+
+---
+
+### Task 3: Implement WineTime adapter
+
+**Files:**
+- Create: `extension/src/sites/winetime.ts`
+- Test: `extension/src/sites/winetime.test.ts`
+
+- [ ] **Step 1: Create the adapter implementation**
+
+Create `extension/src/sites/winetime.ts`:
+
+```ts
+import type { Card, SiteAdapter } from './types';
+
+const CARD_SELECTOR = 'a.product-micro';
+const CONTAINER_SELECTOR = '.products-column';
+
+interface ProductMeta {
+  id: number;
+  title: string;
+  manufacturer?: {
+    title?: string | null;
+  } | null;
+}
+
+function text(el: Element | null | undefined): string {
+  return el?.textContent?.replace(/\s+/g, ' ').trim() ?? '';
+}
+
+function ownerDocument(root: ParentNode): Document | null {
+  return root instanceof Document ? root : root.ownerDocument;
+}
+
+function productMeta(root: ParentNode): Map<number, ProductMeta> {
+  const doc = ownerDocument(root);
+  if (!doc) return new Map();
+
+  for (const script of Array.from(doc.querySelectorAll('script'))) {
+    const source = script.textContent ?? '';
+    const match = source.match(/window\.initialData\.category\s*=\s*(\{[\s\S]*?\})\s*;\s*(?:eS\(|<\/script>|$)/);
+    if (!match) continue;
+
+    try {
+      const category = JSON.parse(match[1]) as { products?: ProductMeta[] };
+      return new Map((category.products ?? []).map((product) => [product.id, product]));
+    } catch {
+      return new Map();
+    }
+  }
+
+  return new Map();
+}
+
+function stripPrefix(value: string, prefix: string): string {
+  const trimmed = value.trim();
+  if (trimmed.toLocaleLowerCase('uk-UA').startsWith(prefix.toLocaleLowerCase('uk-UA'))) {
+    return trimmed.slice(prefix.length).trim();
+  }
+  return trimmed;
+}
+
+function cleanName(rawTitle: string, brewery: string): string {
+  const original = rawTitle.replace(/\s+/g, ' ').trim();
+  let name = stripPrefix(original, 'Пиво');
+
+  if (brewery) name = stripPrefix(name, brewery);
+
+  const cleaned = name
+    .replace(/\s+(?:\d+(?:[,.]\d+)?\s*(?:л|l|ml|мл))$/i, '')
+    .replace(/\s+(?:світле|темне|напівтемне|нефільтроване|фільтроване|пастеризоване|безалкогольне)$/iu, '')
+    .replace(/\s+(?:світле|темне|напівтемне|нефільтроване|фільтроване|пастеризоване|безалкогольне)$/iu, '')
+    .trim();
+
+  return cleaned || name || original;
+}
+
+function visibleBrewery(el: Element): string {
+  const rows = Array.from(el.querySelectorAll('.j-grow-1-xs.j-size-0\\.75-xs'));
+  return text(rows.at(-1));
+}
+
+export const winetime: SiteAdapter = {
+  id: 'winetime',
+  hostMatch: (url) => url.hostname === 'winetime.com.ua' || url.hostname.endsWith('.winetime.com.ua'),
+  reRenderContainerSelector: CONTAINER_SELECTOR,
+
+  parseCards(root) {
+    const meta = productMeta(root);
+    const cards: Card[] = [];
+
+    for (const el of Array.from(root.querySelectorAll<HTMLElement>(CARD_SELECTOR))) {
+      const id = Number(el.querySelector<HTMLElement>('[data-productkey]')?.dataset.productkey);
+      const product = Number.isFinite(id) ? meta.get(id) : undefined;
+      const rawTitle = product?.title ?? text(el.querySelector('.product-micro--title'));
+      if (!rawTitle) continue;
+
+      const brewery = product?.manufacturer?.title?.trim() || visibleBrewery(el);
+      const name = cleanName(rawTitle, brewery);
+      if (!name) continue;
+
+      cards.push({ el, brewery, name });
+    }
+
+    return cards;
+  },
+};
+```
+
+- [ ] **Step 2: Run WineTime tests to verify GREEN or selector evidence**
+
+Run:
+
+```bash
+cd extension && npm test -- src/sites/winetime.test.ts
+```
+
+Expected: PASS. If it fails, use the fixture evidence to adjust only `INITIAL_DATA_RE`, `CARD_SELECTOR`, `CONTAINER_SELECTOR`, `visibleBrewery`, or conservative cleanup tokens.
+
+- [ ] **Step 3: Re-run WineTime tests after implementation**
+
+Run:
+
+```bash
+cd extension && npm test -- src/sites/winetime.test.ts
+```
+
+Expected: PASS.
+
+---
+
+### Task 4: Register adapter and manifest support
+
+**Files:**
+- Modify: `extension/src/sites/registry.ts`
+- Modify: `extension/src/sites/registry.test.ts`
+- Modify: `extension/manifest.config.ts`
+- Modify: `extension/src/manifest.test.ts`
+- Test: `extension/src/sites/registry.test.ts`
+- Test: `extension/src/manifest.test.ts`
+- Test: `extension/src/sites/conformance.test.ts`
+
+- [ ] **Step 1: Update registry**
+
+Modify `extension/src/sites/registry.ts`:
+
+```ts
+import type { SiteAdapter } from './types';
+import { beerrepublic } from './beerrepublic';
+import { onemorebeer } from './onemorebeer';
+import { beerfreak } from './beerfreak';
+import { bierloods22 } from './bierloods22';
+import { winetime } from './winetime';
+
+export const ADAPTERS: SiteAdapter[] = [beerrepublic, onemorebeer, beerfreak, bierloods22, winetime];
+
+export function pickAdapter(url: URL): SiteAdapter | null {
+  return ADAPTERS.find((a) => a.hostMatch(url)) ?? null;
+}
+```
+
+- [ ] **Step 2: Update registry tests**
+
+Modify `extension/src/sites/registry.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { pickAdapter } from './registry';
+import { beerrepublic } from './beerrepublic';
+import { onemorebeer } from './onemorebeer';
+import { beerfreak } from './beerfreak';
+import { bierloods22 } from './bierloods22';
+import { winetime } from './winetime';
+
+describe('pickAdapter', () => {
+  it('selects beerrepublic for beerrepublic.eu', () => {
+    expect(pickAdapter(new URL('https://beerrepublic.eu/collections/all'))).toBe(beerrepublic);
+  });
+
+  it('selects onemorebeer for onemorebeer.pl', () => {
+    expect(pickAdapter(new URL('https://onemorebeer.pl/piwa'))).toBe(onemorebeer);
+  });
+
+  it('selects beerfreak for beerfreak.org', () => {
+    expect(pickAdapter(new URL('https://beerfreak.org/beer/'))).toBe(beerfreak);
+  });
+
+  it('selects bierloods22 for bierloods22.nl', () => {
+    expect(pickAdapter(new URL('https://www.bierloods22.nl/en/all-beers/'))).toBe(bierloods22);
+  });
+
+  it('selects winetime for winetime.com.ua', () => {
+    expect(pickAdapter(new URL('https://winetime.com.ua/ua/napoyi-slaboalkogolni/pyvo'))).toBe(winetime);
+    expect(pickAdapter(new URL('https://www.winetime.com.ua/ua/napoyi-slaboalkogolni/pyvo'))).toBe(winetime);
+  });
+
+  it('returns null for an unknown host', () => {
+    expect(pickAdapter(new URL('https://example.com/'))).toBeNull();
+  });
+});
+
+describe('adapter ids', () => {
+  it('every adapter has a unique non-empty id', () => {
+    const ids = [beerrepublic, onemorebeer, beerfreak, bierloods22, winetime].map((a) => a.id);
+    expect(ids).toEqual(['beerrepublic', 'onemorebeer', 'beerfreak', 'bierloods22', 'winetime']);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const id of ids) expect(id.length).toBeGreaterThan(0);
+  });
+});
+```
+
+- [ ] **Step 3: Add manifest host patterns**
+
+In `extension/manifest.config.ts`, add:
+
+```ts
+'https://winetime.com.ua/*',
+'https://*.winetime.com.ua/*',
+```
+
+Place them in `content_scripts[0].matches` near the other shop hosts.
+
+- [ ] **Step 4: Update manifest tests**
+
+Modify the host-pattern test in `extension/src/manifest.test.ts` so it asserts:
+
+```ts
+expect(contentScript.matches).toContain('https://winetime.com.ua/*');
+expect(contentScript.matches).toContain('https://*.winetime.com.ua/*');
+```
+
+- [ ] **Step 5: Run targeted registration tests**
+
+Run:
+
+```bash
+cd extension && npm test -- src/sites/registry.test.ts src/manifest.test.ts src/sites/conformance.test.ts
+```
+
+Expected: PASS.
+
+---
+
+### Task 5: Update docs and final verification
+
+**Files:**
+- Modify: `extension/CHANGELOG.md`
+- Modify: `spec.md`
+- Test: `extension/src/sites/winetime.test.ts`
+- Test: `extension/src/sites/conformance.test.ts`
+- Test: `extension/src/sites/registry.test.ts`
+- Test: `extension/src/manifest.test.ts`
+
+- [ ] **Step 1: Update changelog**
+
+In `extension/CHANGELOG.md`, add under `## [Unreleased]`:
+
+```md
+- Added WineTime shop support.
+```
+
+- [ ] **Step 2: Update spec**
+
+In `spec.md` section 6, add WineTime to the per-site adapter list:
+
+```md
+`winetime` (WineTime SSR — `a.product-micro`, brewery/name з
+`window.initialData.category.products` metadata keyed by `data-productkey`,
+fallback на видимий title/brewery, ABV опускається, домен `winetime.com.ua`)
+```
+
+- [ ] **Step 3: Run targeted extension tests**
+
+Run:
+
+```bash
+cd extension && npm test -- src/sites/winetime.test.ts src/sites/conformance.test.ts src/sites/registry.test.ts src/manifest.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run full extension test suite**
+
+Run:
+
+```bash
+cd extension && npm test
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Check git diff**
+
+Run:
+
+```bash
+git diff --stat
+```
+
+Expected: changes are limited to the WineTime fixture, adapter, adapter tests, registry, manifest, changelog, and `spec.md`.
+
+- [ ] **Step 6: Commit implementation**
+
+Run:
+
+```bash
+git add extension/tests/fixtures/winetime.html extension/src/sites/winetime.ts extension/src/sites/winetime.test.ts extension/src/sites/registry.ts extension/src/sites/registry.test.ts extension/manifest.config.ts extension/src/manifest.test.ts extension/CHANGELOG.md spec.md
+git commit -m "feat(extension): add WineTime adapter"
+```
+
+Expected: commit succeeds after tests pass.

--- a/docs/superpowers/plans/2026-06-10-winetime-shop-adapter.md
+++ b/docs/superpowers/plans/2026-06-10-winetime-shop-adapter.md
@@ -87,7 +87,7 @@ describe('winetime adapter', () => {
     expect(cards).toContainEqual(
       expect.objectContaining({
         brewery: 'Meteor',
-        name: 'Session IPA',
+        name: 'Pils',
       }),
     );
   });
@@ -110,7 +110,7 @@ describe('winetime adapter', () => {
     );
   });
 
-  it('falls back to visible DOM text when initial cart metadata is unavailable', () => {
+  it('falls back to visible DOM text when embedded product metadata is unavailable', () => {
     const doc = new DOMParser().parseFromString(withoutInitialData(html), 'text/html');
     const parsed = winetime.parseCards(doc);
 

--- a/docs/superpowers/specs/2026-06-10-winetime-shop-adapter-design.md
+++ b/docs/superpowers/specs/2026-06-10-winetime-shop-adapter-design.md
@@ -1,0 +1,89 @@
+# WineTime Shop Adapter Design
+
+## Goal
+
+Add WineTime (`winetime.com.ua`) as a supported browser-extension shop for issue #88. The extension should parse WineTime beer catalog cards, send stable brewery/name pairs through the existing match flow, and render badges using the shared overlay behavior.
+
+## Scope
+
+In scope:
+
+- Add a `winetime` `SiteAdapter`.
+- Capture a static WineTime beer-category fixture.
+- Register the adapter and add manifest host matches.
+- Add focused adapter, registry, manifest, and conformance coverage.
+- Update `extension/CHANGELOG.md` and `spec.md`.
+
+Out of scope:
+
+- Backend or API changes.
+- WineTime-specific matching behavior.
+- ABV parsing from WineTime catalog cards.
+- Custom re-render or pagination machinery.
+
+## Architecture
+
+WineTime support follows the existing per-site adapter architecture in `extension/src/sites/`. The adapter id is `winetime`, matching `extension/tests/fixtures/winetime.html`.
+
+The adapter is SSR-style:
+
+- `hostMatch` accepts `winetime.com.ua` and subdomains.
+- `parseCards` reads visible `a.product-micro` cards.
+- `waitForGrid` is omitted.
+- `reRenderContainerSelector` is optional and only used if the fixture exposes a stable product-grid container.
+
+No shared extension behavior changes are needed. The existing overlay, cache, background worker, and `POST /match` contract remain unchanged.
+
+## Data Flow
+
+1. The content script runs on WineTime pages through manifest matches.
+2. `registry.pickAdapter(url)` selects the `winetime` adapter.
+3. `parseCards(root)` finds product cards.
+4. For each card, the adapter reads `data-productkey`.
+5. The adapter resolves that id against `window.initialData.category.products` when available.
+6. Product metadata supplies `manufacturer.title` for brewery and `title` for the raw product name.
+7. If metadata is unavailable or unparsable, the adapter falls back to visible card title and brewery text.
+8. Parsed cards flow through the existing match and badge rendering path.
+
+## Name Cleanup
+
+Use conservative metadata-first cleanup:
+
+- Strip a leading `Пиво`.
+- Strip trailing package volume such as `0,33 л`, `0,5 л`, or similar liter/ml forms.
+- Strip obvious trailing catalog descriptors such as color, filtration, and alcohol-free markers when they appear as trailing descriptors.
+- Strip a repeated brewery prefix only when it exactly matches the metadata brewery and leaves a non-empty name.
+- Keep the original cleaned title if a rule would produce an empty string.
+
+Do not infer ABV. WineTime catalog cards show volume and category descriptors, not reliable ABV.
+
+## Error Handling
+
+Parsing must stay read-only and fail-soft:
+
+- Invalid or missing `window.initialData` should not throw out of `parseCards`.
+- Cards without a usable name are skipped.
+- Missing brewery is allowed as an empty string, matching existing adapter behavior.
+- Unexpected page changes should degrade to DOM fallback before skipping cards.
+
+## Testing
+
+Implementation should follow TDD:
+
+- Start with `extension/src/sites/winetime.test.ts` against `extension/tests/fixtures/winetime.html`.
+- Cover metadata parsing, fallback parsing, conservative title cleanup, empty-result guards, and `waitForGrid` absence.
+- Add registry tests for apex and subdomain WineTime URLs.
+- Add manifest tests for apex and wildcard WineTime host patterns.
+- Rely on `extension/src/sites/conformance.test.ts` for fixture presence, parse well-formedness, selector validity, and re-render after grid replacement.
+
+Targeted verification should include:
+
+- `cd extension && npm test -- src/sites/winetime.test.ts`
+- `cd extension && npm test -- src/sites/conformance.test.ts src/sites/registry.test.ts src/manifest.test.ts`
+- `cd extension && npm test`
+
+## Documentation
+
+Update `extension/CHANGELOG.md` under `[Unreleased]` with WineTime support.
+
+Update `spec.md` section 6 to list `winetime` as a supported adapter, including the SSR catalog, embedded product metadata, `winetime.com.ua` host, and omitted ABV.

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added WineTime shop support.
+
 ## [0.4.0] - 2026-06-10
 
 - Added Bierloods22 shop support.

--- a/extension/manifest.config.ts
+++ b/extension/manifest.config.ts
@@ -26,6 +26,8 @@ export default defineManifest({
         'https://*.beerfreak.org/*',
         'https://bierloods22.nl/*',
         'https://*.bierloods22.nl/*',
+        'https://winetime.com.ua/*',
+        'https://*.winetime.com.ua/*',
       ],
       js: ['src/content/main.ts'],
       run_at: 'document_idle',

--- a/extension/src/manifest.test.ts
+++ b/extension/src/manifest.test.ts
@@ -21,12 +21,16 @@ describe('manifest', () => {
     expect(manifest.key.length).toBeGreaterThan(100);
   });
 
-  it('injects the content script on BeerFreak pages', () => {
+  it('injects the content script on supported shop pages', () => {
     expect(Array.isArray(manifest.content_scripts)).toBe(true);
     expect(manifest.content_scripts.length).toBeGreaterThan(0);
     const [contentScript] = manifest.content_scripts;
     expect(Array.isArray(contentScript.matches)).toBe(true);
     expect(contentScript.matches).toContain('https://beerfreak.org/*');
     expect(contentScript.matches).toContain('https://*.beerfreak.org/*');
+    expect(contentScript.matches).toContain('https://bierloods22.nl/*');
+    expect(contentScript.matches).toContain('https://*.bierloods22.nl/*');
+    expect(contentScript.matches).toContain('https://winetime.com.ua/*');
+    expect(contentScript.matches).toContain('https://*.winetime.com.ua/*');
   });
 });

--- a/extension/src/sites/registry.test.ts
+++ b/extension/src/sites/registry.test.ts
@@ -4,6 +4,7 @@ import { beerrepublic } from './beerrepublic';
 import { onemorebeer } from './onemorebeer';
 import { beerfreak } from './beerfreak';
 import { bierloods22 } from './bierloods22';
+import { winetime } from './winetime';
 
 describe('pickAdapter', () => {
   it('selects beerrepublic for beerrepublic.eu', () => {
@@ -22,6 +23,11 @@ describe('pickAdapter', () => {
     expect(pickAdapter(new URL('https://www.bierloods22.nl/en/all-beers/'))).toBe(bierloods22);
   });
 
+  it('selects winetime for winetime.com.ua', () => {
+    expect(pickAdapter(new URL('https://winetime.com.ua/ua/napoyi-slaboalkogolni/pyvo'))).toBe(winetime);
+    expect(pickAdapter(new URL('https://www.winetime.com.ua/ua/napoyi-slaboalkogolni/pyvo'))).toBe(winetime);
+  });
+
   it('returns null for an unknown host', () => {
     expect(pickAdapter(new URL('https://example.com/'))).toBeNull();
   });
@@ -29,8 +35,8 @@ describe('pickAdapter', () => {
 
 describe('adapter ids', () => {
   it('every adapter has a unique non-empty id', () => {
-    const ids = [beerrepublic, onemorebeer, beerfreak, bierloods22].map((a) => a.id);
-    expect(ids).toEqual(['beerrepublic', 'onemorebeer', 'beerfreak', 'bierloods22']);
+    const ids = [beerrepublic, onemorebeer, beerfreak, bierloods22, winetime].map((a) => a.id);
+    expect(ids).toEqual(['beerrepublic', 'onemorebeer', 'beerfreak', 'bierloods22', 'winetime']);
     expect(new Set(ids).size).toBe(ids.length);
     for (const id of ids) expect(id.length).toBeGreaterThan(0);
   });

--- a/extension/src/sites/registry.ts
+++ b/extension/src/sites/registry.ts
@@ -3,8 +3,9 @@ import { beerrepublic } from './beerrepublic';
 import { onemorebeer } from './onemorebeer';
 import { beerfreak } from './beerfreak';
 import { bierloods22 } from './bierloods22';
+import { winetime } from './winetime';
 
-export const ADAPTERS: SiteAdapter[] = [beerrepublic, onemorebeer, beerfreak, bierloods22];
+export const ADAPTERS: SiteAdapter[] = [beerrepublic, onemorebeer, beerfreak, bierloods22, winetime];
 
 export function pickAdapter(url: URL): SiteAdapter | null {
   return ADAPTERS.find((a) => a.hostMatch(url)) ?? null;

--- a/extension/src/sites/winetime.test.ts
+++ b/extension/src/sites/winetime.test.ts
@@ -14,12 +14,13 @@ function withoutInitialData(source: string): string {
 function withVisibleBrewery(source: string, productKey: string, brewery: string): string {
   const doc = new DOMParser().parseFromString(source, 'text/html');
   const card = doc.querySelector(`[data-productkey="${productKey}"]`)?.closest('a.product-micro');
-  expect(card).not.toBeNull();
+  if (!card) throw new Error(`Missing WineTime fixture card for product key ${productKey}`);
 
-  const rows = Array.from(card!.querySelectorAll('.j-grow-1-xs.j-size-0\\.75-xs'));
-  expect(rows.length).toBeGreaterThan(0);
+  const rows = Array.from(card.querySelectorAll('.j-grow-1-xs.j-size-0\\.75-xs'));
+  const row = rows[rows.length - 1];
+  if (!row) throw new Error(`Missing visible brewery row for product key ${productKey}`);
 
-  rows[rows.length - 1].textContent = brewery;
+  row.textContent = brewery;
   return doc.documentElement.outerHTML;
 }
 

--- a/extension/src/sites/winetime.test.ts
+++ b/extension/src/sites/winetime.test.ts
@@ -11,6 +11,18 @@ function withoutInitialData(source: string): string {
   return source.replace(CATEGORY_ASSIGNMENT_RE, 'window.initialData.disabledCategory =');
 }
 
+function withVisibleBrewery(source: string, productKey: string, brewery: string): string {
+  const doc = new DOMParser().parseFromString(source, 'text/html');
+  const card = doc.querySelector(`[data-productkey="${productKey}"]`)?.closest('a.product-micro');
+  expect(card).not.toBeNull();
+
+  const rows = Array.from(card!.querySelectorAll('.j-grow-1-xs.j-size-0\\.75-xs'));
+  expect(rows.length).toBeGreaterThan(0);
+
+  rows[rows.length - 1].textContent = brewery;
+  return doc.documentElement.outerHTML;
+}
+
 let cards: ReturnType<typeof winetime.parseCards>;
 beforeAll(() => {
   cards = winetime.parseCards(new DOMParser().parseFromString(html, 'text/html'));
@@ -32,7 +44,10 @@ describe('winetime adapter', () => {
   });
 
   it('uses embedded manufacturer metadata for brewery', () => {
-    expect(cards).toContainEqual(
+    const doc = new DOMParser().parseFromString(withVisibleBrewery(html, '10469', 'Wrong Visible Brewery'), 'text/html');
+    const parsed = winetime.parseCards(doc);
+
+    expect(parsed).toContainEqual(
       expect.objectContaining({
         brewery: 'Meteor',
         name: 'Pils',

--- a/extension/src/sites/winetime.test.ts
+++ b/extension/src/sites/winetime.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { winetime } from './winetime';
+
+const html = readFileSync(resolve(__dirname, '../../tests/fixtures/winetime.html'), 'utf8');
+const CATEGORY_ASSIGNMENT_RE = /window\.initialData\.category\s*=/;
+
+function withoutInitialData(source: string): string {
+  expect(source).toMatch(CATEGORY_ASSIGNMENT_RE);
+  return source.replace(CATEGORY_ASSIGNMENT_RE, 'window.initialData.disabledCategory =');
+}
+
+let cards: ReturnType<typeof winetime.parseCards>;
+beforeAll(() => {
+  cards = winetime.parseCards(new DOMParser().parseFromString(html, 'text/html'));
+});
+
+describe('winetime adapter', () => {
+  it('matches WineTime hosts', () => {
+    expect(winetime.hostMatch(new URL('https://winetime.com.ua/ua/napoyi-slaboalkogolni/pyvo'))).toBe(true);
+    expect(winetime.hostMatch(new URL('https://www.winetime.com.ua/ua/napoyi-slaboalkogolni/pyvo'))).toBe(true);
+    expect(winetime.hostMatch(new URL('https://example.com/'))).toBe(false);
+  });
+
+  it('parses WineTime product cards from the fixture', () => {
+    expect(cards.length).toBeGreaterThan(20);
+    for (const card of cards) {
+      expect(card.el).toBeInstanceOf(HTMLElement);
+      expect(card.name.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('uses embedded manufacturer metadata for brewery', () => {
+    expect(cards).toContainEqual(
+      expect.objectContaining({
+        brewery: 'Meteor',
+        name: 'Pils',
+      }),
+    );
+  });
+
+  it('cleans Ukrainian category descriptors conservatively', () => {
+    expect(cards).toContainEqual(
+      expect.objectContaining({
+        brewery: 'Underwood Brewery',
+        name: 'Ukrainian Tomato Gose',
+      }),
+    );
+  });
+
+  it('keeps packaging words that are part of the product label', () => {
+    expect(cards).toContainEqual(
+      expect.objectContaining({
+        brewery: 'Meteor',
+        name: 'IPA CAN',
+      }),
+    );
+  });
+
+  it('falls back to visible DOM text when embedded product metadata is unavailable', () => {
+    const doc = new DOMParser().parseFromString(withoutInitialData(html), 'text/html');
+    const parsed = winetime.parseCards(doc);
+
+    expect(parsed.length).toBeGreaterThan(20);
+    expect(parsed).toContainEqual(
+      expect.objectContaining({
+        brewery: 'Meteor',
+        name: 'Pils',
+      }),
+    );
+  });
+
+  it('does not define waitForGrid because WineTime renders cards in SSR HTML', () => {
+    expect(winetime.waitForGrid).toBeUndefined();
+  });
+});

--- a/extension/src/sites/winetime.ts
+++ b/extension/src/sites/winetime.ts
@@ -1,0 +1,140 @@
+import type { Card, SiteAdapter } from './types';
+
+const CARD_SELECTOR = 'a.product-micro';
+const CONTAINER_SELECTOR = '.products-column';
+const DESCRIPTOR_RE =
+  /\s+(?:світле|темне|напівтемне|нефільтроване|фільтроване|пастеризоване|безалкогольне)$/iu;
+
+interface ProductMeta {
+  id: number;
+  title: string;
+  manufacturer?: {
+    title?: string | null;
+  } | null;
+}
+
+function text(el: Element | null | undefined): string {
+  return el?.textContent?.replace(/\s+/g, ' ').trim() ?? '';
+}
+
+function ownerDocument(root: ParentNode): Document | null {
+  return root instanceof Document ? root : root.ownerDocument;
+}
+
+function categoryJson(source: string): string | null {
+  const marker = 'window.initialData.category =';
+  const markerAt = source.indexOf(marker);
+  if (markerAt < 0) return null;
+
+  const start = source.indexOf('{', markerAt + marker.length);
+  if (start < 0) return null;
+
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let i = start; i < source.length; i += 1) {
+    const ch = source[i];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (ch === '\\') {
+        escaped = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (ch === '"') {
+      inString = true;
+    } else if (ch === '{') {
+      depth += 1;
+    } else if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) return source.slice(start, i + 1);
+    }
+  }
+
+  return null;
+}
+
+function productMeta(root: ParentNode): Map<number, ProductMeta> {
+  const doc = ownerDocument(root);
+  if (!doc) return new Map();
+
+  for (const script of Array.from(doc.querySelectorAll('script'))) {
+    const json = categoryJson(script.textContent ?? '');
+    if (!json) continue;
+
+    try {
+      const category = JSON.parse(json) as { products?: ProductMeta[] };
+      return new Map((category.products ?? []).map((product) => [product.id, product]));
+    } catch {
+      return new Map();
+    }
+  }
+
+  return new Map();
+}
+
+function stripPrefix(value: string, prefix: string): string {
+  const trimmed = value.trim();
+  const normalizedPrefix = prefix.trim();
+  if (!normalizedPrefix) return trimmed;
+  if (trimmed.toLocaleLowerCase('uk-UA').startsWith(normalizedPrefix.toLocaleLowerCase('uk-UA'))) {
+    return trimmed.slice(normalizedPrefix.length).trim();
+  }
+  return trimmed;
+}
+
+function breweryPrefixes(brewery: string): string[] {
+  const base = brewery.trim();
+  const withoutBrewerySuffix = base.replace(/\s+(?:brewery|броварня)$/iu, '').trim();
+  return [base, withoutBrewerySuffix].filter((value, index, values) => value && values.indexOf(value) === index);
+}
+
+function cleanName(rawTitle: string, brewery: string): string {
+  const original = rawTitle.replace(/\s+/g, ' ').trim();
+  let name = stripPrefix(original, 'Пиво');
+
+  for (const prefix of breweryPrefixes(brewery)) {
+    name = stripPrefix(name, prefix);
+  }
+
+  let cleaned = name.replace(/\s+(?:\d+(?:[,.]\d+)?\s*(?:л|l|ml|мл))$/iu, '').trim();
+  while (DESCRIPTOR_RE.test(cleaned)) cleaned = cleaned.replace(DESCRIPTOR_RE, '').trim();
+
+  return cleaned || name || original;
+}
+
+function visibleBrewery(el: Element): string {
+  const rows = Array.from(el.querySelectorAll('.j-grow-1-xs.j-size-0\\.75-xs'));
+  return text(rows[rows.length - 1]);
+}
+
+export const winetime: SiteAdapter = {
+  id: 'winetime',
+  hostMatch: (url) => url.hostname === 'winetime.com.ua' || url.hostname.endsWith('.winetime.com.ua'),
+  reRenderContainerSelector: CONTAINER_SELECTOR,
+
+  parseCards(root) {
+    const meta = productMeta(root);
+    const cards: Card[] = [];
+
+    for (const el of Array.from(root.querySelectorAll<HTMLElement>(CARD_SELECTOR))) {
+      const id = Number(el.querySelector<HTMLElement>('[data-productkey]')?.dataset.productkey);
+      const product = Number.isFinite(id) ? meta.get(id) : undefined;
+      const rawTitle = product?.title ?? text(el.querySelector('.product-micro--title'));
+      if (!rawTitle) continue;
+
+      const brewery = product?.manufacturer?.title?.trim() || visibleBrewery(el);
+      const name = cleanName(rawTitle, brewery);
+      if (!name) continue;
+
+      cards.push({ el, brewery, name });
+    }
+
+    return cards;
+  },
+};

--- a/extension/tests/fixtures/winetime.html
+++ b/extension/tests/fixtures/winetime.html
@@ -1,0 +1,2094 @@
+<!DOCTYPE html>
+<html lang="uk" translate="no">
+<head>
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate, max-age=0, s-maxage=0"/>
+    <meta http-equiv="Pragma" content="no-cache"/>
+    <meta http-equiv="Expires" content="0"/>
+
+    <meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<meta name="facebook-domain-verification" content="0wlf3wmj05uad2brzdyvs60s22p07a" />
+<meta name="robots" content="index,follow">
+<meta name="csrf-token" content="3KXDSWQbTAfF4Wss4n1RyJNLWZguwcpjhbF5OC5X">
+<meta name="google" content="notranslate">
+
+<title>Пиво - купити онлайн пиво вигідно у Києві, Україні | WINETIME</title>
+<meta name="description" content="Замовити 【ПИВО】 в магазині ➥WINETIME⭐ Величезний вибір різноного ПИВА ✔️ Краща ціна на якісне ПИВО ✈️Доставка ПИВА по Києву та Україні! ☎️ 0 800 330 370.">
+<meta property="og:title" content="Пиво - купити онлайн пиво вигідно у Києві, Україні | WINETIME">
+<meta property="og:type" content="article" />
+<meta property="og:url" content="https://winetime.com.ua/ua/napoyi-slaboalkogolni/pyvo" />
+<meta property="og:image" content="https://winetime.com.ua/storage/b1ff8ed508c91cc37589817c516c86ba.png" />
+<meta property="og:site_name" content="Інтернет магазин WINETIME" />
+<meta property="og:description" content="Замовити 【ПИВО】 в магазині ➥WINETIME⭐ Величезний вибір різноного ПИВА ✔️ Краща ціна на якісне ПИВО ✈️Доставка ПИВА по Києву та Україні! ☎️ 0 800 330 370." />
+<meta property="twitter:title" content="Пиво - купити онлайн пиво вигідно у Києві, Україні | WINETIME" />
+<meta property="twitter:card" content="summary" />
+<meta property="twitter:image" content="https://winetime.com.ua/storage/b1ff8ed508c91cc37589817c516c86ba.png" />
+<meta property="twitter:site" content="Інтернет магазин WINETIME" />
+<meta property="twitter:description" content="Замовити 【ПИВО】 в магазині ➥WINETIME⭐ Величезний вибір різноного ПИВА ✔️ Краща ціна на якісне ПИВО ✈️Доставка ПИВА по Києву та Україні! ☎️ 0 800 330 370." />
+
+<link rel="canonical" href="https://winetime.com.ua/ua/napoyi-slaboalkogolni/pyvo" />
+<link rel="alternate" hreflang="ru-UA" href="https://winetime.com.ua/napoyi-slaboalkogolni/pyvo"/>
+<link rel="alternate" hreflang="uk-UA" href="https://winetime.com.ua/ua/napoyi-slaboalkogolni/pyvo"/>
+
+
+<link rel="preload" href="/fonts/fontawesome-webfont.woff2" as="font" type="font/woff2" crossorigin>
+
+<link href="https://winetime.com.ua/favicon.ico " rel="shortcut icon">
+
+
+<!-- Admitad. Start -->
+
+<!-- Admitad. end -->
+
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+            new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-WQQ3BQF');</script>
+<!-- End Google Tag Manager -->
+
+<!-- Facebook Pixel Code -->
+<script>
+    !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+        n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
+        n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
+        t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
+        document,'script','https://connect.facebook.net/en_US/fbevents.js');
+    fbq('init', '1137009113342954');
+    fbq('track', 'PageView');
+</script>
+<noscript><img height="1" width="1" style="display:none"
+               src="https://www.facebook.com/tr?id=1137009113342954&ev=PageView&noscript=1"
+    /></noscript>
+<!-- DO NOT MODIFY -->
+<!-- End Facebook Pixel Code -->
+
+<script type="application/ld+json">
+{
+    "@context": "http://schema.org",
+    "@type": "LiquorStore",
+    "name": "Wine Time",
+    "openingHours": [
+        "Mo-Su  9:00 — 19:00"
+    ]
+}
+</script>
+    <script type="application/ld+json">
+        {
+    "@context": "http://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+        {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "Головна",
+            "item": "https://winetime.com.ua/ua"
+        },
+        {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "Напої  слабоалкогольні",
+            "item": "https://winetime.com.ua/ua/napoyi-slaboalkogolni"
+        },
+        {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Пиво",
+            "item": "https://winetime.com.ua/ua/napoyi-slaboalkogolni/pyvo"
+        }
+    ]
+}
+    </script>
+
+<script>
+  (function(i,s,o,g,r,a,m){
+  i["esSdk"] = r;
+  i[r] = i[r] || function() {
+    (i[r].q = i[r].q || []).push(arguments)
+  }, a=s.createElement(o), m=s.getElementsByTagName(o)[0]; a.async=1; a.src=g;
+  m.parentNode.insertBefore(a,m)}
+  ) (window, document, "script", "https://esputnik.com/scripts/v1/public/scripts?apiKey=eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiI0NTI0ZWZhYTJkYzI2MGRmYTM4YTE1NDBlMWE3ZjE0OWRiYTIzOTFmMmU0NmZhODMxY2E1NGQ3MGQ2OGMwMjBlMjlhY2IxNzQwZWIzYTQzNjJhMTQ3N2ZmZGYwMWQwNDY1ZGIyYjEwMzU2MzQ2YWFhZjY3MzE1ZDMxOTA5YWQ0YWE2YzhhZTMzMzA2OTc0MTRmYzNjZTUzNGI4ODA0NTEyMDM4MmUwOTI5MTEzNjI1ZWYxMGFlNCJ9.Bg1rfSHUv3EbkBgpisKfs5SKw9C-Nkr1pXACTWq70rlOHPjRD5feGeic-VTZ-3D18RWZCsFBmY4VYyHgwwasDQ&domain=67461BD5-54DD-47E2-A37C-F56351F0FBB0", "es");
+  es("pushOn");
+</script>
+<!--
+<script>
+    !function (t, e, c, n) {
+        var s = e.createElement(c);
+        s.async = 1, s.src = 'https://statics.esputnik.com/scripts/' + n + '.js';
+        var r = e.scripts[0];
+        r.parentNode.insertBefore(s, r);
+        var f = function () {
+            f.c(arguments);
+        };
+        f.q = [];
+        f.c = function () {
+            f.q.push(arguments);
+        };
+        t['eS'] = t['eS'] || f;
+    }(window, document, 'script', 'DA1B8F9B05CF498790712AB865001125');
+</script>
+-->
+<!--
+<script>eS('init');</script>
+-->
+
+
+    <style>
+        @font-face {
+            font-family: 'Montserrat';
+            src: url('/fonts/Montserrat-Regular.ttf') format('truetype');
+            font-weight: 300;
+            font-style: normal;
+            font-display: swap;
+        }
+        @font-face {
+            font-family: 'Montserrat';
+            src: url('/fonts/Montserrat-Italic.ttf') format('truetype');
+            font-weight: 300;
+            font-style: italic;
+            font-display: swap;
+        }
+        @font-face {
+            font-family: 'Montserrat';
+            src: url('/fonts/Montserrat-SemiBold.ttf') format('truetype');
+            font-weight: 600;
+            font-style: normal;
+            font-display: swap;
+        }
+        @font-face {
+            font-family: 'Montserrat';
+            src: url('/fonts/Montserrat-Bold.ttf') format('truetype');
+            font-weight: 700;
+            font-style: normal;
+            font-display: swap;
+        }
+        @font-face {
+            font-family: 'Montserrat';
+            src: url('/fonts/Montserrat-ExtraBold.ttf') format('truetype');
+            font-weight: 800;
+            font-style: normal;
+            font-display: swap;
+        }
+    </style>
+
+    <link href="https://winetime.com.ua/client/css/app--jot.css?v=1781121123" rel="stylesheet">
+</head>
+
+<body>
+<!-- Google Tag Manager (noscript) -->
+<noscript>
+    <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WQQ3BQF" height="0" width="0"
+            style="display:none;visibility:hidden"></iframe>
+</noscript>
+<!-- End Google Tag Manager (noscript) -->
+
+<script type="text/javascript">
+    window._mfq = window._mfq || [];
+    (function() {
+        var mf = document.createElement("script");
+        mf.type = "text/javascript"; mf.defer = true;
+        mf.src = "//cdn.mouseflow.com/projects/9b51efe9-ae29-4b80-b886-e0a77e819fee.js";
+        document.getElementsByTagName("head")[0].appendChild(mf);
+    })();
+</script>
+
+<div class="view-body">
+    <header id="page-header">
+    <style>
+.header--subs {
+    position: relative;
+}
+
+.header--subs .banner-container {
+    width: 100%;
+    cursor: pointer;
+    display: block;
+}
+
+.header--subs .banner-container img.header-banner {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.header--subs .content-container {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 10;
+    pointer-events: none;
+}
+
+.header--subs .j-h-center {
+    text-shadow: 0px 0px 3px rgba(0, 0, 0, 0.7);
+}
+</style>
+
+<div class="header--subs j-dn-xs j-db-bg" id="testInsert">
+  <div id="the-header-slider"></div>
+</div>
+    <div class="header--top j-db-xs j-dn-bg">
+    <div class="j-container j-ph-10-xs j-ph-20-bg  j-pv-10-xs j-mw-1600-xs" style="height: 100%">
+        <div class="j-fx-row-xs j-justify-around-xs j-justify-start-bg j-align-center-xs j-gap-20-bg" style="height: 100%">
+            <div class="j-db-xs j-dn-bg j-grow-1-xs">
+                                    <a href="https://winetime.com.ua/ua" class="header--logo">
+                        <img src="/img/header-logo-invert-new.svg?v=2" alt="">
+                    </a>
+                            </div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+            <div class="j-dn-xs j-db-bg j-grow-1-xs" style="overflow: hidden">
+            </div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+            
+
+                <div class="j-fx-row-xs j-align-center-xs j-db-xs j-dn-bg lang-select lang-select--white">
+                                                                        <span class="j-size-1 lang-select--title hoverdown--header">
+                                Укр
+                            </span>
+                                                                                                <div class="lang-select--dropdown">
+                                <a
+                                    class="dashed-link js-change-lang"
+                                    data-lang="ru"
+                                    href="https://winetime.com.ua/napoyi-slaboalkogolni/pyvo"
+                                >
+                                    Рус
+                                </a>
+                            </div>
+                                                            </div>
+            
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+        </div>
+    </div>
+</div>
+    <div class="header--bottom">
+    <div class="j-container header-bottom--container j-ph-10-xs j-ph-20-bg j-mw-1600-xs j-pv-10-xs j-pv-20-bg">
+        <div class="j-fx-row-xs header-bottom--row j-justify-between-xs j-align-center-xs j-gap-18-xs">
+
+            <button id="additional-menu-button" class="j-btn additional-menu-button j-fx-row j-align-center j-justify-center j-dn-xs j-db-bg">
+                <span class="j-icon j-icon-26-xs icon-burger">
+                    <svg width="28" height="21" viewBox="0 0 28 21" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M2.66699 4.5H25.3337C26.4385 4.5 27.3337 3.60482 27.3337 2.5C27.3337 1.39518 26.4385 0.5 25.3337 0.5H2.66699C1.56217 0.5 0.666992 1.39518 0.666992 2.5C0.666992 3.60482 1.56217 4.5 2.66699 4.5Z" fill="#FF5000"/>
+                    <path d="M25.3337 8.5H2.66699C1.56217 8.5 0.666992 9.39518 0.666992 10.5C0.666992 11.6048 1.56217 12.5 2.66699 12.5H25.3337C26.4385 12.5 27.3337 11.6048 27.3337 10.5C27.3337 9.39518 26.4385 8.5 25.3337 8.5Z" fill="#FF5000"/>
+                    <path d="M25.3337 16.5H2.66699C1.56217 16.5 0.666992 17.3952 0.666992 18.5C0.666992 19.6048 1.56217 20.5 2.66699 20.5H25.3337C26.4385 20.5 27.3337 19.6048 27.3337 18.5C27.3337 17.3952 26.4385 16.5 25.3337 16.5Z" fill="#FF5000"/>
+                </svg>
+                </span>
+                <span class="j-icon j-icon-18-xs icon-close">
+                    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <g clip-path="url(#clip0_6900_485)">
+                        <path d="M9.46585 8.01314L15.6959 1.78287C16.1014 1.37762 16.1014 0.722377 15.6959 0.317124C15.2907 -0.0881297 14.6354 -0.0881297 14.2302 0.317124L7.99991 6.5474L1.76983 0.317124C1.36438 -0.0881297 0.709336 -0.0881297 0.304082 0.317124C-0.101361 0.722377 -0.101361 1.37762 0.304082 1.78287L6.53417 8.01314L0.304082 14.2434C-0.101361 14.6487 -0.101361 15.3039 0.304082 15.7092C0.506045 15.9113 0.771595 16.0129 1.03696 16.0129C1.30232 16.0129 1.56768 15.9113 1.76983 15.7092L7.99991 9.47889L14.2302 15.7092C14.4323 15.9113 14.6977 16.0129 14.9631 16.0129C15.2284 16.0129 15.4938 15.9113 15.6959 15.7092C16.1014 15.3039 16.1014 14.6487 15.6959 14.2434L9.46585 8.01314Z" fill="#FF5000"/>
+                    </g>
+                    <defs>
+                        <clipPath id="clip0_6900_485">
+                            <rect width="16" height="16" fill="white"/>
+                        </clipPath>
+                    </defs>
+                </svg>
+                </span>
+            </button>
+
+            <div class="j-db-xs j-dn-bg">
+                <div id="main-menu--button" class="main-menu--button">
+                    <div class="j-icon j-icon-22-xs icon-burger">
+                        <svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+                            <rect y="8" width="32" height="1" fill="#121111"/>
+                            <rect y="13" width="32" height="1" fill="#121111"/>
+                            <rect y="18" width="32" height="1" fill="#121111"/>
+                            <rect y="23" width="32" height="1" fill="#121111"/>
+                        </svg>
+                    </div>
+                    <div class="j-icon j-icon-16-xs icon-close">
+                        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                            <g clip-path="url(#clip0_6900_485)">
+                                <path d="M9.46585 8.01314L15.6959 1.78287C16.1014 1.37762 16.1014 0.722377 15.6959 0.317124C15.2907 -0.0881297 14.6354 -0.0881297 14.2302 0.317124L7.99991 6.5474L1.76983 0.317124C1.36438 -0.0881297 0.709336 -0.0881297 0.304082 0.317124C-0.101361 0.722377 -0.101361 1.37762 0.304082 1.78287L6.53417 8.01314L0.304082 14.2434C-0.101361 14.6487 -0.101361 15.3039 0.304082 15.7092C0.506045 15.9113 0.771595 16.0129 1.03696 16.0129C1.30232 16.0129 1.56768 15.9113 1.76983 15.7092L7.99991 9.47889L14.2302 15.7092C14.4323 15.9113 14.6977 16.0129 14.9631 16.0129C15.2284 16.0129 15.4938 15.9113 15.6959 15.7092C16.1014 15.3039 16.1014 14.6487 15.6959 14.2434L9.46585 8.01314Z" fill="currentColor"/>
+                            </g>
+                            <defs>
+                                <clipPath id="clip0_6900_485">
+                                    <rect width="16" height="16" fill="white"/>
+                                </clipPath>
+                            </defs>
+                        </svg>
+                    </div>
+                </div>
+            </div>
+
+            <div class="j-dn-xs j-db-bg">
+                                    <a href="https://winetime.com.ua/ua" target="_blank" class="header--logo">
+                        <img src="/img/logo-header-new.svg" alt="Winetime logo">
+                    </a>
+                            </div>
+
+
+            <div class="j-dn-xs j-db-bg">
+                <div class="header--catalog-button">
+                    <button id="catalog-button" class="j-btn main">
+                         <span class="j-icon j-icon-18-xs">
+                             <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                 <path d="M7.92 1.44V6.48C7.92 6.86191 7.76828 7.22818 7.49823 7.49823C7.22818 7.76829 6.86191 7.92 6.48 7.92H1.44C1.05809 7.92 0.691818 7.76829 0.421766 7.49823C0.151714 7.22818 0 6.86191 0 6.48V1.44C0 1.05809 0.151714 0.691819 0.421766 0.421766C0.691818 0.151714 1.05809 0 1.44 0H6.48C6.86191 0 7.22818 0.151714 7.49823 0.421766C7.76828 0.691819 7.92 1.05809 7.92 1.44ZM16.56 0H11.52C11.1381 0 10.7718 0.151714 10.5018 0.421766C10.2317 0.691819 10.08 1.05809 10.08 1.44V6.48C10.08 6.86191 10.2317 7.22818 10.5018 7.49823C10.7718 7.76829 11.1381 7.92 11.52 7.92H16.56C16.9419 7.92 17.3082 7.76829 17.5782 7.49823C17.8483 7.22818 18 6.86191 18 6.48V1.44C18 1.05809 17.8483 0.691819 17.5782 0.421766C17.3082 0.151714 16.9419 0 16.56 0ZM6.48 10.08H1.44C1.05809 10.08 0.691818 10.2317 0.421766 10.5018C0.151714 10.7718 0 11.1381 0 11.52V16.56C0 16.9419 0.151714 17.3082 0.421766 17.5782C0.691818 17.8483 1.05809 18 1.44 18H6.48C6.86191 18 7.22818 17.8483 7.49823 17.5782C7.76828 17.3082 7.92 16.9419 7.92 16.56V11.52C7.92 11.1381 7.76828 10.7718 7.49823 10.5018C7.22818 10.2317 6.86191 10.08 6.48 10.08ZM14.04 10.08C13.2568 10.08 12.4912 10.3123 11.8399 10.7474C11.1887 11.1825 10.6812 11.801 10.3814 12.5246C10.0817 13.2482 10.0033 14.0444 10.1561 14.8126C10.3089 15.5807 10.686 16.2863 11.2399 16.8401C11.7937 17.394 12.4993 17.7711 13.2674 17.9239C14.0356 18.0767 14.8318 17.9983 15.5554 17.6986C16.279 17.3988 16.8975 16.8913 17.3326 16.2401C17.7677 15.5888 18 14.8232 18 14.04C18 12.9897 17.5828 11.9825 16.8401 11.2399C16.0975 10.4972 15.0903 10.08 14.04 10.08Z" fill="white"/>
+                             </svg>
+                         </span>
+                        <span>Всі товари</span>
+                    </button>
+                </div>
+            </div>
+
+            <div class="w-time">
+                <div class="j-fx-row-xs j-align-center-xs j-gap-10-xs">
+                    <div class="j-hoverdown">
+                        <div class="hoverdown--header">
+                            <span class="j-icon j-icon-16-xs"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M7.9938 0C10.2013 0 12.1999 0.897627 13.6508 2.34266C15.0958 3.7939 15.9934 5.79254 15.9934 8C15.9934 10.2075 15.0958 12.2061 13.6508 13.6573C12.1995 15.1024 10.2013 16 7.9938 16C5.78634 16 3.78809 15.1024 2.34305 13.6573C0.891816 12.2061 0 10.2078 0 8C0 5.79254 0.891429 3.7939 2.34266 2.34266C3.78809 0.897627 5.78634 0 7.9938 0ZM12.0709 7.56339C12.3107 7.56339 12.5013 7.76019 12.5013 8C12.5013 8.23981 12.3107 8.43661 12.0709 8.43661H8.0062H7.9938C7.8338 8.43661 7.6924 8.34441 7.61879 8.2154L7.61259 8.2092L7.60639 8.1968V8.19061L7.60019 8.17821L7.594 8.16581V8.15961L7.5878 8.14722L7.5816 8.14102V8.12862L7.5754 8.11622V8.11002L7.5692 8.09763V8.08523V8.07903V8.07283L7.563 8.06664V8.05424V8.04184V8.03099V8.02479V8.0124V8V2.79167C7.563 2.55186 7.75361 2.36126 7.99341 2.36126C8.23322 2.36126 8.43002 2.55186 8.43002 2.79167V7.56339H12.0709ZM13.0359 2.95787C11.7447 1.66663 9.96145 0.87322 7.9938 0.87322C6.02615 0.87322 4.24291 1.66625 2.95167 2.95787C1.66663 4.2491 0.867022 6.03235 0.867022 8C0.867022 9.96765 1.66625 11.7509 2.95167 13.0425C4.24291 14.3338 6.02615 15.1272 7.9938 15.1272C9.96145 15.1272 11.7447 14.3338 13.0359 13.0425C14.3272 11.7513 15.1268 9.96804 15.1268 8C15.1268 6.03235 14.3276 4.2491 13.0359 2.95787Z" fill="#000"/>
+</svg></span>
+                            <span class="j-size-0.75-xs">Час роботи</span>
+                        </div>
+
+                        <dialog class="hoverdown--dialog" open onclick="return false;">
+                                                                                                <div class="j-size-0.875-xs" style="white-space: nowrap">
+                                                                                    Пн-Пт
+                                                                                9:00-20:00
+                                    </div>
+                                                                                                                                <div class="j-size-0.875-xs" style="white-space: nowrap">
+                                                                                    Сб
+                                                                                10:00-18:00
+                                    </div>
+                                                                                                                                <div class="j-size-0.875-xs" style="white-space: nowrap">
+                                                                                    Нд
+                                                                                10:00-15:00
+                                    </div>
+                                                                                    </dialog>
+                    </div>
+                </div>
+            </div>
+
+            <div class="vertical-separator"></div>
+
+            <div class="tel-box">
+                <div class="j-hoverdown">
+                    <div class="hoverdown--header">
+                        <span class="j-icon j-icon-16-xs"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M12.6334 9.9115C12.3059 9.57043 11.9108 9.38808 11.492 9.38808C11.0767 9.38808 10.6782 9.56705 10.3371 9.90812L9.27001 10.9718C9.18221 10.9246 9.09441 10.8807 9.00999 10.8368C8.88842 10.776 8.7736 10.7186 8.67567 10.6578C7.67611 10.0229 6.76772 9.19559 5.89647 8.12511C5.47436 7.59156 5.1907 7.14243 4.98471 6.68655C5.26161 6.43328 5.51826 6.16988 5.76815 5.91661C5.86271 5.82206 5.95726 5.72413 6.05181 5.62957C6.76096 4.92042 6.76096 4.0019 6.05181 3.29275L5.12992 2.37086C5.02523 2.26617 4.91717 2.15811 4.81586 2.05005C4.61325 1.84068 4.4005 1.62456 4.181 1.42194C3.85344 1.09776 3.46172 0.925537 3.04974 0.925537C2.63776 0.925537 2.23928 1.09776 1.90159 1.42194C1.89821 1.42532 1.89821 1.42532 1.89483 1.4287L0.746685 2.58698C0.314441 3.01922 0.0679261 3.54602 0.0138955 4.15724C-0.0671504 5.1433 0.223264 6.06182 0.44614 6.66291C0.9932 8.13862 1.81041 9.50627 3.02948 10.9718C4.50856 12.738 6.2882 14.1326 8.3211 15.1153C9.09779 15.4834 10.1345 15.919 11.2928 15.9933C11.3637 15.9967 11.438 16.0001 11.5055 16.0001C12.2856 16.0001 12.9407 15.7198 13.454 15.1626C13.4574 15.1558 13.4641 15.1525 13.4675 15.1457C13.6431 14.933 13.8457 14.7405 14.0585 14.5345C14.2037 14.396 14.3523 14.2508 14.4975 14.0989C14.8318 13.751 15.0074 13.3458 15.0074 12.9305C15.0074 12.5117 14.8284 12.1099 14.4873 11.7722L12.6334 9.9115ZM13.8423 13.4674C13.839 13.4674 13.839 13.4708 13.8423 13.4674C13.7106 13.6092 13.5756 13.7375 13.4304 13.8794C13.2109 14.0887 12.988 14.3082 12.7786 14.5547C12.4376 14.9195 12.0357 15.0917 11.5089 15.0917C11.4582 15.0917 11.4042 15.0917 11.3536 15.0883C10.3506 15.0241 9.41859 14.6324 8.71957 14.2981C6.80824 13.3728 5.12992 12.0592 3.73525 10.3944C2.58372 9.00648 1.81379 7.72326 1.30388 6.34548C0.989823 5.50463 0.875008 4.84951 0.925661 4.23153C0.959431 3.83643 1.11139 3.50887 1.39168 3.22859L2.5432 2.07706C2.70867 1.92173 2.88427 1.8373 3.05649 1.8373C3.26924 1.8373 3.44146 1.96563 3.54952 2.07369C3.5529 2.07706 3.55627 2.08044 3.55965 2.08382C3.76564 2.2763 3.9615 2.47554 4.1675 2.68828C4.27218 2.79635 4.38024 2.90441 4.4883 3.01585L5.4102 3.93774C5.76815 4.29569 5.76815 4.62663 5.4102 4.98458C5.31227 5.08251 5.21771 5.18044 5.11978 5.275C4.83612 5.56541 4.56597 5.83557 4.27218 6.09896C4.26543 6.10572 4.25867 6.1091 4.2553 6.11585C3.96488 6.40626 4.01891 6.68992 4.0797 6.88241C4.08307 6.89254 4.08645 6.90267 4.08983 6.9128C4.32959 7.49363 4.66728 8.04069 5.18057 8.69243L5.18395 8.69581C6.11597 9.84396 7.09865 10.7388 8.18264 11.4244C8.3211 11.5122 8.46293 11.5831 8.598 11.6506C8.71957 11.7114 8.83439 11.7688 8.93232 11.8296C8.94582 11.8363 8.95933 11.8465 8.97284 11.8532C9.08766 11.9106 9.19572 11.9376 9.30715 11.9376C9.58744 11.9376 9.76304 11.762 9.82045 11.7046L10.9753 10.5497C11.0902 10.4349 11.2725 10.2965 11.4853 10.2965C11.6946 10.2965 11.8669 10.4282 11.9715 10.543C11.9749 10.5464 11.9749 10.5464 11.9783 10.5497L13.839 12.4104C14.1868 12.7549 14.1868 13.1094 13.8423 13.4674Z" fill="#000"/>
+    <path d="M8.63502 3.80622C9.51977 3.9548 10.3235 4.37354 10.9651 5.01515C11.6067 5.65676 12.0221 6.46047 12.174 7.34522C12.2112 7.5681 12.4036 7.72343 12.6231 7.72343C12.6502 7.72343 12.6738 7.72006 12.7008 7.71668C12.9507 7.67616 13.1162 7.43977 13.0757 7.18988C12.8933 6.1194 12.3868 5.14347 11.6135 4.37016C10.8401 3.59685 9.86421 3.09031 8.79373 2.90796C8.54384 2.86744 8.31083 3.0329 8.26693 3.27942C8.22303 3.52593 8.38512 3.76569 8.63502 3.80622Z" fill="#000"/>
+    <path d="M15.9702 7.05794C15.6696 5.29519 14.8389 3.69116 13.5624 2.41469C12.2859 1.13822 10.6819 0.307495 8.91917 0.00695018C8.67265 -0.0369497 8.43965 0.131896 8.39575 0.37841C8.35523 0.628302 8.52069 0.861309 8.77059 0.905209C10.3442 1.17198 11.7794 1.91828 12.9208 3.0563C14.0622 4.1977 14.8051 5.63288 15.0719 7.20653C15.109 7.4294 15.3015 7.58474 15.521 7.58474C15.548 7.58474 15.5717 7.58136 15.5987 7.57799C15.8452 7.54084 16.0141 7.30446 15.9702 7.05794Z" fill="#000"/>
+</svg></span>
+                        <span><a style="color: inherit" href="tel:0 800 330 370">0 800 330 370</a></span>
+                    </div>
+
+                    <dialog class="hoverdown--dialog" open style="min-width: 200px;">
+                        <div class="j-size-0.75-xs">Безкоштовно по Україні!</div>
+
+                        <div>
+                                                                                                                                                            <div>
+                                        <a class="j-size-0.875-xs" style="color: inherit" href="tel:+38 067 239 90 97">+38 067 239 90 97</a>
+                                    </div>
+                                                                                                                                <div>
+                                        <a class="j-size-0.875-xs" style="color: inherit" href="tel:+38 050 315 37 37">+38 050 315 37 37</a>
+                                    </div>
+                                                                                                                                <div>
+                                        <a class="j-size-0.875-xs" style="color: inherit" href="tel:+38 093 957 68 97">+38 093 957 68 97</a>
+                                    </div>
+                                                                                    </div>
+
+                        <hr>
+
+                        <div>
+                            <a class="j-size-0.75-xs" href="/cdn-cgi/l/email-protection#6d04030b022d1a04030819040008430e020043180c"><span class="__cf_email__" data-cfemail="10797e767f5067797e7564797d753e737f7d3e6571">[email&#160;protected]</span></a>
+                        </div>
+
+                        <div class="j-size-0.75-xs c-grey">для замовлень і пропозицій</div>
+                    </dialog>
+                </div>
+            </div>
+
+            <div id="the-header-search-app" class="j-dn-xs j-db-bg header--search j-grow-1-xs">
+                <div class="j-search">
+                    <div class="j-search-wrapper">
+                        <div>
+                            <button
+                                    type="submit"
+                                    class="j-btn search-btn  disabled "
+                            >
+                                <div class="j-icon j-icon-16-xs">
+                                    <svg class="j-svg" width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <path d="M7.7919 0C3.49536 0 0 3.49536 0 7.7919C0 12.0884 3.49536 15.5838 7.7919 15.5838C12.0884 15.5838 15.5838 12.0884 15.5838 7.7919C15.5838 3.49536 12.0885 0 7.7919 0ZM7.7919 14.6671C4.00043 14.6671 0.916681 11.5834 0.916681 7.7919C0.916681 4.00043 4.00043 0.916681 7.7919 0.916681C11.5834 0.916681 14.6671 4.00043 14.6671 7.7919C14.6671 11.5834 11.5834 14.6671 7.7919 14.6671Z" fill="currentColor"></path>
+                                        <path d="M21.8659 21.2188L13.3013 12.654C13.1225 12.4753 12.8319 12.4753 12.6531 12.654C12.4744 12.8328 12.4744 13.1234 12.6531 13.3022L21.2178 21.8668C21.3077 21.9557 21.425 22.0007 21.5423 22.0007C21.6597 22.0007 21.777 21.9558 21.8659 21.8668C22.0447 21.6881 22.0447 21.3975 21.8659 21.2188Z" fill="currentColor"></path>
+                                    </svg>
+                                </div>
+                            </button>
+                        </div>
+                        <div class="j-grow-1-xs">
+                            <input
+                                type="text"
+                                name="q"
+                                autocomplete="off"
+                                value=""
+                                placeholder="Пошук товарів"
+                            />
+                        </div>
+
+                    </div>
+                </div>
+            </div>
+
+            <div class="j-dn-xs j-db-bg" style="position: relative">
+                <div class="js-selected-city-change" style="position: relative">
+                    <div class="j-fx-row-xs j-gap-10-xs">
+                        <div class="j-icon j-icon-16-xs">
+                            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                <path d="M7.99997 0C4.76502 0 2.1333 2.542 2.1333 5.66666C2.1333 8.68866 7.49681 15.576 7.72458 15.868C7.79016 15.9513 7.89162 16 7.99997 16C8.10832 16 8.20978 15.9513 8.27536 15.868C8.50312 15.576 13.8666 8.68866 13.8666 5.66666C13.8666 2.542 11.2349 0 7.99997 0ZM7.99997 15.106C6.8922 13.642 2.82349 8.09866 2.82349 5.66666C2.82349 2.90931 5.1453 0.666656 7.99997 0.666656C10.8546 0.666656 13.1764 2.90931 13.1764 5.66666C13.1764 8.09734 9.10773 13.6413 7.99997 15.106Z" fill="black"/>
+                                <path d="M7.99997 2.66666C6.28759 2.66666 4.89408 4.01266 4.89408 5.66666C4.89408 7.32066 6.28759 8.66666 7.99997 8.66666C9.71235 8.66666 11.1059 7.32066 11.1059 5.66666C11.1059 4.01266 9.71235 2.66666 7.99997 2.66666ZM7.99997 8C6.6679 8 5.58427 6.95334 5.58427 5.66666C5.58427 4.38 6.66786 3.33331 7.99997 3.33331C9.33207 3.33331 10.4157 4.37997 10.4157 5.66666C10.4157 6.95334 9.33204 8 7.99997 8Z" fill="black"/>
+                            </svg>
+                        </div>
+                        <div class="dashed-link j-size-0.875-xs" style="white-space: nowrap">Київ</div>
+                    </div>
+                </div>
+                                    <dialog
+                            class="city-selector__trigger"
+                            open
+                    >
+                        <div class="j-h-center-xs j-mb-20-xs j-size-0.875-xs">Ваше місто: <span class="j-weight-600-xs">Київ</span>?</div>
+                        <div class="j-fx-row-xs j-nowrap-xs j-gap-10-xs j-align-center-xs">
+                            <div>
+                                <button type="button" class="j-btn secondary small js-selected-city-confirm">Так</button>
+                            </div>
+                            <div class="js-selected-city-change j-size-0.875-xs dashed-link" style="white-space: nowrap">Обрати інший</div>
+                        </div>
+                    </dialog>
+                            </div>
+
+
+                            <div class="j-dn-xs j-df-bg vertical-separator"></div>
+
+                <div class="j-fx-row j-align-center-xs j-dn-xs j-df-bg lang-select">
+                                                                        <span class="j-size-1 lang-select--title hoverdown--header">
+                                Укр
+                            </span>
+                                                                                                <div class="lang-select--dropdown">
+                                <a
+                                    class="dashed-link js-change-lang"
+                                    data-lang="ru"
+                                    href="https://winetime.com.ua/napoyi-slaboalkogolni/pyvo"
+                                >
+                                    Рус
+                                </a>
+                            </div>
+                                                            </div>
+            
+            <div class="j-dn-xs j-df-bg vertical-separator"></div>
+
+            <div class="header--actions">
+                <div class="j-fx-row-xs j-align-center-xs j-gap-15-xs j-gap-20-bg">
+
+                    <div id="header-search-button" class="header--search-button j-db-xs j-dn-bg">
+                        <div class="j-icon j-icon-18-xs">
+                            <svg class="j-svg" width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                <path d="M7.7919 0C3.49536 0 0 3.49536 0 7.7919C0 12.0884 3.49536 15.5838 7.7919 15.5838C12.0884 15.5838 15.5838 12.0884 15.5838 7.7919C15.5838 3.49536 12.0885 0 7.7919 0ZM7.7919 14.6671C4.00043 14.6671 0.916681 11.5834 0.916681 7.7919C0.916681 4.00043 4.00043 0.916681 7.7919 0.916681C11.5834 0.916681 14.6671 4.00043 14.6671 7.7919C14.6671 11.5834 11.5834 14.6671 7.7919 14.6671Z" fill="#706F6F"/>
+                                <path d="M21.8659 21.2188L13.3013 12.654C13.1225 12.4753 12.8319 12.4753 12.6531 12.654C12.4744 12.8328 12.4744 13.1234 12.6531 13.3022L21.2178 21.8668C21.3077 21.9557 21.425 22.0007 21.5423 22.0007C21.6597 22.0007 21.777 21.9558 21.8659 21.8668C22.0447 21.6881 22.0447 21.3975 21.8659 21.2188Z" fill="#706F6F"/>
+                            </svg>
+                        </div>
+                    </div>
+
+                    <div class="j-db-xs j-dn-bg vertical-separator"></div>
+
+                    <div class="j-db-xs j-dn-bg" style="position: relative">
+                        <div class="js-selected-city-change" style="position: relative">
+                            <div class="j-fx-row-xs j-gap-10-xs">
+                                <div class="j-icon j-icon-18-xs">
+                                    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                        <path d="M7.99997 0C4.76502 0 2.1333 2.542 2.1333 5.66666C2.1333 8.68866 7.49681 15.576 7.72458 15.868C7.79016 15.9513 7.89162 16 7.99997 16C8.10832 16 8.20978 15.9513 8.27536 15.868C8.50312 15.576 13.8666 8.68866 13.8666 5.66666C13.8666 2.542 11.2349 0 7.99997 0ZM7.99997 15.106C6.8922 13.642 2.82349 8.09866 2.82349 5.66666C2.82349 2.90931 5.1453 0.666656 7.99997 0.666656C10.8546 0.666656 13.1764 2.90931 13.1764 5.66666C13.1764 8.09734 9.10773 13.6413 7.99997 15.106Z" fill="black"/>
+                                        <path d="M7.99997 2.66666C6.28759 2.66666 4.89408 4.01266 4.89408 5.66666C4.89408 7.32066 6.28759 8.66666 7.99997 8.66666C9.71235 8.66666 11.1059 7.32066 11.1059 5.66666C11.1059 4.01266 9.71235 2.66666 7.99997 2.66666ZM7.99997 8C6.6679 8 5.58427 6.95334 5.58427 5.66666C5.58427 4.38 6.66786 3.33331 7.99997 3.33331C9.33207 3.33331 10.4157 4.37997 10.4157 5.66666C10.4157 6.95334 9.33204 8 7.99997 8Z" fill="black"/>
+                                    </svg>
+                                </div>
+
+                            </div>
+                        </div>
+                                                    <dialog
+                                    class="city-selector__trigger"
+                                    open
+                            >
+                                <div class="j-h-center-xs j-mb-20-xs j-size-0.875-xs">Ваше місто: <span class="j-weight-600-xs">Київ</span>?</div>
+                                <div class="j-fx-row-xs j-nowrap-xs j-gap-10-xs j-align-center-xs">
+                                    <div>
+                                        <button type="button" class="j-btn secondary small js-selected-city-confirm">Так</button>
+                                    </div>
+                                    <div class="js-selected-city-change j-size-0.875-xs dashed-link" style="white-space: nowrap">Обрати інший</div>
+                                </div>
+                            </dialog>
+                                            </div>
+
+                    <div class="j-db-xs j-dn-bg vertical-separator"></div>
+
+                    <a href="https://winetime.com.ua/ua/cabinet" class="header--fav j-fx-row-xs j-align-center-xs j-gap-10-xs" style="cursor: pointer; text-decoration: none; color: inherit;">
+                        <div class="j-icon j-icon-18-xs">
+                            <svg width="22" height="20" viewBox="0 0 22 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                <path fill-rule="evenodd" clip-rule="evenodd" d="M11 2.65248C13.5886 -0.766199 17.886 -0.547792 20.1244 1.43088C22.5102 3.53984 22.6774 7.7551 20.2948 11.9726C18.7253 14.9331 14.7311 17.9216 11.3818 19.8953C11.1449 20.0349 10.855 20.0349 10.6181 19.8953C7.26886 17.9216 3.27467 14.9331 1.70517 11.9726C-0.677395 7.7551 -0.510206 3.53988 1.87554 1.43088C4.11393 -0.547747 8.41135 -0.766199 11 2.65248ZM10.8629 3.85564C10.8921 3.90534 10.944 3.93563 11 3.93563C11.0559 3.93563 11.1079 3.90529 11.137 3.85564C13.3338 0.139683 17.5118 0.178425 19.6228 2.04441C21.7786 3.95003 21.7786 7.76118 19.6228 11.5724C18.1138 14.4308 14.2335 17.2892 11 19.1947C7.76643 17.2892 3.88617 14.4308 2.37716 11.5724C0.221455 7.76118 0.221455 3.95003 2.37716 2.04441C4.48811 0.178425 8.66614 0.139683 10.8629 3.85564Z" fill="black"/>
+                            </svg>
+                        </div>
+                        <div id="wishlist-quantity-app"
+                             class="header--value "
+                        >0</div>
+                    </a>
+                    <div id="header--cart-button"
+                         class="header--cart-button j-fx-row-xs j-align-center-xs j-gap-10-xs"
+                    >
+                        <div class="j-icon j-icon-18-xs">
+                            <svg width="18" height="20" viewBox="0 0 18 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                <path d="M16.1861 5.33813C16.1706 5.22202 16.1126 5.11548 16.023 5.03862C15.9334 4.96175 15.8183 4.91987 15.6995 4.92086H13.0188V3.96163C13.0188 2.91094 12.5953 1.90328 11.8417 1.16033C11.088 0.417385 10.0658 0 9 0C7.93416 0 6.91197 0.417385 6.15831 1.16033C5.40465 1.90328 4.98125 2.91094 4.98125 3.96163V4.92086H2.29559C2.1768 4.91987 2.06175 4.96175 1.97212 5.03862C1.8825 5.11548 1.8245 5.22202 1.80906 5.33813L0.00402721 18.8345C-0.00515846 18.9045 0.00141522 18.9755 0.0232801 19.0427C0.045145 19.1098 0.0817632 19.1714 0.130526 19.223C0.334869 19.4388 0.558673 19.6595 0.801939 19.8753C0.891168 19.9552 1.00734 19.9997 1.12792 20H16.8721C16.9927 19.9997 17.1088 19.9552 17.1981 19.8753C17.4365 19.6595 17.6846 19.4388 17.8695 19.223C17.9182 19.1714 17.9549 19.1098 17.9767 19.0427C17.9986 18.9755 18.0052 18.9045 17.996 18.8345L16.1861 5.33813ZM5.96891 3.95204C5.96891 3.15575 6.28979 2.39208 6.86097 1.82902C7.43215 1.26596 8.20683 0.94964 9.0146 0.94964C9.82236 0.94964 10.597 1.26596 11.1682 1.82902C11.7394 2.39208 12.0603 3.15575 12.0603 3.95204V4.91127H5.95431L5.96891 3.95204ZM16.6726 19.0408H1.31766L0.996552 18.7338L2.71887 5.8801H15.2763L16.9986 18.7338L16.6726 19.0408Z" fill="black"/>
+                            </svg>
+                        </div>
+                        <div id="cart-quantity-app"
+                             class="header--value  }}"
+                        >0</div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="j-dn-xs j-df-bg vertical-separator"></div>
+
+            <div class="j-db-bg">
+                <div class="the-auth-button-app">
+                                            <div class="j-fx-row-xs j-align-center-xs j-gap-10-xs">
+                            <div class="j-icon j-icon-26-xs">
+                                <svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                    <path d="M30 15C30 23.2843 23.2843 30 15 30C6.71573 30 0 23.2843 0 15C0 6.71573 6.71573 0 15 0C23.2843 0 30 6.71573 30 15Z" fill="#E5E5E5"/>
+                                    <path d="M15 15.0206C10.5888 15.0206 7 18.4511 7 22.6675C7 22.851 7.15584 23 7.34784 23C7.53984 23 7.69567 22.851 7.69567 22.6675C7.69567 18.8175 10.9722 15.6856 15 15.6856C19.0278 15.6856 22.3043 18.8175 22.3043 22.6675C22.3043 22.851 22.4602 23 22.6522 23C22.8442 23 23 22.851 23 22.6675C23 18.4504 19.4111 15.0206 15 15.0206Z" fill="black"/>
+                                    <path d="M15 7C12.8907 7 11.1739 8.64042 11.1739 10.6572C11.1739 12.674 12.8908 14.3144 15 14.3144C17.1092 14.3144 18.826 12.674 18.826 10.6572C18.826 8.64042 17.1092 7 15 7ZM15 13.6495C13.2741 13.6495 11.8695 12.3069 11.8695 10.6572C11.8695 9.00747 13.2741 7.66494 15 7.66494C16.7259 7.66494 18.1304 9.00747 18.1304 10.6572C18.1304 12.3069 16.7259 13.6495 15 13.6495Z" fill="black"/>
+                                </svg>
+                            </div>
+                            <div class="j-size-0.875-xs">Вхід</div>
+                        </div>
+                                    </div>
+            </div>
+
+        </div>
+    </div>
+
+    <div id="the-catalog-menu-app"></div>
+    <div id="the-additional-menu-app"></div>
+</div>
+</header>
+    <div id="content-wrapper">
+                            <div class="header--banner-notification j-db-xs j-dn-bg" style="background-color: #ff772e; color: #f1efef; font-size: 14px; font-weight: normal;">
+                <p class="j-h-center j-size-1-xs" style="color: #f1efef; font-size: 14px; font-weight: normal;">Зміни умов в Оплаті та Доставці.</p>
+            </div>
+                    <script data-cfasync="false" src="/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"></script><script type="application/ld+json">{
+"@context": "https://schema.org",
+    "@type": "LiquorStore",
+    "name": "WINETIME - інтернет-магазин вина та міцних напоїв",
+    "description": "WINETIME інтернет магазин вина, спиртних напоїв, цукерок, солодощів. Доступні ціни в Вайнтайм. Зручна доставка по Києву, Україні.",
+    "url": "https://winetime.com.ua/ua",
+    "image": "https://winetime.com.ua/img/header-logo.svg",
+    "telephone": "0800330370",
+    "logo": "https://winetime.com.ua/img/header-logo.svg",
+    "priceRange": "UAH",
+    "address": {
+    "@type": "PostalAddress",
+    "streetAddress": "проспект М.Бажана, 1е",
+    "addressLocality": "м.Київ, Україна",
+    "postalCode": "02095",
+    "addressCountry": "Україна"
+  },
+  "geo": {
+    "@type": "GeoCoordinates",
+    "latitude": "50.3963465",
+    "longitude": "30.6149781"
+  },
+  "openingHoursSpecification": [
+  {
+    "@type": "OpeningHoursSpecification",
+    "dayOfWeek": ["Monday","Tuesday","Wednesday","Thursday","Friday","Saturday","Sunday"],
+    "opens": "09:00",
+    "closes": "19:00"
+  }]
+  }</script>
+  <script type="application/ld+json">{
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "url": "https://winetime.com.ua/ua",
+    "logo": "https://winetime.com.ua/img/header-logo.svg",
+    "contactPoint": [{
+    "@type": "ContactPoint",
+    "telephone": "0800330370",
+    "contactType": "customer service"
+    }]
+  }</script>
+  <script type="application/ld+json">{
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "WINETIME",
+    "url": "https://winetime.com.ua/ua",
+    "sameAs": [
+      "https://www.facebook.com/winetime.ukraine","https://www.youtube.com/user/WineTimeUkraine"
+     ]}
+   </script>
+
+    <div class="" style="background-color: #f9f9f9; min-height: 100vh">
+        <div>
+            <div class="j-container j-mw-1600-xs j-ph-15-xs">
+    <nav class="breadcrumbs ">
+        <ul>
+            <li>
+                <a href="https://winetime.com.ua/ua">
+                    <span property="name">Головна</span>
+                </a>
+            </li>
+                            <li>
+                                            <a href="https://winetime.com.ua/ua/napoyi-slaboalkogolni">
+                            <span property="name">Напої  слабоалкогольні</span>
+                        </a>
+                                    </li>
+                            <li>
+                                            <span property="name">Пиво</span>
+                                    </li>
+                    </ul>
+    </nav>
+</div>        </div>
+
+        <section id="category-page-app">
+            <div class="j-container j-mw-1600-xs j-ph-15-xs j-first-content">
+                <h1 class="h1">Каталог з пивом</h1>
+                <div class="j-container j-mw-1600-xs j-ph-15-xs j-mt-30-xs">
+                    <div class="j-fx-col-xs j-fx-row-bg j-align-start-xs j-gap-0-xs j-gap-30-bg j-pb-30-xs">
+                        <div class="filters-column">
+                        </div>
+                        <div class="products-column">
+                            <div class="j-fx-row-xs j-wrap-xs j-mt-20-xs j-gap-4-xs" style="overflow-y: visible; opacity: 1;">
+                                                                <div class="j-col-12-xs j-col-6-sm j-col-4-md j-col-3-bg j-col-2.4-xl">
+                                    <a href="https://winetime.com.ua/ua/pyvo-didko-travmato-svitle-nefiltrovane-05-l" class="product-micro" style="position: relative;">
+                                        <div data-productkey="59191"></div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-size-0.75-xs">
+                                            <div>
+                                                <div class="c-success"></div>
+                                            </div>
+                                            <div class="c-grey">Код: 21622853</div>
+                                        </div>
+                                        <div class="product-micro--title j-mv-15-xs">Пиво Дідько Travmato світле нефільтроване 0,5 л</div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-align-center-xs"></div>
+                                        <div class="j-fx-row-xs j-gap-10-xs j-mt-20-xs j-align-center-xs">
+                                            <div class="j-icon j-icon-20-xs">
+                                            </div>
+                                            <hr class="vertical-separator" style="height: 12px;">
+                                            <div class="j-grow-1-xs j-size-0.75-xs">
+                                                                                                    Дідько
+                                                                                            </div>
+                                        </div>
+                                        <hr class="j-mv-20-xs">
+                                        <div class="j-fx-row-xs j-align-center-xs j-justify-between-xs">
+                                            <div>
+                                                <div class="j-size-1.25-xs j-weight-600-xs">119<span class="j-size-0.875-xs">&nbsp;грн</span></div>
+                                            </div>
+                                        </div>
+                                        <div class="j-mt-10-xs">
+                                            <button type="button" class="j-btn main j-gap-5-xs"><span>Купити</span></button>
+                                        </div>
+                                    </a>
+                                </div>
+                                                                <div class="j-col-12-xs j-col-6-sm j-col-4-md j-col-3-bg j-col-2.4-xl">
+                                    <a href="https://winetime.com.ua/ua/pyvo-kyiv-local-brewery-alco-free-ipa-bezalkogolne-nefiltrovane-033-l" class="product-micro" style="position: relative;">
+                                        <div data-productkey="59174"></div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-size-0.75-xs">
+                                            <div>
+                                                <div class="c-success"></div>
+                                            </div>
+                                            <div class="c-grey">Код: 21552899</div>
+                                        </div>
+                                        <div class="product-micro--title j-mv-15-xs">Пиво Kyiv Local Brewery Alco Free IPA безалкогольне нефільтроване 0,33 л</div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-align-center-xs"></div>
+                                        <div class="j-fx-row-xs j-gap-10-xs j-mt-20-xs j-align-center-xs">
+                                            <div class="j-icon j-icon-20-xs">
+                                            </div>
+                                            <hr class="vertical-separator" style="height: 12px;">
+                                            <div class="j-grow-1-xs j-size-0.75-xs">
+                                                                                                    Kyiv Local Brewery
+                                                                                            </div>
+                                        </div>
+                                        <hr class="j-mv-20-xs">
+                                        <div class="j-fx-row-xs j-align-center-xs j-justify-between-xs">
+                                            <div>
+                                                <div class="j-size-1.25-xs j-weight-600-xs">89<span class="j-size-0.875-xs">&nbsp;грн</span></div>
+                                            </div>
+                                        </div>
+                                        <div class="j-mt-10-xs">
+                                            <button type="button" class="j-btn main j-gap-5-xs"><span>Купити</span></button>
+                                        </div>
+                                    </a>
+                                </div>
+                                                                <div class="j-col-12-xs j-col-6-sm j-col-4-md j-col-3-bg j-col-2.4-xl">
+                                    <a href="https://winetime.com.ua/ua/pyvo-tsypa-orental-svitle-nefiltrovane-05-l" class="product-micro" style="position: relative;">
+                                        <div data-productkey="59170"></div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-size-0.75-xs">
+                                            <div>
+                                                <div class="c-success"></div>
+                                            </div>
+                                            <div class="c-grey">Код: 21527958</div>
+                                        </div>
+                                        <div class="product-micro--title j-mv-15-xs">Пиво Ципа Орєнтал світле нефільтроване 0,5 л</div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-align-center-xs"></div>
+                                        <div class="j-fx-row-xs j-gap-10-xs j-mt-20-xs j-align-center-xs">
+                                            <div class="j-icon j-icon-20-xs">
+                                            </div>
+                                            <hr class="vertical-separator" style="height: 12px;">
+                                            <div class="j-grow-1-xs j-size-0.75-xs">
+                                                                                                    Ципа
+                                                                                            </div>
+                                        </div>
+                                        <hr class="j-mv-20-xs">
+                                        <div class="j-fx-row-xs j-align-center-xs j-justify-between-xs">
+                                            <div>
+                                                <div class="j-size-1.25-xs j-weight-600-xs">93<span class="j-size-0.875-xs">&nbsp;грн</span></div>
+                                            </div>
+                                        </div>
+                                        <div class="j-mt-10-xs">
+                                            <button type="button" class="j-btn main j-gap-5-xs"><span>Купити</span></button>
+                                        </div>
+                                    </a>
+                                </div>
+                                                                <div class="j-col-12-xs j-col-6-sm j-col-4-md j-col-3-bg j-col-2.4-xl">
+                                    <a href="https://winetime.com.ua/ua/pyvo-tsypa-z-ogirkamy-svitle-nefiltrovane-05-l" class="product-micro" style="position: relative;">
+                                        <div data-productkey="59169"></div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-size-0.75-xs">
+                                            <div>
+                                                <div class="c-success"></div>
+                                            </div>
+                                            <div class="c-grey">Код: 21527962</div>
+                                        </div>
+                                        <div class="product-micro--title j-mv-15-xs">Пиво Ципа з огірками світле нефільтроване 0,5 л</div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-align-center-xs"></div>
+                                        <div class="j-fx-row-xs j-gap-10-xs j-mt-20-xs j-align-center-xs">
+                                            <div class="j-icon j-icon-20-xs">
+                                            </div>
+                                            <hr class="vertical-separator" style="height: 12px;">
+                                            <div class="j-grow-1-xs j-size-0.75-xs">
+                                                                                                    Ципа
+                                                                                            </div>
+                                        </div>
+                                        <hr class="j-mv-20-xs">
+                                        <div class="j-fx-row-xs j-align-center-xs j-justify-between-xs">
+                                            <div>
+                                                <div class="j-size-1.25-xs j-weight-600-xs">93<span class="j-size-0.875-xs">&nbsp;грн</span></div>
+                                            </div>
+                                        </div>
+                                        <div class="j-mt-10-xs">
+                                            <button type="button" class="j-btn main j-gap-5-xs"><span>Купити</span></button>
+                                        </div>
+                                    </a>
+                                </div>
+                                                                <div class="j-col-12-xs j-col-6-sm j-col-4-md j-col-3-bg j-col-2.4-xl">
+                                    <a href="https://winetime.com.ua/ua/pyvo-ten-men-boom-100-svitle-nefiltrovane-05-l" class="product-micro" style="position: relative;">
+                                        <div data-productkey="59168"></div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-size-0.75-xs">
+                                            <div>
+                                                <div class="c-success"></div>
+                                            </div>
+                                            <div class="c-grey">Код: 21527964</div>
+                                        </div>
+                                        <div class="product-micro--title j-mv-15-xs">Пиво Ten Men Boom 100! світле нефільтроване 0,5 л</div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-align-center-xs"></div>
+                                        <div class="j-fx-row-xs j-gap-10-xs j-mt-20-xs j-align-center-xs">
+                                            <div class="j-icon j-icon-20-xs">
+                                            </div>
+                                            <hr class="vertical-separator" style="height: 12px;">
+                                            <div class="j-grow-1-xs j-size-0.75-xs">
+                                                                                                    Ten Men brewery
+                                                                                            </div>
+                                        </div>
+                                        <hr class="j-mv-20-xs">
+                                        <div class="j-fx-row-xs j-align-center-xs j-justify-between-xs">
+                                            <div>
+                                                <div class="j-size-1.25-xs j-weight-600-xs">126<span class="j-size-0.875-xs">&nbsp;грн</span></div>
+                                            </div>
+                                        </div>
+                                        <div class="j-mt-10-xs">
+                                            <button type="button" class="j-btn main j-gap-5-xs"><span>Купити</span></button>
+                                        </div>
+                                    </a>
+                                </div>
+                                                                <div class="j-col-12-xs j-col-6-sm j-col-4-md j-col-3-bg j-col-2.4-xl">
+                                    <a href="https://winetime.com.ua/ua/meteor-pils" class="product-micro" style="position: relative;">
+                                        <div data-productkey="10469"></div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-size-0.75-xs">
+                                            <div>
+                                                <div class="c-success"></div>
+                                            </div>
+                                            <div class="c-grey">Код: 19429489</div>
+                                        </div>
+                                        <div class="product-micro--title j-mv-15-xs">Пиво Meteor Pils 0,33 л</div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-align-center-xs"></div>
+                                        <div class="j-fx-row-xs j-gap-10-xs j-mt-20-xs j-align-center-xs">
+                                            <div class="j-icon j-icon-20-xs">
+                                            </div>
+                                            <hr class="vertical-separator" style="height: 12px;">
+                                            <div class="j-grow-1-xs j-size-0.75-xs">
+                                                                                                    Meteor
+                                                                                            </div>
+                                        </div>
+                                        <hr class="j-mv-20-xs">
+                                        <div class="j-fx-row-xs j-align-center-xs j-justify-between-xs">
+                                            <div>
+                                                <div class="j-size-1.25-xs j-weight-600-xs">69<span class="j-size-0.875-xs">&nbsp;грн</span></div>
+                                            </div>
+                                        </div>
+                                        <div class="j-mt-10-xs">
+                                            <button type="button" class="j-btn main j-gap-5-xs"><span>Купити</span></button>
+                                        </div>
+                                    </a>
+                                </div>
+                                                                <div class="j-col-12-xs j-col-6-sm j-col-4-md j-col-3-bg j-col-2.4-xl">
+                                    <a href="https://winetime.com.ua/ua/pyvo-x-mark-flavoured-beer-agave-can-svitle-filtrovane-05-l" class="product-micro" style="position: relative;">
+                                        <div data-productkey="56100"></div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-size-0.75-xs">
+                                            <div>
+                                                <div class="c-success"></div>
+                                            </div>
+                                            <div class="c-grey">Код: 21153032</div>
+                                        </div>
+                                        <div class="product-micro--title j-mv-15-xs">Пиво X-mark Flavoured Beer Agave CAN світле фільтроване 0,5 л</div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-align-center-xs"></div>
+                                        <div class="j-fx-row-xs j-gap-10-xs j-mt-20-xs j-align-center-xs">
+                                            <div class="j-icon j-icon-20-xs">
+                                            </div>
+                                            <hr class="vertical-separator" style="height: 12px;">
+                                            <div class="j-grow-1-xs j-size-0.75-xs">
+                                                                                                    X-mark
+                                                                                            </div>
+                                        </div>
+                                        <hr class="j-mv-20-xs">
+                                        <div class="j-fx-row-xs j-align-center-xs j-justify-between-xs">
+                                            <div>
+                                                <div class="j-size-1.25-xs j-weight-600-xs">69<span class="j-size-0.875-xs">&nbsp;грн</span></div>
+                                            </div>
+                                        </div>
+                                        <div class="j-mt-10-xs">
+                                            <button type="button" class="j-btn main j-gap-5-xs"><span>Купити</span></button>
+                                        </div>
+                                    </a>
+                                </div>
+                                                                <div class="j-col-12-xs j-col-6-sm j-col-4-md j-col-3-bg j-col-2.4-xl">
+                                    <a href="https://winetime.com.ua/ua/pohjala-cozy-nights" class="product-micro" style="position: relative;">
+                                        <div data-productkey="20402"></div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-size-0.75-xs">
+                                            <div>
+                                                <div class="c-success"></div>
+                                            </div>
+                                            <div class="c-grey">Код: 20608069</div>
+                                        </div>
+                                        <div class="product-micro--title j-mv-15-xs">Пиво Pohjala Cozy Nights світле нефільтроване 0,33 л</div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-align-center-xs"></div>
+                                        <div class="j-fx-row-xs j-gap-10-xs j-mt-20-xs j-align-center-xs">
+                                            <div class="j-icon j-icon-20-xs">
+                                            </div>
+                                            <hr class="vertical-separator" style="height: 12px;">
+                                            <div class="j-grow-1-xs j-size-0.75-xs">
+                                                                                                    Pohjala
+                                                                                            </div>
+                                        </div>
+                                        <hr class="j-mv-20-xs">
+                                        <div class="j-fx-row-xs j-align-center-xs j-justify-between-xs">
+                                            <div>
+                                                <div class="j-size-1.25-xs j-weight-600-xs">299<span class="j-size-0.875-xs">&nbsp;грн</span></div>
+                                            </div>
+                                        </div>
+                                        <div class="j-mt-10-xs">
+                                            <button type="button" class="j-btn main j-gap-5-xs"><span>Купити</span></button>
+                                        </div>
+                                    </a>
+                                </div>
+                                                                <div class="j-col-12-xs j-col-6-sm j-col-4-md j-col-3-bg j-col-2.4-xl">
+                                    <a href="https://winetime.com.ua/ua/meteor-blanche" class="product-micro" style="position: relative;">
+                                        <div data-productkey="10468"></div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-size-0.75-xs">
+                                            <div>
+                                                <div class="c-success"></div>
+                                            </div>
+                                            <div class="c-grey">Код: 19429493</div>
+                                        </div>
+                                        <div class="product-micro--title j-mv-15-xs">Пиво Meteor Blanche 0,33 л</div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-align-center-xs"></div>
+                                        <div class="j-fx-row-xs j-gap-10-xs j-mt-20-xs j-align-center-xs">
+                                            <div class="j-icon j-icon-20-xs">
+                                            </div>
+                                            <hr class="vertical-separator" style="height: 12px;">
+                                            <div class="j-grow-1-xs j-size-0.75-xs">
+                                                                                                    Meteor
+                                                                                            </div>
+                                        </div>
+                                        <hr class="j-mv-20-xs">
+                                        <div class="j-fx-row-xs j-align-center-xs j-justify-between-xs">
+                                            <div>
+                                                <div class="j-size-1.25-xs j-weight-600-xs">69<span class="j-size-0.875-xs">&nbsp;грн</span></div>
+                                            </div>
+                                        </div>
+                                        <div class="j-mt-10-xs">
+                                            <button type="button" class="j-btn main j-gap-5-xs"><span>Купити</span></button>
+                                        </div>
+                                    </a>
+                                </div>
+                                                                <div class="j-col-12-xs j-col-6-sm j-col-4-md j-col-3-bg j-col-2.4-xl">
+                                    <a href="https://winetime.com.ua/ua/meteor-lager" class="product-micro" style="position: relative;">
+                                        <div data-productkey="10471"></div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-size-0.75-xs">
+                                            <div>
+                                                <div class="c-success"></div>
+                                            </div>
+                                            <div class="c-grey">Код: 19429485</div>
+                                        </div>
+                                        <div class="product-micro--title j-mv-15-xs">Пиво Meteor Lager 0,33 л</div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-align-center-xs"></div>
+                                        <div class="j-fx-row-xs j-gap-10-xs j-mt-20-xs j-align-center-xs">
+                                            <div class="j-icon j-icon-20-xs">
+                                            </div>
+                                            <hr class="vertical-separator" style="height: 12px;">
+                                            <div class="j-grow-1-xs j-size-0.75-xs">
+                                                                                                    Meteor
+                                                                                            </div>
+                                        </div>
+                                        <hr class="j-mv-20-xs">
+                                        <div class="j-fx-row-xs j-align-center-xs j-justify-between-xs">
+                                            <div>
+                                                <div class="j-size-1.25-xs j-weight-600-xs">69<span class="j-size-0.875-xs">&nbsp;грн</span></div>
+                                            </div>
+                                        </div>
+                                        <div class="j-mt-10-xs">
+                                            <button type="button" class="j-btn main j-gap-5-xs"><span>Купити</span></button>
+                                        </div>
+                                    </a>
+                                </div>
+                                                                <div class="j-col-12-xs j-col-6-sm j-col-4-md j-col-3-bg j-col-2.4-xl">
+                                    <a href="https://winetime.com.ua/ua/pyvo-x-mark-flavoured-beer-mojito-can-svitle-filtrovane-05-l" class="product-micro" style="position: relative;">
+                                        <div data-productkey="56111"></div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-size-0.75-xs">
+                                            <div>
+                                                <div class="c-success"></div>
+                                            </div>
+                                            <div class="c-grey">Код: 21153036</div>
+                                        </div>
+                                        <div class="product-micro--title j-mv-15-xs">Пиво X-mark Flavoured Beer Mojito CAN світле фільтроване 0,5 л</div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-align-center-xs"></div>
+                                        <div class="j-fx-row-xs j-gap-10-xs j-mt-20-xs j-align-center-xs">
+                                            <div class="j-icon j-icon-20-xs">
+                                            </div>
+                                            <hr class="vertical-separator" style="height: 12px;">
+                                            <div class="j-grow-1-xs j-size-0.75-xs">
+                                                                                                    X-mark
+                                                                                            </div>
+                                        </div>
+                                        <hr class="j-mv-20-xs">
+                                        <div class="j-fx-row-xs j-align-center-xs j-justify-between-xs">
+                                            <div>
+                                                <div class="j-size-1.25-xs j-weight-600-xs">69<span class="j-size-0.875-xs">&nbsp;грн</span></div>
+                                            </div>
+                                        </div>
+                                        <div class="j-mt-10-xs">
+                                            <button type="button" class="j-btn main j-gap-5-xs"><span>Купити</span></button>
+                                        </div>
+                                    </a>
+                                </div>
+                                                                <div class="j-col-12-xs j-col-6-sm j-col-4-md j-col-3-bg j-col-2.4-xl">
+                                    <a href="https://winetime.com.ua/ua/pyvo-x-mark-flavoured-beer-cannabis-svitle-filtrovane-033-l" class="product-micro" style="position: relative;">
+                                        <div data-productkey="56101"></div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-size-0.75-xs">
+                                            <div>
+                                                <div class="c-success"></div>
+                                            </div>
+                                            <div class="c-grey">Код: 21153028</div>
+                                        </div>
+                                        <div class="product-micro--title j-mv-15-xs">Пиво X-mark Flavoured Beer Cannabis світле фільтроване 0,33 л</div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-align-center-xs"></div>
+                                        <div class="j-fx-row-xs j-gap-10-xs j-mt-20-xs j-align-center-xs">
+                                            <div class="j-icon j-icon-20-xs">
+                                            </div>
+                                            <hr class="vertical-separator" style="height: 12px;">
+                                            <div class="j-grow-1-xs j-size-0.75-xs">
+                                                                                                    X-mark
+                                                                                            </div>
+                                        </div>
+                                        <hr class="j-mv-20-xs">
+                                        <div class="j-fx-row-xs j-align-center-xs j-justify-between-xs">
+                                            <div>
+                                                <div class="j-size-1.25-xs j-weight-600-xs">69<span class="j-size-0.875-xs">&nbsp;грн</span></div>
+                                            </div>
+                                        </div>
+                                        <div class="j-mt-10-xs">
+                                            <button type="button" class="j-btn main j-gap-5-xs"><span>Купити</span></button>
+                                        </div>
+                                    </a>
+                                </div>
+                                                                <div class="j-col-12-xs j-col-6-sm j-col-4-md j-col-3-bg j-col-2.4-xl">
+                                    <a href="https://winetime.com.ua/ua/warsteiner-premium-16652" class="product-micro" style="position: relative;">
+                                        <div data-productkey="16652"></div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-size-0.75-xs">
+                                            <div>
+                                                <div class="c-success"></div>
+                                            </div>
+                                            <div class="c-grey">Код: 09952686</div>
+                                        </div>
+                                        <div class="product-micro--title j-mv-15-xs">Пиво Warsteiner Premium світле фільтроване 0,5 л</div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-align-center-xs"></div>
+                                        <div class="j-fx-row-xs j-gap-10-xs j-mt-20-xs j-align-center-xs">
+                                            <div class="j-icon j-icon-20-xs">
+                                            </div>
+                                            <hr class="vertical-separator" style="height: 12px;">
+                                            <div class="j-grow-1-xs j-size-0.75-xs">
+                                                                                                    Warsteiner
+                                                                                            </div>
+                                        </div>
+                                        <hr class="j-mv-20-xs">
+                                        <div class="j-fx-row-xs j-align-center-xs j-justify-between-xs">
+                                            <div>
+                                                <div class="j-size-1.25-xs j-weight-600-xs">64<span class="j-size-0.875-xs">&nbsp;грн</span></div>
+                                            </div>
+                                        </div>
+                                        <div class="j-mt-10-xs">
+                                            <button type="button" class="j-btn main j-gap-5-xs"><span>Купити</span></button>
+                                        </div>
+                                    </a>
+                                </div>
+                                                                <div class="j-col-12-xs j-col-6-sm j-col-4-md j-col-3-bg j-col-2.4-xl">
+                                    <a href="https://winetime.com.ua/ua/pyvo-underwood-ipa-svitle-nefiltrovane-033-l" class="product-micro" style="position: relative;">
+                                        <div data-productkey="55823"></div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-size-0.75-xs">
+                                            <div>
+                                                <div class="c-success"></div>
+                                            </div>
+                                            <div class="c-grey">Код: 20969204</div>
+                                        </div>
+                                        <div class="product-micro--title j-mv-15-xs">Пиво Underwood IPA світле нефільтроване 0,33 л</div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-align-center-xs"></div>
+                                        <div class="j-fx-row-xs j-gap-10-xs j-mt-20-xs j-align-center-xs">
+                                            <div class="j-icon j-icon-20-xs">
+                                            </div>
+                                            <hr class="vertical-separator" style="height: 12px;">
+                                            <div class="j-grow-1-xs j-size-0.75-xs">
+                                                                                                    Underwood Brewery
+                                                                                            </div>
+                                        </div>
+                                        <hr class="j-mv-20-xs">
+                                        <div class="j-fx-row-xs j-align-center-xs j-justify-between-xs">
+                                            <div>
+                                                <div class="j-size-1.25-xs j-weight-600-xs">99<span class="j-size-0.875-xs">&nbsp;грн</span></div>
+                                            </div>
+                                        </div>
+                                        <div class="j-mt-10-xs">
+                                            <button type="button" class="j-btn main j-gap-5-xs"><span>Купити</span></button>
+                                        </div>
+                                    </a>
+                                </div>
+                                                                <div class="j-col-12-xs j-col-6-sm j-col-4-md j-col-3-bg j-col-2.4-xl">
+                                    <a href="https://winetime.com.ua/ua/pyvo-underwood-rising-sun-svitle-nefiltrovane-033-l" class="product-micro" style="position: relative;">
+                                        <div data-productkey="56710"></div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-size-0.75-xs">
+                                            <div>
+                                                <div class="c-success"></div>
+                                            </div>
+                                            <div class="c-grey">Код: 21224184</div>
+                                        </div>
+                                        <div class="product-micro--title j-mv-15-xs">Пиво Underwood Rising Sun світле нефільтроване 0,33 л</div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-align-center-xs"></div>
+                                        <div class="j-fx-row-xs j-gap-10-xs j-mt-20-xs j-align-center-xs">
+                                            <div class="j-icon j-icon-20-xs">
+                                            </div>
+                                            <hr class="vertical-separator" style="height: 12px;">
+                                            <div class="j-grow-1-xs j-size-0.75-xs">
+                                                                                                    Underwood Brewery
+                                                                                            </div>
+                                        </div>
+                                        <hr class="j-mv-20-xs">
+                                        <div class="j-fx-row-xs j-align-center-xs j-justify-between-xs">
+                                            <div>
+                                                <div class="j-size-1.25-xs j-weight-600-xs">89<span class="j-size-0.875-xs">&nbsp;грн</span></div>
+                                            </div>
+                                        </div>
+                                        <div class="j-mt-10-xs">
+                                            <button type="button" class="j-btn main j-gap-5-xs"><span>Купити</span></button>
+                                        </div>
+                                    </a>
+                                </div>
+                                                                <div class="j-col-12-xs j-col-6-sm j-col-4-md j-col-3-bg j-col-2.4-xl">
+                                    <a href="https://winetime.com.ua/ua/pyvo-underwood-ukrainian-tomato-gose-svitle-nefiltrovane-033-l" class="product-micro" style="position: relative;">
+                                        <div data-productkey="55832"></div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-size-0.75-xs">
+                                            <div>
+                                                <div class="c-success"></div>
+                                            </div>
+                                            <div class="c-grey">Код: 20969212</div>
+                                        </div>
+                                        <div class="product-micro--title j-mv-15-xs">Пиво Underwood Ukrainian Tomato Gose світле нефільтроване 0,33 л</div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-align-center-xs"></div>
+                                        <div class="j-fx-row-xs j-gap-10-xs j-mt-20-xs j-align-center-xs">
+                                            <div class="j-icon j-icon-20-xs">
+                                            </div>
+                                            <hr class="vertical-separator" style="height: 12px;">
+                                            <div class="j-grow-1-xs j-size-0.75-xs">
+                                                                                                    Underwood Brewery
+                                                                                            </div>
+                                        </div>
+                                        <hr class="j-mv-20-xs">
+                                        <div class="j-fx-row-xs j-align-center-xs j-justify-between-xs">
+                                            <div>
+                                                <div class="j-size-1.25-xs j-weight-600-xs">89<span class="j-size-0.875-xs">&nbsp;грн</span></div>
+                                            </div>
+                                        </div>
+                                        <div class="j-mt-10-xs">
+                                            <button type="button" class="j-btn main j-gap-5-xs"><span>Купити</span></button>
+                                        </div>
+                                    </a>
+                                </div>
+                                                                <div class="j-col-12-xs j-col-6-sm j-col-4-md j-col-3-bg j-col-2.4-xl">
+                                    <a href="https://winetime.com.ua/ua/pilsner-urquell" class="product-micro" style="position: relative;">
+                                        <div data-productkey="13"></div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-size-0.75-xs">
+                                            <div>
+                                                <div class="c-success"></div>
+                                            </div>
+                                            <div class="c-grey">Код: 17657878</div>
+                                        </div>
+                                        <div class="product-micro--title j-mv-15-xs">Пиво Pilsner Urquell світле фільтроване 0,5 л</div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-align-center-xs"></div>
+                                        <div class="j-fx-row-xs j-gap-10-xs j-mt-20-xs j-align-center-xs">
+                                            <div class="j-icon j-icon-20-xs">
+                                            </div>
+                                            <hr class="vertical-separator" style="height: 12px;">
+                                            <div class="j-grow-1-xs j-size-0.75-xs">
+                                                                                                    Pilsner Urquell
+                                                                                            </div>
+                                        </div>
+                                        <hr class="j-mv-20-xs">
+                                        <div class="j-fx-row-xs j-align-center-xs j-justify-between-xs">
+                                            <div>
+                                                <div class="j-size-1.25-xs j-weight-600-xs">85<span class="j-size-0.875-xs">&nbsp;грн</span></div>
+                                            </div>
+                                        </div>
+                                        <div class="j-mt-10-xs">
+                                            <button type="button" class="j-btn main j-gap-5-xs"><span>Купити</span></button>
+                                        </div>
+                                    </a>
+                                </div>
+                                                                <div class="j-col-12-xs j-col-6-sm j-col-4-md j-col-3-bg j-col-2.4-xl">
+                                    <a href="https://winetime.com.ua/ua/corona-extra" class="product-micro" style="position: relative;">
+                                        <div data-productkey="3089"></div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-size-0.75-xs">
+                                            <div>
+                                                <div class="c-success"></div>
+                                            </div>
+                                            <div class="c-grey">Код: 08290225</div>
+                                        </div>
+                                        <div class="product-micro--title j-mv-15-xs">Пиво Corona Extra світле фільтроване 0,33 л</div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-align-center-xs"></div>
+                                        <div class="j-fx-row-xs j-gap-10-xs j-mt-20-xs j-align-center-xs">
+                                            <div class="j-icon j-icon-20-xs">
+                                            </div>
+                                            <hr class="vertical-separator" style="height: 12px;">
+                                            <div class="j-grow-1-xs j-size-0.75-xs">
+                                                                                                    Corona Extra
+                                                                                            </div>
+                                        </div>
+                                        <hr class="j-mv-20-xs">
+                                        <div class="j-fx-row-xs j-align-center-xs j-justify-between-xs">
+                                            <div>
+                                                <div class="j-size-1.25-xs j-weight-600-xs">59<span class="j-size-0.875-xs">&nbsp;грн</span></div>
+                                            </div>
+                                        </div>
+                                        <div class="j-mt-10-xs">
+                                            <button type="button" class="j-btn main j-gap-5-xs"><span>Купити</span></button>
+                                        </div>
+                                    </a>
+                                </div>
+                                                                <div class="j-col-12-xs j-col-6-sm j-col-4-md j-col-3-bg j-col-2.4-xl">
+                                    <a href="https://winetime.com.ua/ua/pyvo-underwood-kyiv-lager-svitle-nefiltrovane-033-l" class="product-micro" style="position: relative;">
+                                        <div data-productkey="55820"></div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-size-0.75-xs">
+                                            <div>
+                                                <div class="c-success"></div>
+                                            </div>
+                                            <div class="c-grey">Код: 20969198</div>
+                                        </div>
+                                        <div class="product-micro--title j-mv-15-xs">Пиво Underwood Kyiv Lager світле нефільтроване 0,33 л</div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-align-center-xs"></div>
+                                        <div class="j-fx-row-xs j-gap-10-xs j-mt-20-xs j-align-center-xs">
+                                            <div class="j-icon j-icon-20-xs">
+                                            </div>
+                                            <hr class="vertical-separator" style="height: 12px;">
+                                            <div class="j-grow-1-xs j-size-0.75-xs">
+                                                                                                    Underwood Brewery
+                                                                                            </div>
+                                        </div>
+                                        <hr class="j-mv-20-xs">
+                                        <div class="j-fx-row-xs j-align-center-xs j-justify-between-xs">
+                                            <div>
+                                                <div class="j-size-1.25-xs j-weight-600-xs">64<span class="j-size-0.875-xs">&nbsp;грн</span></div>
+                                            </div>
+                                        </div>
+                                        <div class="j-mt-10-xs">
+                                            <button type="button" class="j-btn main j-gap-5-xs"><span>Купити</span></button>
+                                        </div>
+                                    </a>
+                                </div>
+                                                                <div class="j-col-12-xs j-col-6-sm j-col-4-md j-col-3-bg j-col-2.4-xl">
+                                    <a href="https://winetime.com.ua/ua/pyvo-schweden-pils-schwarzbrau-svitle-filtrovane-033-l" class="product-micro" style="position: relative;">
+                                        <div data-productkey="57739"></div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-size-0.75-xs">
+                                            <div>
+                                                <div class="c-success"></div>
+                                            </div>
+                                            <div class="c-grey">Код: 21363479</div>
+                                        </div>
+                                        <div class="product-micro--title j-mv-15-xs">Пиво Schweden Pils Schwarzbrau світле фільтроване 0,33 л</div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-align-center-xs"></div>
+                                        <div class="j-fx-row-xs j-gap-10-xs j-mt-20-xs j-align-center-xs">
+                                            <div class="j-icon j-icon-20-xs">
+                                            </div>
+                                            <hr class="vertical-separator" style="height: 12px;">
+                                            <div class="j-grow-1-xs j-size-0.75-xs">
+                                                                                                    Schwarzbrau
+                                                                                            </div>
+                                        </div>
+                                        <hr class="j-mv-20-xs">
+                                        <div class="j-fx-row-xs j-align-center-xs j-justify-between-xs">
+                                            <div>
+                                                <div class="j-size-1.25-xs j-weight-600-xs">144<span class="j-size-0.875-xs">&nbsp;грн</span></div>
+                                            </div>
+                                        </div>
+                                        <div class="j-mt-10-xs">
+                                            <button type="button" class="j-btn main j-gap-5-xs"><span>Купити</span></button>
+                                        </div>
+                                    </a>
+                                </div>
+                                                                <div class="j-col-12-xs j-col-6-sm j-col-4-md j-col-3-bg j-col-2.4-xl">
+                                    <a href="https://winetime.com.ua/ua/pyvo-st-feuillien-saison-svitle-nefiltrovane-033-l" class="product-micro" style="position: relative;">
+                                        <div data-productkey="57719"></div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-size-0.75-xs">
+                                            <div>
+                                                <div class="c-success"></div>
+                                            </div>
+                                            <div class="c-grey">Код: 21363433</div>
+                                        </div>
+                                        <div class="product-micro--title j-mv-15-xs">Пиво St-Feuillien Saison світле нефільтроване 0,33 л</div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-align-center-xs"></div>
+                                        <div class="j-fx-row-xs j-gap-10-xs j-mt-20-xs j-align-center-xs">
+                                            <div class="j-icon j-icon-20-xs">
+                                            </div>
+                                            <hr class="vertical-separator" style="height: 12px;">
+                                            <div class="j-grow-1-xs j-size-0.75-xs">
+                                                                                                    St-Feuillien
+                                                                                            </div>
+                                        </div>
+                                        <hr class="j-mv-20-xs">
+                                        <div class="j-fx-row-xs j-align-center-xs j-justify-between-xs">
+                                            <div>
+                                                <div class="j-size-1.25-xs j-weight-600-xs">167<span class="j-size-0.875-xs">&nbsp;грн</span></div>
+                                            </div>
+                                        </div>
+                                        <div class="j-mt-10-xs">
+                                            <button type="button" class="j-btn main j-gap-5-xs"><span>Купити</span></button>
+                                        </div>
+                                    </a>
+                                </div>
+                                                                <div class="j-col-12-xs j-col-6-sm j-col-4-md j-col-3-bg j-col-2.4-xl">
+                                    <a href="https://winetime.com.ua/ua/pyvo-aged-bock-2018-schwarzbrau-svitle-filtrovane-033-l" class="product-micro" style="position: relative;">
+                                        <div data-productkey="57728"></div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-size-0.75-xs">
+                                            <div>
+                                                <div class="c-success"></div>
+                                            </div>
+                                            <div class="c-grey">Код: 21363455</div>
+                                        </div>
+                                        <div class="product-micro--title j-mv-15-xs">Пиво Aged Bock 2018 Schwarzbrau світле фільтроване 0,33 л</div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-align-center-xs"></div>
+                                        <div class="j-fx-row-xs j-gap-10-xs j-mt-20-xs j-align-center-xs">
+                                            <div class="j-icon j-icon-20-xs">
+                                            </div>
+                                            <hr class="vertical-separator" style="height: 12px;">
+                                            <div class="j-grow-1-xs j-size-0.75-xs">
+                                                                                                    Schwarzbrau
+                                                                                            </div>
+                                        </div>
+                                        <hr class="j-mv-20-xs">
+                                        <div class="j-fx-row-xs j-align-center-xs j-justify-between-xs">
+                                            <div>
+                                                <div class="j-size-1.25-xs j-weight-600-xs">139<span class="j-size-0.875-xs">&nbsp;грн</span></div>
+                                            </div>
+                                        </div>
+                                        <div class="j-mt-10-xs">
+                                            <button type="button" class="j-btn main j-gap-5-xs"><span>Купити</span></button>
+                                        </div>
+                                    </a>
+                                </div>
+                                                                <div class="j-col-12-xs j-col-6-sm j-col-4-md j-col-3-bg j-col-2.4-xl">
+                                    <a href="https://winetime.com.ua/ua/pyvo-hefe-weissbier-dunkel-schwarzbrau-temne-nefiltrovane-05-l" class="product-micro" style="position: relative;">
+                                        <div data-productkey="57734"></div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-size-0.75-xs">
+                                            <div>
+                                                <div class="c-success"></div>
+                                            </div>
+                                            <div class="c-grey">Код: 21363475</div>
+                                        </div>
+                                        <div class="product-micro--title j-mv-15-xs">Пиво Hefe-Weissbier Dunkel Schwarzbrau темне нефільтроване 0,5 л</div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-align-center-xs"></div>
+                                        <div class="j-fx-row-xs j-gap-10-xs j-mt-20-xs j-align-center-xs">
+                                            <div class="j-icon j-icon-20-xs">
+                                            </div>
+                                            <hr class="vertical-separator" style="height: 12px;">
+                                            <div class="j-grow-1-xs j-size-0.75-xs">
+                                                                                                    Schwarzbrau
+                                                                                            </div>
+                                        </div>
+                                        <hr class="j-mv-20-xs">
+                                        <div class="j-fx-row-xs j-align-center-xs j-justify-between-xs">
+                                            <div>
+                                                <div class="j-size-1.25-xs j-weight-600-xs">149<span class="j-size-0.875-xs">&nbsp;грн</span></div>
+                                            </div>
+                                        </div>
+                                        <div class="j-mt-10-xs">
+                                            <button type="button" class="j-btn main j-gap-5-xs"><span>Купити</span></button>
+                                        </div>
+                                    </a>
+                                </div>
+                                                                <div class="j-col-12-xs j-col-6-sm j-col-4-md j-col-3-bg j-col-2.4-xl">
+                                    <a href="https://winetime.com.ua/ua/meteor-ipa-can" class="product-micro" style="position: relative;">
+                                        <div data-productkey="11476"></div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-size-0.75-xs">
+                                            <div>
+                                                <div class="c-success"></div>
+                                            </div>
+                                            <div class="c-grey">Код: 19644136</div>
+                                        </div>
+                                        <div class="product-micro--title j-mv-15-xs">Пиво Meteor IPA CAN світле 0,5 л</div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-align-center-xs"></div>
+                                        <div class="j-fx-row-xs j-gap-10-xs j-mt-20-xs j-align-center-xs">
+                                            <div class="j-icon j-icon-20-xs">
+                                            </div>
+                                            <hr class="vertical-separator" style="height: 12px;">
+                                            <div class="j-grow-1-xs j-size-0.75-xs">
+                                                                                                    Meteor
+                                                                                            </div>
+                                        </div>
+                                        <hr class="j-mv-20-xs">
+                                        <div class="j-fx-row-xs j-align-center-xs j-justify-between-xs">
+                                            <div>
+                                                <div class="j-size-1.25-xs j-weight-600-xs">189<span class="j-size-0.875-xs">&nbsp;грн</span></div>
+                                            </div>
+                                        </div>
+                                        <div class="j-mt-10-xs">
+                                            <button type="button" class="j-btn main j-gap-5-xs"><span>Купити</span></button>
+                                        </div>
+                                    </a>
+                                </div>
+                                                                <div class="j-col-12-xs j-col-6-sm j-col-4-md j-col-3-bg j-col-2.4-xl">
+                                    <a href="https://winetime.com.ua/ua/pyvo-st-feuillien-blonde-svitle-filtrovane-075-l" class="product-micro" style="position: relative;">
+                                        <div data-productkey="57723"></div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-size-0.75-xs">
+                                            <div>
+                                                <div class="c-success"></div>
+                                            </div>
+                                            <div class="c-grey">Код: 21363445</div>
+                                        </div>
+                                        <div class="product-micro--title j-mv-15-xs">Пиво St-Feuillien Blonde світле фільтроване 0,75 л</div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-align-center-xs"></div>
+                                        <div class="j-fx-row-xs j-gap-10-xs j-mt-20-xs j-align-center-xs">
+                                            <div class="j-icon j-icon-20-xs">
+                                            </div>
+                                            <hr class="vertical-separator" style="height: 12px;">
+                                            <div class="j-grow-1-xs j-size-0.75-xs">
+                                                                                                    St-Feuillien
+                                                                                            </div>
+                                        </div>
+                                        <hr class="j-mv-20-xs">
+                                        <div class="j-fx-row-xs j-align-center-xs j-justify-between-xs">
+                                            <div>
+                                                <div class="j-size-1.25-xs j-weight-600-xs">329<span class="j-size-0.875-xs">&nbsp;грн</span></div>
+                                            </div>
+                                        </div>
+                                        <div class="j-mt-10-xs">
+                                            <button type="button" class="j-btn main j-gap-5-xs"><span>Купити</span></button>
+                                        </div>
+                                    </a>
+                                </div>
+                                                                <div class="j-col-12-xs j-col-6-sm j-col-4-md j-col-3-bg j-col-2.4-xl">
+                                    <a href="https://winetime.com.ua/ua/pyvo-trio-stout-extra-can-staut-filtrovane-05-l" class="product-micro" style="position: relative;">
+                                        <div data-productkey="56104"></div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-size-0.75-xs">
+                                            <div>
+                                                <div class="c-success"></div>
+                                            </div>
+                                            <div class="c-grey">Код: 21153022</div>
+                                        </div>
+                                        <div class="product-micro--title j-mv-15-xs">Пиво Trio Stout Extra CAN темне фільтроване 0,5 л</div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-align-center-xs"></div>
+                                        <div class="j-fx-row-xs j-gap-10-xs j-mt-20-xs j-align-center-xs">
+                                            <div class="j-icon j-icon-20-xs">
+                                            </div>
+                                            <hr class="vertical-separator" style="height: 12px;">
+                                            <div class="j-grow-1-xs j-size-0.75-xs">
+                                                                                                    Trio Stout
+                                                                                            </div>
+                                        </div>
+                                        <hr class="j-mv-20-xs">
+                                        <div class="j-fx-row-xs j-align-center-xs j-justify-between-xs">
+                                            <div>
+                                                <div class="j-size-1.25-xs j-weight-600-xs">69<span class="j-size-0.875-xs">&nbsp;грн</span></div>
+                                            </div>
+                                        </div>
+                                        <div class="j-mt-10-xs">
+                                            <button type="button" class="j-btn main j-gap-5-xs"><span>Купити</span></button>
+                                        </div>
+                                    </a>
+                                </div>
+                                                                <div class="j-col-12-xs j-col-6-sm j-col-4-md j-col-3-bg j-col-2.4-xl">
+                                    <a href="https://winetime.com.ua/ua/pyvo-nabir-meteor-christmas-beer-2-bokala-gift-pack-svitle-filtrovane-065-l" class="product-micro" style="position: relative;">
+                                        <div data-productkey="56856"></div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-size-0.75-xs">
+                                            <div>
+                                                <div class="c-success"></div>
+                                            </div>
+                                            <div class="c-grey">Код: 21266308</div>
+                                        </div>
+                                        <div class="product-micro--title j-mv-15-xs">Пиво Набір Meteor Christmas Beer + 2 бокала Gift Pack світле фільтроване 0,65 л</div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-align-center-xs"></div>
+                                        <div class="j-fx-row-xs j-gap-10-xs j-mt-20-xs j-align-center-xs">
+                                            <div class="j-icon j-icon-20-xs">
+                                            </div>
+                                            <hr class="vertical-separator" style="height: 12px;">
+                                            <div class="j-grow-1-xs j-size-0.75-xs">
+                                                                                                    Meteor
+                                                                                            </div>
+                                        </div>
+                                        <hr class="j-mv-20-xs">
+                                        <div class="j-fx-row-xs j-align-center-xs j-justify-between-xs">
+                                            <div>
+                                                <div class="j-size-1.25-xs j-weight-600-xs">990<span class="j-size-0.875-xs">&nbsp;грн</span></div>
+                                            </div>
+                                        </div>
+                                        <div class="j-mt-10-xs">
+                                            <button type="button" class="j-btn main j-gap-5-xs"><span>Купити</span></button>
+                                        </div>
+                                    </a>
+                                </div>
+                                                                <div class="j-col-12-xs j-col-6-sm j-col-4-md j-col-3-bg j-col-2.4-xl">
+                                    <a href="https://winetime.com.ua/ua/pyvo-marie-hausbrendel-hell-svitle-filtrovane-05-l" class="product-micro" style="position: relative;">
+                                        <div data-productkey="57738"></div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-size-0.75-xs">
+                                            <div>
+                                                <div class="c-success"></div>
+                                            </div>
+                                            <div class="c-grey">Код: 21363461</div>
+                                        </div>
+                                        <div class="product-micro--title j-mv-15-xs">Пиво Marie Hausbrendel Hell світле фільтроване 0,5 л</div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-align-center-xs"></div>
+                                        <div class="j-fx-row-xs j-gap-10-xs j-mt-20-xs j-align-center-xs">
+                                            <div class="j-icon j-icon-20-xs">
+                                            </div>
+                                            <hr class="vertical-separator" style="height: 12px;">
+                                            <div class="j-grow-1-xs j-size-0.75-xs">
+                                                                                                    Marie Hausbrendel
+                                                                                            </div>
+                                        </div>
+                                        <hr class="j-mv-20-xs">
+                                        <div class="j-fx-row-xs j-align-center-xs j-justify-between-xs">
+                                            <div>
+                                                <div class="j-size-1.25-xs j-weight-600-xs">177<span class="j-size-0.875-xs">&nbsp;грн</span></div>
+                                            </div>
+                                        </div>
+                                        <div class="j-mt-10-xs">
+                                            <button type="button" class="j-btn main j-gap-5-xs"><span>Купити</span></button>
+                                        </div>
+                                    </a>
+                                </div>
+                                                                <div class="j-col-12-xs j-col-6-sm j-col-4-md j-col-3-bg j-col-2.4-xl">
+                                    <a href="https://winetime.com.ua/ua/pyvo-st-feuillien-belgian-coast-ipa-svitle-filtrovane-033-l" class="product-micro" style="position: relative;">
+                                        <div data-productkey="57718"></div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-size-0.75-xs">
+                                            <div>
+                                                <div class="c-success"></div>
+                                            </div>
+                                            <div class="c-grey">Код: 21363435</div>
+                                        </div>
+                                        <div class="product-micro--title j-mv-15-xs">Пиво St-Feuillien Belgian Coast IPA світле фільтроване 0,33 л</div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-align-center-xs"></div>
+                                        <div class="j-fx-row-xs j-gap-10-xs j-mt-20-xs j-align-center-xs">
+                                            <div class="j-icon j-icon-20-xs">
+                                            </div>
+                                            <hr class="vertical-separator" style="height: 12px;">
+                                            <div class="j-grow-1-xs j-size-0.75-xs">
+                                                                                                    St-Feuillien
+                                                                                            </div>
+                                        </div>
+                                        <hr class="j-mv-20-xs">
+                                        <div class="j-fx-row-xs j-align-center-xs j-justify-between-xs">
+                                            <div>
+                                                <div class="j-size-1.25-xs j-weight-600-xs">177<span class="j-size-0.875-xs">&nbsp;грн</span></div>
+                                            </div>
+                                        </div>
+                                        <div class="j-mt-10-xs">
+                                            <button type="button" class="j-btn main j-gap-5-xs"><span>Купити</span></button>
+                                        </div>
+                                    </a>
+                                </div>
+                                                                <div class="j-col-12-xs j-col-6-sm j-col-4-md j-col-3-bg j-col-2.4-xl">
+                                    <a href="https://winetime.com.ua/ua/pyvo-x-mark-flavoured-beer-cannabis-can-svitle-filtrovane-05-l" class="product-micro" style="position: relative;">
+                                        <div data-productkey="56099"></div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-size-0.75-xs">
+                                            <div>
+                                                <div class="c-success"></div>
+                                            </div>
+                                            <div class="c-grey">Код: 21153034</div>
+                                        </div>
+                                        <div class="product-micro--title j-mv-15-xs">Пиво X-mark Flavoured Beer Cannabis CAN світле фільтроване 0,5 л</div>
+                                        <div class="j-fx-row-xs j-justify-between-xs j-align-center-xs"></div>
+                                        <div class="j-fx-row-xs j-gap-10-xs j-mt-20-xs j-align-center-xs">
+                                            <div class="j-icon j-icon-20-xs">
+                                            </div>
+                                            <hr class="vertical-separator" style="height: 12px;">
+                                            <div class="j-grow-1-xs j-size-0.75-xs">
+                                                                                                    X-mark
+                                                                                            </div>
+                                        </div>
+                                        <hr class="j-mv-20-xs">
+                                        <div class="j-fx-row-xs j-align-center-xs j-justify-between-xs">
+                                            <div>
+                                                <div class="j-size-1.25-xs j-weight-600-xs">69<span class="j-size-0.875-xs">&nbsp;грн</span></div>
+                                            </div>
+                                        </div>
+                                        <div class="j-mt-10-xs">
+                                            <button type="button" class="j-btn main j-gap-5-xs"><span>Купити</span></button>
+                                        </div>
+                                    </a>
+                                </div>
+                                                            </div>
+                            <div class="j-mt-30-xs">
+                                <div class="j-fx-col-xs j-align-center-xs j-pt-30-xs">
+                                    <div class="the-pagination j-gap-10-xs j-gap-20-bg">
+                                        <div class="the-pagination--prev disabled">
+                                            <div class="j-icon j-icon-16-xs j-icon-20-bg">
+                                                <svg width="22" height="8" viewBox="0 0 22 8" fill="none"
+                                                     xmlns="http://www.w3.org/2000/svg">
+                                                    <path fill-rule="evenodd" clip-rule="evenodd"
+                                                          d="M0.646447 4.3534C0.451184 4.15814 0.451184 3.84156 0.646447 3.6463L3.82843 0.464318C4.02369 0.269056 4.34027 0.269056 4.53553 0.464318C4.7308 0.65958 4.7308 0.976162 4.53553 1.17142L2.20711 3.49985H21C21.2761 3.49985 21.5 3.72371 21.5 3.99985C21.5 4.27599 21.2761 4.49985 21 4.49985H2.20711L4.53553 6.82828C4.7308 7.02354 4.7308 7.34012 4.53553 7.53539C4.34027 7.73065 4.02369 7.73065 3.82843 7.53539L0.646447 4.3534Z"
+                                                          fill="black"></path>
+                                                </svg>
+                                            </div>
+                                        </div>
+
+                                        <div class="the-pagination--pages">
+                                                                                            <a
+                                                        href="https://winetime.com.ua/ua/napoyi-slaboalkogolni/pyvo?page=1"
+                                                        class="the-pagination--page"
+                                                >1</a>
+                                                                                    </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="j-pv-20-xs j-pv-30-bg">
+                                <div class="the-expandable">
+                                    <div class="the-expandable--article" style="max-height: 400px;">
+                                        <article class="article">
+                                            <h2>Пиво це ...</h2><p><strong>Пиво</strong> є одним із найпоширеніших слабоалкогольних напоїв у світі. Крім того, це дуже давній напій, який вживали у Стародавньому Єгипті, Римі та Греції. А ширшу популярність пивоваріння набуло у європейських країнах, оскільки на той час ще не виготовлялися гарні вина. І одним із лідерів було німецьке пиво.</p><h2>Коротка історія виникнення пива</h2><p>Вважають, що пивоваріння з'явилося приблизно 10 000 років тому. І є припущення, що цей напій із ячмінних зерен змогли виготовити раніше за хліб, який випікали вже з відходів пивоваріння. Приблизно 1600 року до н.е. цар Вавилона Хаммурапі випустив Регламент, на підставі якого потрібно було виготовляти та пити пиво. Приблизно у 1200-1300 роках до н. у Стародавньому Єгипті вперше виготовили пшеничне пиво.</p><p>Оскільки ченці називали пиво рідким хлібом, а рідина не може порушити піст, то навіть найміцніше пиво можна було вживати під час посту. Тоді пиво вважалося цілющим напоєм, здатним вилікувати від багатьох недуг. Є монастирські броварні тих часів, які продовжують займатися пивоварінням і зараз.</p><p>І лише у 13 столітті н.е. стали з'являтися професійні пивоварні, які почали виготовляти цей напій високої якості, як чеське пиво. Для створення різних уподобань, у процесі виготовлення стали додавати різні складові: кмин, кору дуба, різні ягоди та інше. А на початку 16 століття нашої ери було закладено фундамент з культури виробництва пива і було встановлено, що цей слабоалкогольний напій потрібно виготовляти із солоду ячменю, хмелю та води.</p><p>Якщо ви надаєте перевагу тільки якісній продукції, то купити пиво відмінного виробництва можна в нашому інтернет-магазині winetime.com.ua, де представлений широкий асортимент пива за доступними цінами.</p><h2>Склад та де замовити пиво за найкращою ціною</h2><p>Найголовніше у виготовленні – це суворе дотримання пропорцій та температури. Все впливає на пиво – калорійність, ступінь гіркоти та солодкості. Мало хто замислюється, що пивоваріння є дуже трудомістким та складним процесом.</p><h3>Розглянемо найголовніші складові під час виготовлення пива:</h3><ol><li><i><strong>Хміль</strong></i> – сімейство конопельних рослин, які застосовуються завдяки тому, що мають антибактеріальну властивість, здатні врегулювати смак солодкість/гіркоту (наприклад, створити пиво м'яке) і підвищити термін зберігання. Також на запах та смак пива може залежати від того, в якому регіоні вирощувався хміль.</li><li><i><strong>Дріжджі</strong></i> – їх класифікують як гриби, а основною їх функцією є процес бродіння: цукор перетворюється на алкоголь. Завдяки різним сортам дріжджів можна виготовити живе пиво з різними смаковими відтінками.</li><li><i><strong>Солод із ячменю</strong></i>. Сьогодні у пивоварстві використовуються зерна пшениці, жита, рису, кукурудзи. Але саме ячмінні зерна вважаються лідером процесу складання. Зерна замочуються, проростають, а при збільшенні температури їхнє зростання зупиняється. Важливо знати, що температурний показник безпосередньо впливає на зовнішній вигляд та смак солоду, а отже, і на сам смак напою.</li><li><i><strong>Вода</strong>.</i> Це важливий компонент у пивоварінні, який повинен відповідати певним показникам (рН, мінерали та інше). Залежно від того, де виготовляється пиво, і яка вода використовується присмаком пива може значно відрізнятися. Бажано використовувати лише дистильовану воду, до якої додають різні сполуки.</li></ol><p>Таким чином, на смак, колір та якість пива впливають компоненти, з яких воно вариться. Купити пиво онлайн можна у нас на сайті Winetime, де кожен зможе вибрати напій виходячи зі своїх смакових уподобань.</p><h2>Класифікація та як вигідно купити пиво</h2><p>Якої єдиної класифікації пива немає, але воно може поділятися на дві групи на кшталт бродіння:</p><ul><li>нижче – бродильний процес здійснюється під дією невисокої температури від 5 до 100С, виходять лагери та інші аналоги;</li><li>верхнє – бродіння здійснюється при підвищеній температурі від 15 до 250С, виходять елі, портери та стаути.</li></ul><p>Крім того, пиво може підрозділятися на 2 категорії: макро – виробництво великих пивоварних компаній, що випускають марочне пиво та крафтове – від невеликих виробників, які можуть експериментувати із виробництвом цього напою.</p><p>Ви можете купити пиво у нас будь-яких марок та на будь-який смак <a href="/ua/napoyi-slaboalkogolni/svitle">світле пиво</a>, <a href="/ua/napoyi-slaboalkogolni/temne">темне пиво</a> як у бляшанках, так і в пляшках. Зробити замовлення можна на сайті товару або зателефонуємо нашим операторам.</p><h2>Технологія пивоваріння</h2><p>Процес пивоваріння налічує кілька тисяч років. Але, звісно, сучасна технологія значно відрізняється від тих часів.</p><h3>Розглянемо основні етапи пивоваріння:</h3><ol><li><i><strong>Подрібнення зерен солоду</strong></i> так, щоб не дуже дрібно розмоловся центр зерна, де міститься крохмаль, інакше пиво буде в'язким. Але й не дуже велико, щоб забезпечити потрібну кількість цукрів для бродильного процесу.</li><li><i><strong>Затирання</strong>.</i> Дроблені зерна змішують із водою, температура якої становить 50-70 С. Завдяки цьому активізуються ферменти ячменю і крохмаль перетворюється на бродильні цукри. Таким чином виходить сусло – густа та солодка рідина.</li><li><i><strong>Фільтрація</strong>.</i> Потім сусло фільтрується і від нього відокремлюється пивна дробина, що дозволяє стати суслу прозорішим.</li><li><i><strong>Кип'ячення</strong>.</i> Далі сусло кип'ятиться протягом 1,5-2 годин. Це дозволяє позбутися різних бактерій. У період кип'ятіння в сусло додається хміль, а його кількість залежить від того, яке пиво марки готується.</li><li><i><strong>Процес ферментації</strong>.</i> Охолоджене сусло поміщають у ферментер і додають до нього дріжджі, які споживають цукор і утворюється алкоголь та вуглекислота. Ферментація триває від 1,5-2 тижнів, якщо готується елі і приблизно 2 місяці, якщо лагер. Потім забираються дріжджі і виходить готовий напій для тари на продаж: пиво в банку бляшаній або пляшці (скляній або пластиковій).</li></ol><p>Як видно не тільки від складових компонентів залежатиме якість напою та його марка, а й від дотримання технологічного процесу.</p><p>У нашому магазині на&nbsp;<a href="/ua/napoyi-slaboalkogolni/bezalkogolne">безалкогольне пиво</a> ціна доступна, а якість висока. При виборі товару ми можемо проконсультувати вас за телефоном, вказаним на сайті winetime.com.ua. Також у нас є фото пиво для всього асортименту. Замовлення здійснюється по Україні.</p>
+                                        </article>
+
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </div>
+    </div>
+
+    <footer id="footer">
+    <div class="j-container j-mw-1600 j-ph-15 j-pv-50">
+        <div class="j-fx-col j-fx-row-bg j-gap-40 j-gap-20-bg j-justify-between">
+            <div class="j-fx-col j-align-center j-align-start-bg">
+                <div>
+                                            <div>
+                            <a href="/" class="footer-logo">
+                                <img src="/img/footer-logo.svg?v=1" alt="WineTime">
+                            </a>
+                        </div>
+                    
+                </div>
+                <div class="j-mt-30 j-h-center j-h-left-bg">
+                                                                        <div>
+                                                                    Пн-Пт
+                                                                9:00-20:00
+                            </div>
+                                                                                                <div>
+                                                                    Сб
+                                                                10:00-18:00
+                            </div>
+                                                                                                <div>
+                                                                    Нд
+                                                                10:00-15:00
+                            </div>
+                                                            </div>
+                <div class="j-mt-30">
+                    <a class="j-btn main"
+                       href="https://winetime.com.ua/ua/contacts">Зв&#039;язатись з нами</a>
+                </div>
+            </div>
+
+            <div>
+                <div class="j-fx-col j-fx-row-bg j-gap-10 j-gap-20-bg j-align-center">
+                    <a href="tel:0 800 330 370" class="j-size-2.5 j-weight-700">0 800 330 370</a>
+                    <div class="j-size-0.875 j-h-center j-h-left-bg">
+                        Безкоштовно <br>з усіх операторів України
+                    </div>
+                </div>
+
+                <div class="j-fx-col j-fx-row-bg j-align-center j-justify-between j-gap-10 j-mt-40 j-weight-600">
+                                                                                                                    <div>
+                                <a style="color: inherit" href="tel:+38 067 239 90 97">+38 067 239 90 97</a>
+                            </div>
+                                                                                                <div>
+                                <a style="color: inherit" href="tel:+38 050 315 37 37">+38 050 315 37 37</a>
+                            </div>
+                                                                                                <div>
+                                <a style="color: inherit" href="tel:+38 093 957 68 97">+38 093 957 68 97</a>
+                            </div>
+                                                            </div>
+
+                <div class="j-fx-col j-fx-row-bg j-gap-20 j-justify-between j-mt-40">
+                    <div class="j-size-0.875 j-h-center j-h-left-bg">
+                        Слідкуйте за нашими новинами<br>та акціями в соцмережах
+                    </div>
+                    <div class="j-fx-row j-gap-20 j-justify-center j-justify-between-bg">
+                        <a
+                                href="https://www.facebook.com/winetime.ukraine/"
+                                target="_blank"
+                        >
+                            <svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                <path d="M17.5512 0C7.8735 0 0 7.8735 0 17.5512C0 27.2282 7.8735 35.1024 17.5512 35.1024C27.2282 35.1024 35.1024 27.2282 35.1024 17.5512C35.1024 7.8735 27.2296 0 17.5512 0ZM21.916 18.1691H19.0606C19.0606 22.7311 19.0606 28.3465 19.0606 28.3465H14.8294C14.8294 28.3465 14.8294 22.7856 14.8294 18.1691H12.818V14.572H14.8294V12.2454C14.8294 10.5791 15.6212 7.97532 19.0995 7.97532L22.2348 7.98733V11.479C22.2348 11.479 20.3296 11.479 19.9591 11.479C19.5887 11.479 19.062 11.6643 19.062 12.4589V14.5728H22.2858L21.916 18.1691Z"
+                                      fill="#FF5000"></path>
+                            </svg>
+                        </a>
+                        <a
+                                href="https://www.youtube.com/user/WineTimeUkraine"
+                                target="_blank"
+                        >
+                            <svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                <path d="M14.4519 21.5478C17.104 20.1724 19.733 18.8098 22.3862 17.4339C19.7251 16.0453 17.0968 14.6748 14.4519 13.2944C14.4519 16.055 14.4519 18.7874 14.4519 21.5478Z"
+                                      fill="#FF5000"></path>
+                                <path d="M17.6742 0C7.91334 0 0 7.91298 0 17.6742C0 27.4355 7.91334 35.3484 17.6742 35.3484C27.435 35.3484 35.3484 27.4355 35.3484 17.6742C35.3484 7.91298 27.435 0 17.6742 0ZM29.7165 23.5736C29.4106 24.9008 28.3251 25.8797 27.0184 26.0255C23.9241 26.3715 20.7925 26.3733 17.6735 26.3715C14.5545 26.3733 11.4221 26.3715 8.32704 26.0255C7.0205 25.8797 5.93564 24.9008 5.63043 23.5736C5.19541 21.6831 5.19541 19.6201 5.19541 17.6742C5.19541 15.7283 5.20046 13.6646 5.6355 11.7747C5.94071 10.4476 7.02557 9.46832 8.3321 9.32221C11.4272 8.9765 14.5595 8.9747 17.6785 8.9765C20.7968 8.9747 23.9292 8.9765 27.0231 9.32221C28.3305 9.46832 29.416 10.4472 29.7212 11.7747C30.1562 13.6649 30.1526 15.7283 30.1526 17.6742C30.1526 19.6201 30.1515 21.6835 29.7165 23.5736Z"
+                                      fill="#FF5000"></path>
+                            </svg>
+                        </a>
+                        <a
+                                href="https://t.me/WINETIME_bot"
+                                target="_blank"
+                        >
+                            <svg width="37" height="37" viewBox="0 0 37 37" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                <path d="M18.5298 0C23.469 0.0302376 27.6825 1.65299 31.2004 4.96905C34.7082 8.2851 36.6234 12.3974 36.8553 17.2254C37.0972 22.3859 35.4441 26.9014 31.8657 30.6408C28.3477 34.3197 24.0033 36.2146 18.9028 36.265C14.1551 36.3154 9.99202 34.7229 6.50433 31.5076C2.39168 27.7077 0.415994 22.9503 0.627674 17.3564C0.799035 12.6696 2.60336 8.63788 5.91969 5.3319C9.41746 1.83441 13.6914 0.0907128 18.5298 0Z"
+                                      fill="#FF5000"></path>
+                                <path d="M13.1673 20.5811C12.1795 20.2787 11.1816 19.9662 10.1937 19.6639C9.7099 19.5127 9.22606 19.3615 8.74222 19.2103C8.56078 19.1498 8.38942 19.0893 8.23822 18.9785C7.95598 18.7668 7.93582 18.5048 8.17774 18.2427C8.33902 18.0613 8.54062 17.9403 8.76238 17.8496C9.34702 17.6178 9.93166 17.386 10.5163 17.1541C14.5483 15.6019 18.5803 14.0397 22.6224 12.4875C23.9026 11.9936 25.1727 11.4997 26.4528 11.0058C26.6242 10.9353 26.8056 10.895 26.9971 10.9252C27.3802 10.9857 27.6725 11.2981 27.7128 11.7013C27.733 11.923 27.7229 12.1448 27.6826 12.3665C27.1887 14.6847 26.6947 17.013 26.2008 19.3313C25.7976 21.2463 25.3843 23.1613 24.9811 25.0865C24.8904 25.5199 24.7997 25.9533 24.709 26.3867C24.6687 26.5984 24.6082 26.7999 24.5074 26.9914C24.3058 27.3644 23.9832 27.5055 23.5699 27.4249C23.3179 27.3745 23.0962 27.2636 22.8946 27.1124C21.5035 26.0843 20.1125 25.0462 18.7114 24.0181C18.6509 23.9677 18.5803 23.9274 18.5198 23.8871C18.2779 23.8165 18.1066 23.6351 17.915 23.494C17.2498 23.0102 16.5845 22.5062 15.9192 22.0224C15.8688 21.9821 15.8184 21.9418 15.7781 21.8914C15.7176 21.7906 15.7781 21.7301 15.8386 21.6696C16.7458 20.8633 17.6429 20.0368 18.5501 19.2305C19.2053 18.6358 19.8706 18.0411 20.5258 17.4464C21.181 16.8518 21.8362 16.2672 22.4914 15.6826C23.0054 15.2189 23.5195 14.7654 24.0235 14.3017C24.0639 14.2614 24.1042 14.2211 24.1445 14.1808C24.1747 14.1405 24.2151 14.1001 24.1949 14.0497C24.1747 13.9893 24.1143 13.9893 24.0639 13.9893C23.8824 13.9691 23.7312 14.0397 23.58 14.1304C23.0256 14.463 22.4914 14.8158 21.947 15.1585C20.2939 16.1966 18.6307 17.2449 16.9776 18.283C15.8386 18.9986 14.6995 19.7143 13.5605 20.44C13.4294 20.5105 13.3387 20.6415 13.1673 20.5811Z"
+                                      fill="black"></path>
+                                <path d="M13.1672 20.5821C13.4394 20.4712 13.6712 20.2898 13.9232 20.1386C14.649 19.685 15.3748 19.2314 16.1005 18.7678C16.6146 18.4453 17.1186 18.1127 17.6327 17.7901C18.4794 17.2559 19.3362 16.7217 20.193 16.1875C20.7877 15.8146 21.3825 15.4316 21.9873 15.0486C22.5114 14.716 23.0356 14.3833 23.5597 14.0507C23.7311 13.9499 23.9025 13.8895 24.1141 13.9096C24.1746 13.9197 24.2351 13.9197 24.2553 13.9802C24.2855 14.0407 24.2653 14.1011 24.2149 14.1616C24.094 14.2826 23.9831 14.4136 23.842 14.5245C23.59 14.726 23.3682 14.9579 23.1263 15.1695C22.7332 15.5021 22.3703 15.865 21.9772 16.1976C21.8159 16.3387 21.6647 16.4899 21.5034 16.631C21.2716 16.8225 21.0498 17.0543 20.8281 17.2559C20.4853 17.5684 20.1325 17.8707 19.7898 18.1731C19.6386 18.3142 19.4773 18.4553 19.3362 18.5965C18.9633 18.9492 18.5701 19.2818 18.1972 19.6346C17.7436 20.0479 17.2799 20.451 16.8364 20.8744C16.5138 21.1767 16.1711 21.4589 15.8384 21.7512C15.788 21.7916 15.788 21.8319 15.8183 21.8823C15.7477 23.0212 15.6671 24.1602 15.5965 25.2991C15.5764 25.6015 15.536 25.8938 15.5461 26.1962C15.5461 26.2869 15.5461 26.3675 15.4756 26.4381C15.4151 26.4582 15.3445 26.4582 15.284 26.4582C15.1026 26.4482 14.9716 26.3574 14.9212 26.1861C14.8708 26.0047 14.8103 25.8333 14.7599 25.6519C14.266 24.0291 13.772 22.3963 13.2781 20.7736C13.2277 20.703 13.1975 20.6425 13.1672 20.5821Z"
+                                      fill="black"></path>
+                                <path d="M15.4455 26.4276C15.4152 26.0345 15.4858 25.6414 15.4959 25.2584C15.516 24.835 15.5563 24.4117 15.5765 23.9884C15.6067 23.555 15.637 23.1216 15.6672 22.6983C15.6773 22.4765 15.6975 22.2548 15.6975 22.0431C15.6975 21.9725 15.7176 21.9222 15.7882 21.8818C16.6047 22.4866 17.4212 23.0813 18.2276 23.686C18.3183 23.7566 18.4191 23.807 18.4896 23.8977C17.7336 24.6335 16.9676 25.3692 16.2116 26.105C16.0099 26.3066 15.768 26.4679 15.4455 26.4276Z"
+                                      fill="black"></path>
+                            </svg>
+                        </a>
+                        <a
+                                href="https://instagram.com/winetime.ua"
+                                target="_blank"
+                        >
+                            <svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                <path d="M0 17.5427V18.5131C0.253125 27.8224 7.74844 35.2966 16.6711 35.9998H19.4133C28.3852 35.2896 35.7539 27.7521 36 18.499V17.5427C35.7539 8.1279 28.132 0.491966 18.9422 0.020872C9.05625 -0.478347 0.274219 7.4529 0 17.5427Z"
+                                      fill="#FF5000"></path>
+                                <path d="M18.0844 9.04248C20.9532 9.04248 21.2907 9.04951 22.4297 9.10576C23.4774 9.14795 24.0399 9.33076 24.4196 9.47842C24.9188 9.67529 25.2774 9.91436 25.65 10.294C26.0227 10.6737 26.2618 11.0394 26.4586 11.5456C26.6063 11.9323 26.775 12.5089 26.8313 13.5776C26.8875 14.7308 26.8946 15.0753 26.8946 17.9933C26.8946 20.9112 26.8875 21.2558 26.8313 22.4089C26.7891 23.4706 26.6133 24.0542 26.4586 24.4409C26.2618 24.9472 26.0297 25.3128 25.65 25.6925C25.2774 26.0722 24.9188 26.3112 24.4196 26.5081C24.0399 26.6628 23.4704 26.8386 22.4297 26.8808C21.2977 26.937 20.9532 26.944 18.0844 26.944C15.2157 26.944 14.8782 26.937 13.7391 26.8808C12.6915 26.8386 12.129 26.6558 11.7493 26.5081C11.25 26.3112 10.8915 26.0722 10.5188 25.6925C10.1461 25.3128 9.90708 24.9472 9.71021 24.4409C9.56255 24.0542 9.3938 23.4776 9.33755 22.4089C9.2813 21.2558 9.27427 20.9112 9.27427 17.9933C9.27427 15.0753 9.2813 14.7308 9.33755 13.5776C9.37974 12.5159 9.55552 11.9323 9.71021 11.5456C9.90708 11.0394 10.1391 10.6737 10.5188 10.294C10.8915 9.91436 11.25 9.67529 11.7493 9.47842C12.129 9.32373 12.6985 9.14795 13.7391 9.10576C14.8711 9.05654 15.2157 9.04248 18.0844 9.04248ZM18.0844 7.07373C15.1665 7.07373 14.8008 7.08779 13.6618 7.14404C12.5227 7.20029 11.7352 7.38311 11.0532 7.65029C10.343 7.93154 9.74536 8.3042 9.15474 8.91592C8.55708 9.52764 8.19146 10.1323 7.91724 10.8565C7.65005 11.5456 7.46724 12.3472 7.41802 13.5073C7.36177 14.6675 7.35474 15.0401 7.35474 18.0073C7.35474 20.9745 7.3688 21.3472 7.41802 22.5073C7.47427 23.6675 7.65708 24.462 7.91724 25.1581C8.19146 25.8753 8.55708 26.487 9.15474 27.0987C9.75239 27.7105 10.35 28.0831 11.0532 28.3644C11.7352 28.6386 12.5227 28.8214 13.6618 28.8706C14.8079 28.9269 15.1735 28.9409 18.0844 28.9409C20.9954 28.9409 21.368 28.9269 22.5071 28.8706C23.6461 28.8144 24.4336 28.6315 25.1157 28.3644C25.8258 28.0831 26.4235 27.7105 27.0141 27.0987C27.6118 26.487 27.9774 25.8823 28.2516 25.1581C28.5188 24.469 28.7016 23.6675 28.7508 22.5073C28.8071 21.3472 28.8141 20.9745 28.8141 18.0073C28.8141 15.0401 28.8 14.6675 28.7508 13.5073C28.6946 12.3472 28.5118 11.5526 28.2516 10.8565C27.9774 10.1394 27.6118 9.52764 27.0141 8.91592C26.4165 8.3042 25.8188 7.93154 25.1157 7.65029C24.4336 7.37607 23.6461 7.19326 22.5071 7.14404C21.368 7.08779 20.9954 7.07373 18.0844 7.07373Z"
+                                      fill="black"></path>
+                                <path d="M18.0843 12.3896C15.0327 12.3896 12.5718 14.8998 12.5718 18.0006C12.5718 21.1014 15.0397 23.6115 18.0843 23.6115C21.1288 23.6115 23.5968 21.1014 23.5968 18.0006C23.5968 14.8998 21.1288 12.3896 18.0843 12.3896ZM18.0843 21.6428C16.1085 21.6428 14.5054 20.0186 14.5054 18.0006C14.5054 15.9826 16.1085 14.3584 18.0843 14.3584C20.0601 14.3584 21.6632 15.9826 21.6632 18.0006C21.6632 20.0186 20.0601 21.6428 18.0843 21.6428Z"
+                                      fill="black"></path>
+                                <path d="M23.815 13.4721C24.5257 13.4721 25.1018 12.8865 25.1018 12.1643C25.1018 11.442 24.5257 10.8564 23.815 10.8564C23.1044 10.8564 22.5283 11.442 22.5283 12.1643C22.5283 12.8865 23.1044 13.4721 23.815 13.4721Z"
+                                      fill="black"></path>
+                            </svg>
+                        </a>
+                    </div>
+                </div>
+
+                <div class="j-fx-col j-fx-row-bg j-gap-20 j-mt-40">
+                    <a href="https://apps.apple.com/ua/app/winetime-new/id6746325462?l=uk"
+                       target="_blank"
+                       class="app-link"
+                    >
+                        <svg xmlns="http://www.w3.org/2000/svg" height="40" width="135"
+                            viewBox="3.552713678800501e-15 -8.881784197001252e-16 540.0040000000001 160">
+                            <linearGradient id="a" gradientTransform="matrix(4.0022 0 0 4.0011 191.95 -349.736)"
+                                gradientUnits="userSpaceOnUse" x1="-23.235" x2="-23.235" y1="97.431" y2="61.386">
+                                  <stop offset="0" stop-color="#1a1a1a" stop-opacity=".1"/>
+                                  <stop offset=".123" stop-color="#212121" stop-opacity=".151"/>
+                                  <stop offset=".308" stop-color="#353535" stop-opacity=".227"/>
+                                  <stop offset=".532" stop-color="#575757" stop-opacity=".318"/>
+                                  <stop offset=".783" stop-color="#858585" stop-opacity=".421"/>
+                                  <stop offset="1" stop-color="#b3b3b3" stop-opacity=".51"/>
+                            </linearGradient>
+                            <path
+                                d="M536.418 141.11a15.328 15.324 0 0 1-15.345 15.325H18.926a15.348 15.344 0 0 1-15.364-15.324V18.905A15.368 15.364 0 0 1 18.926 3.561H521.07a15.344 15.34 0 0 1 15.345 15.344z"
+                                fill="#fff"/>
+                            <path
+                                d="M521.073 160H18.926A18.93 18.925 0 0 1 0 141.11V18.91A18.942 18.937 0 0 1 18.926 0H521.07a18.95 18.945 0 0 1 18.926 18.91v122.2c.008 10.42-8.496 18.89-18.922 18.89z"
+                                fill="#a6a6a6"/>
+                            <path
+                                d="M536.418 141.11a15.328 15.324 0 0 1-15.345 15.325H18.926a15.348 15.344 0 0 1-15.364-15.324V18.905A15.368 15.364 0 0 1 18.926 3.561H521.07a15.344 15.34 0 0 1 15.345 15.344z"/>
+                            <path
+                                d="M120.577 79.158c-.116-12.896 10.562-19.17 11.05-19.462-6.047-8.814-15.42-10.018-18.714-10.114-7.872-.829-15.508 4.709-19.519 4.709-4.09 0-10.265-4.63-16.92-4.493-8.565.132-16.578 5.09-20.972 12.787-9.069 15.697-2.305 38.763 6.383 51.45 4.347 6.218 9.425 13.152 16.073 12.908 6.504-.264 8.933-4.141 16.781-4.141 7.776 0 10.058 4.14 16.837 3.985 6.98-.108 11.374-6.242 15.569-12.512 5.022-7.118 7.04-14.135 7.12-14.496-.16-.056-13.552-5.169-13.688-20.621zM107.77 41.235c3.498-4.373 5.891-10.323 5.227-16.36-5.063.224-11.394 3.5-15.04 7.778-3.226 3.769-6.107 9.947-5.363 15.756 5.687.424 11.526-2.868 15.176-7.174z"
+                                fill="#fff"/>
+                            <path
+                                d="M130.198 0H62.993l26.323 39.989h40.882a4.733 4.733 0 0 0 4.729-4.724V4.726A4.734 4.734 0 0 0 130.198 0z"
+                                fill="url(#a)" transform="scale(4.00216 4.0011)"/>
+                            <g fill="#fff">
+                              <path
+                                  d="M214.776 126.05h-9.089l-4.979-15.64h-17.305l-4.743 15.64h-8.848l17.149-53.246h10.59zm-15.568-22.201l-4.503-13.904c-.476-1.42-1.373-4.766-2.685-10.031h-.16c-.529 2.265-1.373 5.61-2.53 10.03l-4.426 13.905zm59.584 2.532c0 6.53-1.773 11.691-5.323 15.48-3.178 3.373-7.128 5.058-11.839 5.058-5.086 0-8.744-1.813-10.966-5.446v20.146h-8.532v-41.343c0-4.102-.108-8.307-.316-12.62h7.504l.476 6.086h.16c2.846-4.585 7.164-6.878 12.96-6.878 4.53 0 8.312 1.788 11.337 5.37 3.022 3.588 4.539 8.302 4.539 14.147zm-8.693.312c0-3.737-.84-6.818-2.53-9.246-1.844-2.525-4.322-3.79-7.427-3.79-2.106 0-4.019.705-5.727 2.093-1.713 1.4-2.834 3.23-3.358 5.494a11.142 11.14 0 0 0-.397 2.597v6.405c0 2.79.857 5.146 2.57 7.074 1.713 1.92 3.938 2.885 6.675 2.885 3.214 0 5.716-1.244 7.505-3.713 1.792-2.477 2.689-5.742 2.689-9.799zm52.865-.312c0 6.53-1.773 11.691-5.323 15.48-3.182 3.373-7.128 5.058-11.843 5.058-5.086 0-8.744-1.813-10.966-5.446v20.146H266.3v-41.343c0-4.102-.108-8.307-.316-12.62h7.504l.476 6.086h.16c2.841-4.585 7.16-6.878 12.959-6.878 4.526 0 8.308 1.788 11.342 5.37 3.018 3.588 4.539 8.302 4.539 14.147zm-8.697.312c0-3.737-.845-6.818-2.534-9.246-1.845-2.525-4.314-3.79-7.42-3.79-2.105 0-4.018.705-5.735 2.093-1.713 1.4-2.83 3.23-3.353 5.494-.26 1.056-.4 1.916-.4 2.597v6.405c0 2.79.86 5.146 2.565 7.074 1.713 1.917 3.938 2.885 6.683 2.885 3.218 0 5.72-1.244 7.504-3.713 1.793-2.477 2.69-5.742 2.69-9.799zm58.083 4.422c0 4.533-1.585 8.218-4.734 11.063-3.466 3.104-8.305 4.66-14.508 4.66-5.731 0-10.326-1.103-13.792-3.316l1.973-7.11c3.742 2.217 7.853 3.32 12.327 3.32 3.218 0 5.72-.727 7.504-2.172 1.79-1.448 2.694-3.385 2.694-5.801 0-2.165-.749-3.977-2.218-5.454-1.476-1.472-3.918-2.845-7.348-4.105-9.325-3.477-13.991-8.562-13.991-15.252 0-4.37 1.649-7.946 4.939-10.743 3.29-2.793 7.652-4.19 13.079-4.19 4.846 0 8.884.845 12.09 2.53l-2.141 6.953c-3.018-1.632-6.424-2.448-10.234-2.448-3.01 0-5.37.74-7.06 2.212-1.42 1.317-2.14 2.921-2.14 4.826 0 2.1.82 3.845 2.453 5.213 1.417 1.26 4.002 2.633 7.74 4.105 4.586 1.849 7.956 4.001 10.113 6.474 2.174 2.473 3.254 5.558 3.254 9.235zm28.283-17.057h-9.405v18.641c0 4.741 1.657 7.106 4.979 7.106 1.525 0 2.79-.128 3.79-.396l.236 6.478c-1.68.628-3.894.944-6.635.944-3.37 0-6.004-1.028-7.905-3.085-1.893-2.057-2.845-5.501-2.845-10.35V94.041h-5.603V87.64h5.603v-7.03l8.38-2.529v9.56h9.405zm42.351 12.48c0 5.9-1.689 10.746-5.058 14.535-3.526 3.901-8.217 5.846-14.064 5.846-5.643 0-10.13-1.869-13.475-5.602-3.346-3.74-5.019-8.454-5.019-14.14 0-5.95 1.729-10.823 5.175-14.612 3.454-3.793 8.104-5.69 13.951-5.69 5.635 0 10.162 1.873 13.588 5.61 3.273 3.625 4.902 8.307 4.902 14.052zm-8.844.195c0-3.517-.76-6.533-2.286-9.058-1.789-3.049-4.35-4.573-7.668-4.573-3.418 0-6.04 1.524-7.824 4.573-1.529 2.525-2.29 5.593-2.29 9.218 0 3.521.761 6.546 2.29 9.063 1.845 3.049 4.418 4.573 7.752 4.573 3.262 0 5.82-1.556 7.668-4.65 1.57-2.584 2.358-5.62 2.358-9.146zm36.591-11.575a14.848 14.844 0 0 0-2.69-.236c-3 0-5.322 1.128-6.955 3.401-1.417 2-2.13 4.53-2.13 7.582v20.146h-8.532V99.747a269.866 269.794 0 0 0-.248-12.087h7.432l.312 7.346h.236c.905-2.525 2.322-4.561 4.267-6.086a10.318 10.315 0 0 1 6.167-2.056c.789 0 1.5.056 2.133.156zm38.16 9.879a20.01 20.006 0 0 1-.311 3.869h-25.598c.096 3.793 1.337 6.698 3.714 8.698 2.157 1.785 4.947 2.681 8.372 2.681 3.79 0 7.248-.6 10.358-1.812l1.337 5.917c-3.634 1.585-7.925 2.373-12.875 2.373-5.955 0-10.63-1.753-14.032-5.25-3.394-3.5-5.095-8.206-5.095-14.1 0-5.785 1.581-10.606 4.747-14.451 3.314-4.106 7.792-6.158 13.427-6.158 5.535 0 9.725 2.052 12.571 6.158 2.253 3.252 3.386 7.286 3.386 12.075zm-8.136-2.213c.06-2.532-.5-4.713-1.656-6.558-1.477-2.376-3.75-3.56-6.796-3.56-2.79 0-5.063 1.156-6.792 3.476-1.42 1.845-2.265 4.062-2.525 6.634zM180.942 53.979c-2.374 0-4.427-.116-6.136-.312V27.924a46.45 46.437 0 0 1 7.224-.544c9.786 0 14.292 4.813 14.292 12.659 0 9.05-5.323 13.94-15.38 13.94zm1.432-23.299c-1.32 0-2.445.08-3.377.273v19.569c.504.08 1.472.116 2.833.116 6.412 0 10.062-3.65 10.062-10.483 0-6.094-3.302-9.475-9.518-9.475zm27.992 23.495c-5.515 0-9.09-4.117-9.09-9.707 0-5.825 3.65-9.979 9.402-9.979 5.435 0 9.089 3.922 9.089 9.671 0 5.898-3.766 10.015-9.401 10.015zm.16-16.62c-3.03 0-4.971 2.832-4.971 6.793 0 3.885 1.981 6.718 4.93 6.718s4.931-3.029 4.931-6.798c0-3.84-1.94-6.714-4.89-6.714zm40.69-2.677l-5.904 18.869h-3.846l-2.445-8.194a62.154 62.137 0 0 1-1.517-6.094h-.08c-.308 2.056-.892 4.117-1.513 6.094l-2.601 8.194h-3.886l-5.555-18.87h4.31l2.137 8.971c.505 2.137.929 4.153 1.281 6.058h.08c.308-1.589.812-3.573 1.553-6.018l2.681-9.006h3.418l2.566 8.814a73.86 73.86 0 0 1 1.516 6.214h.112c.273-1.94.7-4.001 1.281-6.214l2.293-8.814zm21.731 18.869h-4.194V42.912c0-3.337-1.28-5.01-3.806-5.01-2.485 0-4.194 2.137-4.194 4.622v11.223h-4.195V40.27c0-1.668-.04-3.457-.156-5.397h3.69l.196 2.912h.117c1.128-2.016 3.417-3.297 5.983-3.297 3.962 0 6.563 3.03 6.563 7.959zm11.567 0h-4.199V26.219h4.199zm15.292.428c-5.511 0-9.09-4.117-9.09-9.707 0-5.825 3.65-9.979 9.398-9.979 5.439 0 9.089 3.922 9.089 9.671.004 5.898-3.766 10.015-9.397 10.015zm.156-16.62c-3.03 0-4.97 2.832-4.97 6.793 0 3.885 1.984 6.718 4.926 6.718 2.953 0 4.93-3.029 4.93-6.798.005-3.84-1.933-6.714-4.886-6.714zm25.778 16.192l-.304-2.173h-.112c-1.281 1.749-3.15 2.6-5.52 2.6-3.381 0-5.783-2.368-5.783-5.553 0-4.657 4.039-7.066 11.03-7.066v-.348c0-2.484-1.316-3.729-3.918-3.729-1.86 0-3.494.468-4.93 1.4l-.853-2.756c1.745-1.088 3.922-1.633 6.48-1.633 4.93 0 7.42 2.601 7.42 7.807v6.95c0 1.904.084 3.38.272 4.505zm-.577-9.399c-4.658 0-6.995 1.129-6.995 3.805 0 1.98 1.204 2.949 2.877 2.949 2.133 0 4.118-1.628 4.118-3.841zm24.454 9.399l-.196-3.03h-.116c-1.205 2.29-3.23 3.458-6.06 3.458-4.55 0-7.92-4.001-7.92-9.63 0-5.902 3.494-10.06 8.264-10.06 2.526 0 4.315.853 5.323 2.565h.084V26.22h4.199V48.66c0 1.825.044 3.533.156 5.086zm-.62-11.103c0-2.641-1.75-4.894-4.419-4.894-3.11 0-5.01 2.757-5.01 6.638 0 3.805 1.972 6.41 4.926 6.41 2.637 0 4.502-2.293 4.502-5.01zm30.816 11.53c-5.511 0-9.085-4.116-9.085-9.706 0-5.825 3.65-9.979 9.397-9.979 5.44 0 9.09 3.922 9.09 9.671.003 5.898-3.763 10.015-9.402 10.015zm.156-16.62c-3.026 0-4.967 2.833-4.967 6.794 0 3.885 1.981 6.718 4.927 6.718 2.954 0 4.93-3.029 4.93-6.798.009-3.84-1.932-6.714-4.89-6.714zm31.801 16.193h-4.198V42.912c0-3.337-1.28-5.01-3.806-5.01-2.485 0-4.19 2.137-4.19 4.622v11.223h-4.199V40.27c0-1.668-.04-3.457-.156-5.397h3.69l.196 2.912h.116c1.125-2.016 3.418-3.3 5.98-3.3 3.962 0 6.567 3.028 6.567 7.958zm28.22-15.725h-4.615v9.163c0 2.333.808 3.497 2.441 3.497.74 0 1.361-.08 1.861-.196l.116 3.185c-.812.312-1.9.468-3.253.468-3.306 0-5.283-1.825-5.283-6.602v-9.515h-2.754v-3.144h2.754V31.42l4.118-1.245v4.698h4.614zm22.203 15.725h-4.19V42.992c0-3.377-1.277-5.086-3.806-5.086-2.173 0-4.198 1.477-4.198 4.466v11.375h-4.19V26.219h4.19v11.335h.084c1.32-2.056 3.234-3.069 5.675-3.069 3.994 0 6.435 3.105 6.435 8.039zm22.749-8.427h-12.587c.08 3.573 2.445 5.59 5.947 5.59 1.861 0 3.574-.312 5.087-.892l.652 2.913c-1.785.776-3.886 1.164-6.331 1.164-5.903 0-9.397-3.73-9.397-9.51 0-5.786 3.578-10.136 8.925-10.136 4.822 0 7.848 3.573 7.848 8.97a8.084 8.082 0 0 1-.144 1.901zm-3.846-2.988c0-2.913-1.47-4.97-4.15-4.97-2.41 0-4.315 2.097-4.587 4.97z"/>
+                            </g>
+                        </svg>
+                    </a>
+                    <a href="https://play.google.com/store/apps/details?id=pro.maximus.winetime"
+                           target="_blank"
+                           class="app-link"
+                    >
+                        <svg xmlns="http://www.w3.org/2000/svg" width="135" height="40" viewBox="0 0 135 40">
+                            <path d="M130 40H5c-2.8 0-5-2.2-5-5V5c0-2.8 2.2-5 5-5h125c2.8 0 5 2.2 5 5v30c0 2.8-2.2 5-5 5z"/>
+                            <path
+                                d="M130 .8c2.3 0 4.2 1.9 4.2 4.2v30c0 2.3-1.9 4.2-4.2 4.2H5C2.7 39.2.8 37.3.8 35V5C.8 2.7 2.7.8 5 .8h125m0-.8H5C2.2 0 0 2.3 0 5v30c0 2.8 2.2 5 5 5h125c2.8 0 5-2.2 5-5V5c0-2.7-2.2-5-5-5z"
+                                style="fill:#a6a6a6"/>
+                            <path
+                                d="M47.4 10.2c0 .8-.2 1.5-.7 2-.6.6-1.3.9-2.2.9-.9 0-1.6-.3-2.2-.9-.6-.6-.9-1.3-.9-2.2 0-.9.3-1.6.9-2.2.6-.6 1.3-.9 2.2-.9.4 0 .8.1 1.2.3.4.2.7.4.9.7l-.5.5c-.4-.5-.9-.7-1.6-.7-.6 0-1.2.2-1.6.7-.5.4-.7 1-.7 1.7s.2 1.3.7 1.7c.5.4 1 .7 1.6.7.7 0 1.2-.2 1.7-.7.3-.3.5-.7.5-1.2h-2.2v-.8h2.9v.4zM52 7.7h-2.7v1.9h2.5v.7h-2.5v1.9H52v.8h-3.5V7H52v.7zm3.3 5.3h-.8V7.7h-1.7V7H57v.7h-1.7V13zm4.6 0V7h.8v6h-.8zm4.2 0h-.8V7.7h-1.7V7h4.1v.7H64V13zm9.5-.8c-.6.6-1.3.9-2.2.9-.9 0-1.6-.3-2.2-.9-.6-.6-.9-1.3-.9-2.2s.3-1.6.9-2.2c.6-.6 1.3-.9 2.2-.9.9 0 1.6.3 2.2.9.6.6.9 1.3.9 2.2 0 .9-.3 1.6-.9 2.2zm-3.8-.5c.4.4 1 .7 1.6.7.6 0 1.2-.2 1.6-.7.4-.4.7-1 .7-1.7s-.2-1.3-.7-1.7c-.4-.4-1-.7-1.6-.7-.6 0-1.2.2-1.6.7-.4.4-.7 1-.7 1.7s.2 1.3.7 1.7zm5.8 1.3V7h.9l2.9 4.7V7h.8v6h-.8l-3.1-4.9V13h-.7z"
+                                style="fill:#fff;stroke:#fff;stroke-width:.2;stroke-miterlimit:10"/>
+                            <path
+                                d="M68.1 21.8c-2.4 0-4.3 1.8-4.3 4.3 0 2.4 1.9 4.3 4.3 4.3s4.3-1.8 4.3-4.3c0-2.6-1.9-4.3-4.3-4.3zm0 6.8c-1.3 0-2.4-1.1-2.4-2.6s1.1-2.6 2.4-2.6c1.3 0 2.4 1 2.4 2.6 0 1.5-1.1 2.6-2.4 2.6zm-9.3-6.8c-2.4 0-4.3 1.8-4.3 4.3 0 2.4 1.9 4.3 4.3 4.3s4.3-1.8 4.3-4.3c0-2.6-1.9-4.3-4.3-4.3zm0 6.8c-1.3 0-2.4-1.1-2.4-2.6s1.1-2.6 2.4-2.6c1.3 0 2.4 1 2.4 2.6 0 1.5-1.1 2.6-2.4 2.6zm-11.1-5.5v1.8H52c-.1 1-.5 1.8-1 2.3-.6.6-1.6 1.3-3.3 1.3-2.7 0-4.7-2.1-4.7-4.8s2.1-4.8 4.7-4.8c1.4 0 2.5.6 3.3 1.3l1.3-1.3c-1.1-1-2.5-1.8-4.5-1.8-3.6 0-6.7 3-6.7 6.6 0 3.6 3.1 6.6 6.7 6.6 2 0 3.4-.6 4.6-1.9 1.2-1.2 1.6-2.9 1.6-4.2 0-.4 0-.8-.1-1.1h-6.2zm45.4 1.4c-.4-1-1.4-2.7-3.6-2.7s-4 1.7-4 4.3c0 2.4 1.8 4.3 4.2 4.3 1.9 0 3.1-1.2 3.5-1.9l-1.4-1c-.5.7-1.1 1.2-2.1 1.2s-1.6-.4-2.1-1.3l5.7-2.4-.2-.5zm-5.8 1.4c0-1.6 1.3-2.5 2.2-2.5.7 0 1.4.4 1.6.9l-3.8 1.6zM82.6 30h1.9V17.5h-1.9V30zm-3-7.3c-.5-.5-1.3-1-2.3-1-2.1 0-4.1 1.9-4.1 4.3s1.9 4.2 4.1 4.2c1 0 1.8-.5 2.2-1h.1v.6c0 1.6-.9 2.5-2.3 2.5-1.1 0-1.9-.8-2.1-1.5l-1.6.7c.5 1.1 1.7 2.5 3.8 2.5 2.2 0 4-1.3 4-4.4V22h-1.8v.7zm-2.2 5.9c-1.3 0-2.4-1.1-2.4-2.6s1.1-2.6 2.4-2.6c1.3 0 2.3 1.1 2.3 2.6s-1 2.6-2.3 2.6zm24.4-11.1h-4.5V30h1.9v-4.7h2.6c2.1 0 4.1-1.5 4.1-3.9s-2-3.9-4.1-3.9zm.1 6h-2.7v-4.3h2.7c1.4 0 2.2 1.2 2.2 2.1-.1 1.1-.9 2.2-2.2 2.2zm11.5-1.8c-1.4 0-2.8.6-3.3 1.9l1.7.7c.4-.7 1-.9 1.7-.9 1 0 1.9.6 2 1.6v.1c-.3-.2-1.1-.5-1.9-.5-1.8 0-3.6 1-3.6 2.8 0 1.7 1.5 2.8 3.1 2.8 1.3 0 1.9-.6 2.4-1.2h.1v1h1.8v-4.8c-.2-2.2-1.9-3.5-4-3.5zm-.2 6.9c-.6 0-1.5-.3-1.5-1.1 0-1 1.1-1.3 2-1.3.8 0 1.2.2 1.7.4-.2 1.2-1.2 2-2.2 2zm10.5-6.6-2.1 5.4h-.1l-2.2-5.4h-2l3.3 7.6-1.9 4.2h1.9l5.1-11.8h-2zm-16.8 8h1.9V17.5h-1.9V30z"
+                                style="fill:#fff"/>
+                            <linearGradient id="a" x1="21.8" x2="5.017" y1="33.29" y2="16.508"
+                                            gradientTransform="matrix(1 0 0 -1 0 42)" gradientUnits="userSpaceOnUse">
+                              <stop offset="0" stop-color="#00a0ff"/>
+                              <stop offset=".007" stop-color="#00a1ff"/>
+                              <stop offset=".26" stop-color="#00beff"/>
+                              <stop offset=".512" stop-color="#00d2ff"/>
+                              <stop offset=".76" stop-color="#00dfff"/>
+                              <stop offset="1" stop-color="#00e3ff"/>
+                            </linearGradient>
+                            <path d="M10.4 7.5c-.3.3-.4.8-.4 1.4V31c0 .6.2 1.1.5 1.4l.1.1L23 20.1v-.2L10.4 7.5z"
+                                  style="fill:rgb(66, 133, 244)"/>
+                            <linearGradient id="b" x1="33.834" x2="9.637" y1="21.999" y2="21.999"
+                                            gradientTransform="matrix(1 0 0 -1 0 42)" gradientUnits="userSpaceOnUse">
+                              <stop offset="0" stop-color="#ffe000"/>
+                              <stop offset=".409" stop-color="#ffbd00"/>
+                              <stop offset=".775" stop-color="orange"/>
+                              <stop offset="1" stop-color="#ff9c00"/>
+                            </linearGradient>
+                            <path d="m27 24.3-4.1-4.1v-.3l4.1-4.1.1.1 4.9 2.8c1.4.8 1.4 2.1 0 2.9l-5 2.7z" style="fill:url(#b)"/>
+                            <linearGradient id="c" x1="24.827" x2="2.069" y1="19.704" y2="-3.054"
+                                            gradientTransform="matrix(1 0 0 -1 0 42)" gradientUnits="userSpaceOnUse">
+                              <stop offset="0" stop-color="#ff3a44"/>
+                              <stop offset="1" stop-color="#c31162"/>
+                            </linearGradient>
+                            <path d="M27.1 24.2 22.9 20 10.4 32.5c.5.5 1.2.5 2.1.1l14.6-8.4" style="fill:url(#c)"/>
+                            <linearGradient id="d" x1="7.297" x2="17.46" y1="41.824" y2="31.661"
+                                            gradientTransform="matrix(1 0 0 -1 0 42)" gradientUnits="userSpaceOnUse">
+                              <stop offset="0" stop-color="#32a071"/>
+                              <stop offset=".069" stop-color="#2da771"/>
+                              <stop offset=".476" stop-color="#15cf74"/>
+                              <stop offset=".801" stop-color="#06e775"/>
+                              <stop offset="1" stop-color="#00f076"/>
+                            </linearGradient>
+                            <path d="M27.1 15.8 12.5 7.5c-.9-.5-1.6-.4-2.1.1L22.9 20l4.2-4.2z" style="fill:url(#d)"/>
+                            <path d="m27 24.1-14.5 8.2c-.8.5-1.5.4-2 0l-.1.1.1.1c.5.4 1.2.5 2 0L27 24.1z"
+                                  style="opacity:.2;enable-background:new"/>
+                            <path
+                                d="M10.4 32.3c-.3-.3-.4-.8-.4-1.4v.1c0 .6.2 1.1.5 1.4v-.1h-.1zm21.6-11-5 2.8.1.1 4.9-2.8c.7-.4 1-.9 1-1.4 0 .5-.4.9-1 1.3z"
+                                style="opacity:.12;enable-background:new"/>
+                            <path
+                                d="M12.5 7.6 32 18.7c.6.4 1 .8 1 1.3 0-.5-.3-1-1-1.4L12.5 7.5c-1.4-.8-2.5-.2-2.5 1.4V9c0-1.5 1.1-2.2 2.5-1.4z"
+                                style="opacity:.25;fill:#fff;enable-background:new"/>
+                        </svg>
+                    </a>
+                </div>
+            </div>
+
+            <div class="j-dn j-db-bg">
+                <div class="j-fx-col j-gap-5">
+                                        <div>
+                        <a href="https://winetime.com.ua/ua/o-dostavke">
+                            Оплата та доставка
+                        </a>
+                    </div>
+                                        <div>
+                        <a href="https://winetime.com.ua/ua/vidguky">
+                            Відгуки
+                        </a>
+                    </div>
+                                        <div>
+                        <a href="https://winetime.com.ua/ua/novosti">
+                            Новини
+                        </a>
+                    </div>
+                                        <div>
+                        <a href="https://winetime.com.ua/ua/o-magazine">
+                            Про магазин
+                        </a>
+                    </div>
+                                        <div>
+                        <a href="https://winetime.com.ua/ua/contacts">
+                            Контакти
+                        </a>
+                    </div>
+                                        <div>
+                        <a href="https://winetime.com.ua/ua/litsenzii">
+                            Ліцензії
+                        </a>
+                    </div>
+                                        <div>
+                        <a href="https://winetime.com.ua/ua/povernennya-tovaru">
+                            Умови повернення
+                        </a>
+                    </div>
+                                        <div>
+                        <a href="https://winetime.com.ua/ua/politika-konfidentsialnosti">
+                            Політика конфіденційності
+                        </a>
+                    </div>
+                                        <div>
+                        <a href="https://winetime.com.ua/ua/usloviya-ispolzovaniya">
+                            Умови використання
+                        </a>
+                    </div>
+                                        <div>
+                        <a href="https://winetime.com.ua/ua/finansova-zvitnist-kompanii">
+                            Фінансова звітність компанії
+                        </a>
+                    </div>
+                                        <div>
+                        <a href="https://winetime.com.ua/ua/informatsiya-dlya-aktsioneriv-ta-steykkholderiv">
+                            Інформація для Акціонерів та Стейкхолдерів
+                        </a>
+                    </div>
+                                    </div>
+            </div>
+        </div>
+
+
+    </div>
+
+    <div class="j-container j-mw-1600 j-fx-row j-justify-end j-ph-15">
+        <img class="footer-fox" src="/img/footer-fox.svg?v=1" alt="winetime">
+    </div>
+
+    <div class="j-container j-mw-1600 j-ph-15 j-pv-30" style="border-top: 1px solid rgba(255,255,255,0.3)">
+        <div class="j-fx-col j-fx-row-bg j-gap-10 j-justify-between j-h-center j-h-left-bg">
+            <div class="j-size-0.875">
+                ©
+                Всі права захищені 
+                2026. WINETIME
+            </div>
+            <div class="j-size-0.875 j-size-1-bg c-main j-weight-600">
+                Ми продаємо алкоголь тільки повнолітнім
+            </div>
+        </div>
+    </div>
+
+</footer>
+</div>
+
+
+<script>
+    
+    window.apiUrl = ""
+    window.initialData = {
+        app_env: 'production',
+        cart: {"items":[],"totalQuantity":0,"totalGross":0,"totalNet":0,"freeDeliveryLimit":1000,"checkoutLimit":500},
+        user: {"info":null,"auth_state":null},
+        checkout: {"user_data":[],"delivery_data":[],"payment_data":[],"general_data":[],"delivery_types":[{"id":"np_warehouse","key":"np","title":"Відділення Нової Пошти","cost":0,"free_limit":1000,"price_gift":149,"tip":"за тарифами перевізника. Послуга «Післяплата» оплачується замовником"},{"id":"courier_country","key":"courier","title":"Кур’єрська доставка","cost":0,"free_limit":1000,"price_gift":149,"tip":"По м. Київ, Черкаси — доставка нашим кур'єром;<br>по Україні - доставка кур'єром перевізника.<br>Доставка замовлень на суму від <span>1500<\/span> грн - <strong>безкоштовна<\/strong>"},{"id":"courier_city","key":"courier","title":"Кур’єрська доставка","cost":0,"cities_cost":{"1605":"99","4135":"99"},"free_limit":1000,"price_gift":149,"tip":"По м. Київ, Черкаси — доставка нашим кур'єром;<br>по Україні - доставка кур'єром перевізника.<br>Доставка замовлень на суму від <span>1500<\/span> грн - <strong>безкоштовна<\/strong>"},{"id":"self","key":"pickup","title":"Самовивіз з магазину","cost":0,"free_limit":1000,"tip":"за адресою м. Київ, просп. Бажана 1 Е.<br>Отримання товару Пн-Пт 11:00-20:00, Сб-Нд 11:00-14:00.<br>Резерв товарів - 3 дні"}],"payment_types":[{"id":"visa","title":"Онлайн сплата VISA \/ Mastercard без врахування комісії за послугу \"Післяплата\"","tip":"","show_card_icons":false},{"id":"cashless","title":"Безготівковий (розрахунок між контрагентами)","tip":"розрахунок для юридичних осіб шляхом перерахунку коштів за банківськими реквізитами. Вкажіть номер ЄДРПОУ юридичної особи в коментарі до замовлення","show_card_icons":false},{"id":"cash","title":"Готівкою або карткою при отриманні","tip":"при доставці по м. Київ – розрахунок при отриманні тільки готівкою, карткою; при доставці по Україні – розрахунок при отриманні із платою за послугу «Післяплата»  (20 грн + 2% від суми замовлення)","show_card_icons":false}],"gift_certificates":{"total_net":0,"delivery_price":0,"goods_plus_delivery":0,"certificate_coverage":0,"amount_to_pay":0,"applied":[],"min_online_payment":50}},
+        main_menu: {"static_pages":[{"href":"https:\/\/winetime.com.ua\/ua\/o-dostavke","title":"Оплата та доставка"},{"href":"https:\/\/winetime.com.ua\/ua\/vidguky","title":"Відгуки"},{"href":"https:\/\/winetime.com.ua\/ua\/novosti","title":"Новини"},{"href":"https:\/\/winetime.com.ua\/ua\/o-magazine","title":"Про магазин"},{"href":"https:\/\/winetime.com.ua\/ua\/contacts","title":"Контакти"},{"href":"https:\/\/winetime.com.ua\/ua\/litsenzii","title":"Ліцензії"},{"href":"https:\/\/winetime.com.ua\/ua\/povernennya-tovaru","title":"Умови повернення"},{"href":"https:\/\/winetime.com.ua\/ua\/politika-konfidentsialnosti","title":"Політика конфіденційності"},{"href":"https:\/\/winetime.com.ua\/ua\/usloviya-ispolzovaniya","title":"Умови використання"},{"href":"https:\/\/winetime.com.ua\/ua\/finansova-zvitnist-kompanii","title":"Фінансова звітність компанії"},{"href":"https:\/\/winetime.com.ua\/ua\/informatsiya-dlya-aktsioneriv-ta-steykkholderiv","title":"Інформація для Акціонерів та Стейкхолдерів"}],"schedule":["9:00-20:00","10:00-18:00","10:00-15:00"],"tels":["0 800 330 370","+38 067 239 90 97","+38 050 315 37 37","+38 093 957 68 97"]},
+        catalog_menu: [{"id":333,"title":"Тоніки","parent_id":40,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/7f1cecbfb31185ecc0a205df8253d7e0.png","template":"1_level","depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/napoyi-bezalkogolni\/toniky","link_target":"_self","is_accented":0},{"id":334,"title":"Квас та Комбуча","parent_id":40,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/74797b6972360f0e0b4e145b6ee09c8b.png","template":"1_level","depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/napoyi-bezalkogolni\/kvas-ta-kombucha","link_target":"_self","is_accented":0},{"id":312,"title":"Суші","parent_id":311,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/001eba1a1b18537672ade2630d1599f9.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/gotovi-stravy\/sushi","link_target":"_self","is_accented":0},{"id":313,"title":"Піца","parent_id":311,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/db38163a9469af1a9720eca2d2bf86be.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/gotovi-stravy\/pitsa","link_target":"_self","is_accented":0},{"id":314,"title":"Бургери","parent_id":311,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/6768baad3548e23a551b661ec2270d7c.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/gotovi-stravy\/burgery","link_target":"_self","is_accented":0},{"id":315,"title":"Устриці","parent_id":311,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/edc7769c37016ee4a84630645ae61352.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/gotovi-stravy\/ustrytsi","link_target":"_self","is_accented":0},{"id":316,"title":"Салати","parent_id":311,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/1bcfd961ec6d109516534e159d4aaba5.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/gotovi-stravy\/salaty","link_target":"_self","is_accented":0},{"id":317,"title":"Перші страви","parent_id":311,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/cd35373fe6482f59a7f98a5666c2232c.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/gotovi-stravy\/pershi-stravy","link_target":"_self","is_accented":0},{"id":318,"title":"Другі страви","parent_id":311,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/c10a2b9313a105cdb0136264d1482bb0.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/gotovi-stravy\/drugi-stravy","link_target":"_self","is_accented":0},{"id":319,"title":"Ланчі 12:00 - 15:00","parent_id":311,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/927972cf0bdc7adc8af64f14144d3b7d.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/gotovi-stravy\/lanchi-12:00-15:00","link_target":"_self","is_accented":0},{"id":320,"title":"Сніданки 11:00-14:00","parent_id":311,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/d7e79e9461c4c2be16c56d53d6c739da.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/gotovi-stravy\/snidanky-11:00-14:00","link_target":"_self","is_accented":0},{"id":321,"title":"Grill Box","parent_id":311,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/9dcb86605eb0937b0f3d0d79e68d5414.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/gotovi-stravy\/grill-box","link_target":"_self","is_accented":0},{"id":322,"title":"Десерти","parent_id":311,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/ccee89a6c0e3b5425a36d21178c3138e.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/gotovi-stravy\/deserty","link_target":"_self","is_accented":0},{"id":323,"title":"Гарніри","parent_id":311,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/71e0f7ae8164bfe0923e325422d09a68.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/gotovi-stravy\/garniry","link_target":"_self","is_accented":0},{"id":324,"title":"Закуски","parent_id":311,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/49884d14e84f8c0de49e3503ff0ccffe.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/gotovi-stravy\/zakusky","link_target":"_self","is_accented":0},{"id":61,"title":"Сидр","parent_id":55,"group_id":303,"image":"https:\/\/winetime.com.ua\/storage\/da951940ce7c0ace5de370bc4881fa8e.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/napoyi-slaboalkogolni\/sydr","link_target":"_self","is_accented":0},{"id":228,"title":"Пиво","parent_id":55,"group_id":303,"image":"https:\/\/winetime.com.ua\/storage\/7187790819bc54bdb738c804ee61bfc3.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/napoyi-slaboalkogolni\/pyvo","link_target":"_self","is_accented":0},{"id":332,"title":"Слабоалкогольні коктейлі","parent_id":55,"group_id":303,"image":"https:\/\/winetime.com.ua\/storage\/30fd1d1a739a8581d9cd318ecda8afa7.png","template":"1_level","depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/napoyi-slaboalkogolni\/slaboalkogolni-kokteyli","link_target":"_self","is_accented":0},{"id":303,"title":"Тип","parent_id":55,"group_id":null,"image":"https:\/\/winetime.com.ua\/img\/no-photo-available.png","template":"group","depth":2,"link_href":null,"link_target":"_self","is_accented":0},{"id":162,"title":"Знижки на вино","parent_id":161,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/a2b521d9d8b14a02160569cb42d71582.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/wine\/promotional","link_target":"_self","is_accented":0},{"id":297,"title":"Морепродукти","parent_id":133,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/b5730491f4a4f0adeef075daf825d068.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/zamorozheni-produkty\/moreprodukty","link_target":"_self","is_accented":0},{"id":300,"title":"Ігристе безалкогольне","parent_id":29,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/32f85ad6d530e5e2e01335756ea3d7b6.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/igryste-shampanske\/igryste-bezalkogolne","link_target":"_self","is_accented":0},{"id":1,"title":"Вино","parent_id":null,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/e49a8ff223c689b438f96bc07658794a.png","template":"2_levels","depth":1,"link_href":"https:\/\/winetime.com.ua\/ua\/wine","link_target":"_self","is_accented":0},{"id":294,"title":"Дегустація Riesling 25.07.2024","parent_id":274,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/bcfef46aab89090b4f4d044c3bf2646c.jpeg","template":null,"depth":2,"link_href":null,"link_target":"_self","is_accented":0},{"id":206,"title":"Бар","parent_id":151,"group_id":null,"image":"https:\/\/winetime.com.ua\/img\/no-photo-available.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/bar","link_target":"_self","is_accented":0},{"id":216,"title":"Господарські товари","parent_id":151,"group_id":null,"image":"https:\/\/winetime.com.ua\/img\/no-photo-available.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/gospodarski-tovary","link_target":"_self","is_accented":0},{"id":190,"title":"Затишок","parent_id":151,"group_id":null,"image":"https:\/\/winetime.com.ua\/img\/no-photo-available.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/zatyshok","link_target":"_self","is_accented":0},{"id":156,"title":"Ігри та сувеніри","parent_id":151,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/1870b9f12f2885c6ff24c63bd25a0b0a.jpg","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/igry-ta-suveniry","link_target":"_self","is_accented":0},{"id":187,"title":"Косметика","parent_id":151,"group_id":null,"image":"https:\/\/winetime.com.ua\/img\/no-photo-available.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/kosmetyka","link_target":"_self","is_accented":0},{"id":157,"title":"Література","parent_id":151,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/ce7405ef37de285231342e1a2d35ccc1.jpg","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/literatura","link_target":"_self","is_accented":0},{"id":198,"title":"Посуд та кухонне приладдя","parent_id":151,"group_id":null,"image":"https:\/\/winetime.com.ua\/img\/no-photo-available.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/posud-ta-kuhonne-pryladdya","link_target":"_self","is_accented":0},{"id":159,"title":"Сертифікати","parent_id":151,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/95bb238c7207b76d1d875c310cbc2ca0.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/sertyfikaty","link_target":"_self","is_accented":0},{"id":29,"title":"Ігристе, шампанське","parent_id":null,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/8da3567fe1fa7efafcabb2e71dc59d79.jpeg","template":"2_levels","depth":1,"link_href":"https:\/\/winetime.com.ua\/ua\/igryste-shampanske","link_target":"_self","is_accented":0},{"id":38,"title":"Віскі","parent_id":null,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/c57c6c811afaf72a766d6483fb475c22.jpeg","template":"2_levels","depth":1,"link_href":"https:\/\/winetime.com.ua\/ua\/viski","link_target":"_self","is_accented":0},{"id":39,"title":"Міцний алкоголь","parent_id":null,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/e40fd362b7e39652927c1141c782e01e.png","template":"2_levels","depth":1,"link_href":"https:\/\/winetime.com.ua\/ua\/mitsnyy-alkogol","link_target":"_self","is_accented":0},{"id":5,"title":"Продукти","parent_id":null,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/e789666dea00f10ff09b8678c5c5b2d6.png","template":"3_levels","depth":1,"link_href":"https:\/\/winetime.com.ua\/ua\/food","link_target":"_self","is_accented":0},{"id":91,"title":"Бакалія","parent_id":5,"group_id":null,"image":"https:\/\/winetime.com.ua\/img\/no-photo-available.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/bakaliya","link_target":"_self","is_accented":0},{"id":107,"title":"Веганські продукти","parent_id":5,"group_id":null,"image":"https:\/\/winetime.com.ua\/img\/no-photo-available.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/veganski-produkty","link_target":"_self","is_accented":0},{"id":102,"title":"Дитяче харчування","parent_id":5,"group_id":null,"image":"https:\/\/winetime.com.ua\/img\/no-photo-available.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/dytyache-harchuvannya","link_target":"_self","is_accented":0},{"id":133,"title":"Заморожені продукти","parent_id":5,"group_id":null,"image":"https:\/\/winetime.com.ua\/img\/no-photo-available.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/zamorozheni-produkty","link_target":"_self","is_accented":0},{"id":74,"title":"Кондитерські вироби","parent_id":5,"group_id":null,"image":"https:\/\/winetime.com.ua\/img\/no-photo-available.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/kondyterski-vyroby","link_target":"_self","is_accented":0},{"id":241,"title":"Консервація","parent_id":5,"group_id":null,"image":"https:\/\/winetime.com.ua\/img\/no-photo-available.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/konservatsiya","link_target":"_self","is_accented":0},{"id":126,"title":"Молочні продукти","parent_id":5,"group_id":null,"image":"https:\/\/winetime.com.ua\/img\/no-photo-available.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/molochni-produkty","link_target":"_self","is_accented":0},{"id":121,"title":"Морепродукти, риба","parent_id":5,"group_id":null,"image":"https:\/\/winetime.com.ua\/img\/no-photo-available.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/ryba-moreprodukty","link_target":"_self","is_accented":0},{"id":7,"title":"М'яcні делікатеси","parent_id":5,"group_id":null,"image":"https:\/\/winetime.com.ua\/img\/no-photo-available.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/myasni-delikatesy","link_target":"_self","is_accented":0},{"id":141,"title":"Свіжі овочі, фрукти","parent_id":5,"group_id":null,"image":"https:\/\/winetime.com.ua\/img\/no-photo-available.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/svizhi-ovochi-frukty","link_target":"_self","is_accented":0},{"id":144,"title":"Свіже м'ясо","parent_id":5,"group_id":null,"image":"https:\/\/winetime.com.ua\/img\/no-photo-available.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/svizhe-myaso","link_target":"_self","is_accented":0},{"id":114,"title":"Сири","parent_id":5,"group_id":null,"image":"https:\/\/winetime.com.ua\/img\/no-photo-available.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/syry","link_target":"_self","is_accented":0},{"id":84,"title":"Снеки","parent_id":5,"group_id":null,"image":"https:\/\/winetime.com.ua\/img\/no-photo-available.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/sneky","link_target":"_self","is_accented":0},{"id":35,"title":"Шампанське","parent_id":29,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/06334985505de615b37ffad100eb2952.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/wine\/region=shampan","link_target":"_self","is_accented":0},{"id":57,"title":"Пілснер","parent_id":55,"group_id":257,"image":"https:\/\/winetime.com.ua\/storage\/7187790819bc54bdb738c804ee61bfc3.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/napoyi-slaboalkogolni\/pilsner","link_target":"_self","is_accented":0},{"id":60,"title":"Лагер","parent_id":55,"group_id":257,"image":"https:\/\/winetime.com.ua\/storage\/7187790819bc54bdb738c804ee61bfc3.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/napoyi-slaboalkogolni\/lager","link_target":"_self","is_accented":0},{"id":56,"title":"Ель","parent_id":55,"group_id":257,"image":"https:\/\/winetime.com.ua\/storage\/7187790819bc54bdb738c804ee61bfc3.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/napoyi-slaboalkogolni\/el","link_target":"_self","is_accented":0},{"id":258,"title":"IPA","parent_id":55,"group_id":257,"image":"https:\/\/winetime.com.ua\/storage\/7187790819bc54bdb738c804ee61bfc3.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/napoyi-slaboalkogolni\/ipa","link_target":"_self","is_accented":0},{"id":259,"title":"Безалкогольное","parent_id":55,"group_id":257,"image":"https:\/\/winetime.com.ua\/storage\/7187790819bc54bdb738c804ee61bfc3.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/napoyi-slaboalkogolni\/bezalkogolne","link_target":"_self","is_accented":0},{"id":260,"title":"Стаут","parent_id":55,"group_id":257,"image":"https:\/\/winetime.com.ua\/storage\/7187790819bc54bdb738c804ee61bfc3.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/napoyi-slaboalkogolni\/staut","link_target":"_self","is_accented":0},{"id":59,"title":"Світле","parent_id":55,"group_id":256,"image":"https:\/\/winetime.com.ua\/storage\/6fdd09d1b276f2f119bd9ff90f200de0.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/napoyi-slaboalkogolni\/pyvo\/type=svitle","link_target":"_self","is_accented":0},{"id":58,"title":"Темне","parent_id":55,"group_id":256,"image":"https:\/\/winetime.com.ua\/storage\/c0511ac67df67b5da6ba83000e39c593.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/napoyi-slaboalkogolni\/pyvo\/type=temne","link_target":"_self","is_accented":0},{"id":75,"title":"Шоколад","parent_id":74,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/ceef07f07acf13a074a2b05afadfaa78.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/kondyterski-vyroby\/shokolad","link_target":"_self","is_accented":0},{"id":160,"title":"Упаковка","parent_id":151,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/e58bf5984f6a675aa3768c0eca444e33.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/upakovka","link_target":"_self","is_accented":0},{"id":172,"title":"Сухе","parent_id":1,"group_id":168,"image":"https:\/\/winetime.com.ua\/storage\/9c8d8d42231360fcd06642e059450cb5.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/wine\/sweetnes=sukhe","link_target":"_self","is_accented":0},{"id":173,"title":"Напівсухе","parent_id":1,"group_id":168,"image":"https:\/\/winetime.com.ua\/storage\/9c8d8d42231360fcd06642e059450cb5.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/wine\/sweetnes=napivsukhe","link_target":"_self","is_accented":0},{"id":174,"title":"Напівсолодке","parent_id":1,"group_id":168,"image":"https:\/\/winetime.com.ua\/storage\/9c8d8d42231360fcd06642e059450cb5.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/wine\/sweetnes=napivsolodke","link_target":"_self","is_accented":0},{"id":175,"title":"Солодке","parent_id":1,"group_id":168,"image":"https:\/\/winetime.com.ua\/storage\/9c8d8d42231360fcd06642e059450cb5.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/wine\/sweetnes=solodke","link_target":"_self","is_accented":0},{"id":26,"title":"Тихе","parent_id":1,"group_id":167,"image":"https:\/\/winetime.com.ua\/storage\/9c8d8d42231360fcd06642e059450cb5.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/wine\/type=tikhe","link_target":"_self","is_accented":0},{"id":169,"title":"Біле","parent_id":1,"group_id":166,"image":"https:\/\/winetime.com.ua\/storage\/5a7e4685e72f71e96a518d9bc71a8593.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/wine\/color=bile","link_target":"_self","is_accented":0},{"id":170,"title":"Червоне","parent_id":1,"group_id":166,"image":"https:\/\/winetime.com.ua\/storage\/7432a0810a5d068b0a5ac85cd80458b0.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/wine\/color=chervone","link_target":"_self","is_accented":0},{"id":171,"title":"Рожеве","parent_id":1,"group_id":166,"image":"https:\/\/winetime.com.ua\/storage\/5c91c132fdfbbc03d775e36f4f027626.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/wine\/color=rozheve","link_target":"_self","is_accented":0},{"id":4,"title":"Мадера","parent_id":1,"group_id":167,"image":"https:\/\/winetime.com.ua\/storage\/89df0c3ff70802ee39fc1de747a333fa.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/wine\/type=madera","link_target":"_self","is_accented":0},{"id":27,"title":"Портвейн","parent_id":1,"group_id":167,"image":"https:\/\/winetime.com.ua\/storage\/fdbe65957cc66d2f646076561adcd429.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/wine\/type=portveyn","link_target":"_self","is_accented":0},{"id":30,"title":"Херес","parent_id":1,"group_id":167,"image":"https:\/\/winetime.com.ua\/storage\/e3e3efafd4eb64762253b011282e795b.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/wine\/type=kheres","link_target":"_self","is_accented":0},{"id":3,"title":"Вермут","parent_id":1,"group_id":167,"image":"https:\/\/winetime.com.ua\/storage\/01baa5dd73e6450904167ce1e1f0195f.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/wine\/type=vermut","link_target":"_self","is_accented":0},{"id":24,"title":"Плодове","parent_id":1,"group_id":167,"image":"https:\/\/winetime.com.ua\/storage\/eb8ac8ac0112a9601fd9e04f5c011e72.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/wine\/type=plodove","link_target":"_self","is_accented":0},{"id":25,"title":"Безалкогольне","parent_id":1,"group_id":167,"image":"https:\/\/winetime.com.ua\/storage\/b65694777561d865b506449cb0ae1f28.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/wine\/type=bezalkogolne","link_target":"_self","is_accented":0},{"id":167,"title":"Тип","parent_id":1,"group_id":null,"image":"https:\/\/winetime.com.ua\/img\/no-photo-available.png","template":"group","depth":2,"link_href":null,"link_target":"_self","is_accented":0},{"id":166,"title":"Колір","parent_id":1,"group_id":null,"image":"https:\/\/winetime.com.ua\/img\/no-photo-available.png","template":"group","depth":2,"link_href":null,"link_target":"_self","is_accented":0},{"id":67,"title":"Хлібобулочні вироби","parent_id":5,"group_id":null,"image":"https:\/\/winetime.com.ua\/img\/no-photo-available.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/hlibobulochni-vyroby","link_target":"_self","is_accented":0},{"id":55,"title":"Напої слабоалкогольні","parent_id":null,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/85f473dc432ab37069f67195505a9bfb.jpeg","template":"2_levels","depth":1,"link_href":"https:\/\/winetime.com.ua\/ua\/napoyi-slaboalkogolni","link_target":"_self","is_accented":0},{"id":40,"title":"Напої безалкогольні","parent_id":null,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/aad23ee69b32d277acbc3e16fd1e1685.jpeg","template":"2_levels","depth":1,"link_href":"https:\/\/winetime.com.ua\/ua\/napoyi-bezalkogolni","link_target":"_self","is_accented":0},{"id":37,"title":"Асті","parent_id":29,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/e5ab076ba5afaea123ebacc327bb1dbf.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/wine\/type=asti-asti","link_target":"_self","is_accented":0},{"id":31,"title":"Ігристе","parent_id":29,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/a7922703d8b7643dc27dab3e340d680e.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/wine\/type=igriste","link_target":"_self","is_accented":0},{"id":32,"title":"Просекко","parent_id":29,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/75afcd6da2ea6c9ebbd583a0a8c57c39.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/wine\/type=prosekko-rrosecco","link_target":"_self","is_accented":0},{"id":33,"title":"Кава","parent_id":29,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/efe888c05cb68ea40e523a2b591169e6.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/wine\/type=kava-sava","link_target":"_self","is_accented":0},{"id":34,"title":"Ламбруско","parent_id":29,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/acff7a9fc40349c335182c17b2a9930d.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/wine\/type=lambrusko-lambrusco","link_target":"_self","is_accented":0},{"id":36,"title":"Фраголіно","parent_id":29,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/7d08dd93435eddc09eef3c20bac80aca.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/wine\/type=fragolino-fragolino","link_target":"_self","is_accented":0},{"id":10,"title":"Хамон","parent_id":7,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/8699b874c1ddc13fbb8737bb57074bec.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/myasni-delikatesy\/hamon","link_target":"_self","is_accented":0},{"id":11,"title":"Прошуто","parent_id":7,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/2ff9834e46e08a97cd760675a326355a.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/myasni-delikatesy\/proshuto","link_target":"_self","is_accented":0},{"id":12,"title":"Шинка","parent_id":7,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/97cad1f2844f8cde8c628bb7681e443a.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/myasni-delikatesy\/shynka","link_target":"_self","is_accented":0},{"id":13,"title":"Сосиски","parent_id":7,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/7b58faf0fd6f1869c185a89f24eb5b63.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/myasni-delikatesy\/sosysky","link_target":"_self","is_accented":0},{"id":14,"title":"Ковбаса","parent_id":7,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/907cc547050634a3bbefd4a93a7011dc.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/myasni-delikatesy\/kovbasa","link_target":"_self","is_accented":0},{"id":308,"title":"М'ясні снеки","parent_id":7,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/2ff56096264599e2637b09ce23524449.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/myasni-delikatesy\/myasni-sneky","link_target":"_self","is_accented":0},{"id":41,"title":"Бурбон","parent_id":38,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/f7dc6e8d0caa54802a6bc28f0d05b491.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/viski\/burbon","link_target":"_self","is_accented":0},{"id":42,"title":"Односолодовий","parent_id":38,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/6208ea25f68a3f5455d82810bdf2a2bb.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/viski\/odnosolodovyy","link_target":"_self","is_accented":0},{"id":43,"title":"Купажований (бленд)","parent_id":38,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/ab85007a4e06b93ab1c6642a3f2fc7a8.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/viski\/kupazhovanyy-blend","link_target":"_self","is_accented":0},{"id":44,"title":"Купажований солодовий","parent_id":38,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/b9dbf46b7dbc64cfcb524a699676b818.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/viski\/kupazhovanyy-solodovyy","link_target":"_self","is_accented":0},{"id":330,"title":"Однозерновий","parent_id":38,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/d3fc03da13076c0a64c9e96b8d254fa1.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/viski\/odnozernovyy","link_target":"_self","is_accented":0},{"id":45,"title":"Коньяк","parent_id":39,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/c8074ef07ddf6ce775f815fae8ff3dcd.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/alcohol\/type=konyak-1826","link_target":"_self","is_accented":0},{"id":236,"title":"Бренді","parent_id":39,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/4f3a030011e969de9b6ae9c3db67cf58.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/mitsnyy-alkogol\/brendi","link_target":"_self","is_accented":0},{"id":46,"title":"Горілка","parent_id":39,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/7bd7e5b2a6644f266ade45721b4a8a8e.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/alcohol\/type=gorilka","link_target":"_self","is_accented":0},{"id":302,"title":"Настоянка","parent_id":39,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/5ad9b500428ec1b6e19f14bd19c3ca3d.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/mitsnyy-alkogol\/nastoyanka","link_target":"_self","is_accented":0},{"id":48,"title":"Ром","parent_id":39,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/33b99dd070e69d243e86051d3dcbeb15.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/alcohol\/type=rom","link_target":"_self","is_accented":0},{"id":49,"title":"Текіла","parent_id":39,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/78c0a67d7244741c4c1948534e5ae924.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/alcohol\/type=tekila","link_target":"_self","is_accented":0},{"id":50,"title":"Джин","parent_id":39,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/efb8753c4bf4b5bcb905532c7c697519.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/alcohol\/type=dzhin","link_target":"_self","is_accented":0},{"id":51,"title":"Лікер","parent_id":39,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/e588bdc8a135be49a63299ecb35ab092.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/alcohol\/type=liker","link_target":"_self","is_accented":0},{"id":52,"title":"Арманьяк","parent_id":39,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/aabaa9097ccd3560e369325aa3301a44.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/alcohol\/type=armanyak","link_target":"_self","is_accented":0},{"id":53,"title":"Кальвадос","parent_id":39,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/552078a82faefaf34403edb51d098f93.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/alcohol\/type=kalvados","link_target":"_self","is_accented":0},{"id":54,"title":"Саке","parent_id":39,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/6be4bbbe547064b1d8728a0741e0b042.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/alcohol\/type=sake","link_target":"_self","is_accented":0},{"id":62,"title":"Вода","parent_id":40,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/d8103f0781dc31a5edde28f8527089ae.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/napoyi-bezalkogolni\/voda","link_target":"_self","is_accented":0},{"id":63,"title":"Сік та нектар","parent_id":40,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/1777ad0e6400ed4df4a1b5842ad48f63.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/napoyi-bezalkogolni\/sik","link_target":"_self","is_accented":0},{"id":64,"title":"Енергетики","parent_id":40,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/d05f23df509fda8d2604ef961045600d.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/napoyi-bezalkogolni\/energetyky","link_target":"_self","is_accented":0},{"id":65,"title":"Сиропи","parent_id":40,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/4e29e61811f898e016ba2a95a176790a.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/napoyi-bezalkogolni\/syropy","link_target":"_self","is_accented":0},{"id":66,"title":"Вода солодка, напої","parent_id":40,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/23fb299e39d933a357a0b64d78b332ca.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/napoyi-bezalkogolni\/voda-solodka-napoyi","link_target":"_self","is_accented":0},{"id":68,"title":"Хліб","parent_id":67,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/d46200af3be5cacdad911a6b05ceb48f.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/hlibobulochni-vyroby\/hlib","link_target":"_self","is_accented":0},{"id":69,"title":"Паски, панеттоне","parent_id":67,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/0c17ad4438e23a96637d7844aa9d896f.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/hlibobulochni-vyroby\/pasky-panettone","link_target":"_self","is_accented":0},{"id":70,"title":"Гріссіні","parent_id":67,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/ccfe6a4e4d041ecaa44eb6c50abdddca.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/hlibobulochni-vyroby\/grissini","link_target":"_self","is_accented":0},{"id":71,"title":"Хлібці","parent_id":67,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/16a0ff1937e9bc8b5238bf49410212c4.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/hlibobulochni-vyroby\/hlibtsi","link_target":"_self","is_accented":0},{"id":76,"title":"Цукерки","parent_id":74,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/7abf66eee2cc6db9b548964e7a688288.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/kondyterski-vyroby\/tsukerky","link_target":"_self","is_accented":0},{"id":77,"title":"Печиво,вафлі","parent_id":74,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/46e29fac49ab73d5c3c8e7f89bb70ff9.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/kondyterski-vyroby\/pechyvo-vafli","link_target":"_self","is_accented":0},{"id":79,"title":"Зефір,мармелад","parent_id":74,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/573ae7ef8ee99e2faf8be20b7047a4c4.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/kondyterski-vyroby\/marmelad-zefir","link_target":"_self","is_accented":0},{"id":80,"title":"Карамель, льодяники, жуйки","parent_id":74,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/21146cd075c514e2ceedf15b8be8786c.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/kondyterski-vyroby\/karamel-lodyanykyzhuyky","link_target":"_self","is_accented":0},{"id":82,"title":"Джеми, курди","parent_id":74,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/0826a55d4e411f0d0173714938443193.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/kondyterski-vyroby\/dzhemy-kurdy","link_target":"_self","is_accented":0},{"id":83,"title":"Шоколадна, горіхова паста","parent_id":74,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/b4061d416bd1a7d491b851ba144ea55b.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/kondyterski-vyroby\/shokoladna-gorihova-pasty","link_target":"_self","is_accented":0},{"id":85,"title":"Чипси","parent_id":84,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/4732e5d435029afe0f179b27436dc349.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/sneky\/chypsy","link_target":"_self","is_accented":0},{"id":87,"title":"Попкорн","parent_id":84,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/b92ec557e8030030f5b38575ebbdea59.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/sneky\/popkorn","link_target":"_self","is_accented":0},{"id":89,"title":"Сухофрукти","parent_id":84,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/8b1428557716ebb4449af325208eb7b7.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/sneky\/suhofrukty","link_target":"_self","is_accented":0},{"id":90,"title":"Горіхи","parent_id":84,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/668ac3da5d4ad4b1528333dc22324ae7.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/sneky\/gorishky","link_target":"_self","is_accented":0},{"id":237,"title":"Чай, кава","parent_id":5,"group_id":null,"image":"https:\/\/winetime.com.ua\/img\/no-photo-available.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/chay-kava","link_target":"_self","is_accented":0},{"id":92,"title":"Борошно, для випікання","parent_id":91,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/cc56b12f4b331786fd4f7a529d9a62a2.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/bakaliya\/boroshno-dlya-vypikannya","link_target":"_self","is_accented":0},{"id":93,"title":"Крупи","parent_id":91,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/2248674ab15a11e968a62cb1f016cf40.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/bakaliya\/krupy","link_target":"_self","is_accented":0},{"id":94,"title":"Сухі сніданки та пластівці","parent_id":91,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/57a5b8f0e22204b450133d4dee6505ef.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/bakaliya\/suhi-snidanky-ta-plastivtsi","link_target":"_self","is_accented":0},{"id":95,"title":"Макаронні вироби","parent_id":91,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/15896547faec2eeeb85dddeccee4858e.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/bakaliya\/makaronni-vyroby","link_target":"_self","is_accented":0},{"id":304,"title":"Олія","parent_id":91,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/cc7cc87e4c5dc0c24e4f073ba1258841.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/bakaliya\/oliya","link_target":"_self","is_accented":0},{"id":96,"title":"Соуси","parent_id":91,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/40afa994e1281016c034b7293c85bdfa.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/bakaliya\/sousy","link_target":"_self","is_accented":0},{"id":305,"title":"Оцет","parent_id":91,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/af165ceab4f3bdd666e273f63eae7689.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/bakaliya\/otset","link_target":"_self","is_accented":0},{"id":97,"title":"Спеції та прянощі","parent_id":91,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/fb5d3c70aed7002cd992ee0baf779032.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/bakaliya\/spetsiyi-ta-pryanoshchi","link_target":"_self","is_accented":0},{"id":306,"title":"Майонез","parent_id":91,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/6a58aa4ef45d2e231497d1e31bfd825a.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/bakaliya\/mayonez","link_target":"_self","is_accented":0},{"id":98,"title":"Японська кухня","parent_id":91,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/0a59ed1a34d314330c41e3289230f2ac.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/bakaliya\/yaponska-kuhnya","link_target":"_self","is_accented":0},{"id":103,"title":"Пюре","parent_id":102,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/54dcf233b78337248803780533b725f8.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/dytyache-harchuvannya\/pyure","link_target":"_self","is_accented":0},{"id":104,"title":"Суміші, каші","parent_id":102,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/06c3b9fe43792594ef1eb41e8090d3c6.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/dytyache-harchuvannya\/sumishi-kashi","link_target":"_self","is_accented":0},{"id":105,"title":"Напої","parent_id":102,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/2eebd014d4b54a155451331e31c03d3b.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/dytyache-harchuvannya\/napoyi","link_target":"_self","is_accented":0},{"id":106,"title":"Солодощі","parent_id":102,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/ad65473c7d9c425e6ba2e9254c4fb243.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/dytyache-harchuvannya\/solodoshchi","link_target":"_self","is_accented":0},{"id":109,"title":"Вега напівфабрикати","parent_id":107,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/4852d82bfff7a84dc555dc1b1628a76f.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/veganski-produkty\/vega-napivfabrykaty","link_target":"_self","is_accented":0},{"id":110,"title":"Вега сир","parent_id":107,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/7b5b8272b7b70f02820fdb158460acd2.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/veganski-produkty\/vega-syr","link_target":"_self","is_accented":0},{"id":111,"title":"Вега ковбаса","parent_id":107,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/2dd37e1c4834f1e641f3d0758046e8f3.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/veganski-produkty\/vega-kovbasa","link_target":"_self","is_accented":0},{"id":112,"title":"Вега солодощі","parent_id":107,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/fc10329963f285440949c482d5a4ed03.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/veganski-produkty\/vega-solodoshchi","link_target":"_self","is_accented":0},{"id":113,"title":"Альтернативна молочна продукція","parent_id":107,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/8aed8bc242071ebd3b2acd781264ecd5.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/veganski-produkty\/alternatyvna-molochna-produktsiya","link_target":"_self","is_accented":0},{"id":115,"title":"Сир витриманий","parent_id":114,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/65b4e3cbee70d1922e5d9fb07c135157.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/syry\/syr-vytrymanyy","link_target":"_self","is_accented":0},{"id":116,"title":"Сир м'який","parent_id":114,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/f49ed5abef2750c316a137ff48a70658.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/syry\/syr-myakyy","link_target":"_self","is_accented":0},{"id":117,"title":"Сир з блакитною пліснявою","parent_id":114,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/45c0c5fdbd5470ed76bfed979acbbb44.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/syry\/syr-z-blakytnoyu-plisnyavoyu","link_target":"_self","is_accented":0},{"id":120,"title":"Сир напівтвердий","parent_id":114,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/7edd127a86cb7e03921759027e97d53b.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/syry\/syr-napivtverdyy","link_target":"_self","is_accented":0},{"id":122,"title":"Ікра","parent_id":121,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/357bcca5ccbeaea48f85c3387f8c33ee.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/ryba-moreprodukty\/ikra","link_target":"_self","is_accented":0},{"id":124,"title":"Риба","parent_id":121,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/898b7dd27e570124de9da763c67835e1.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/ryba-moreprodukty\/ryba","link_target":"_self","is_accented":0},{"id":127,"title":"Молоко","parent_id":126,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/cc4dd555a36262995342a7cf25c01c28.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/molochni-produkty\/moloko","link_target":"_self","is_accented":0},{"id":128,"title":"Масло вершкове","parent_id":126,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/15877cf02b477dd5e5715d87d1b14185.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/molochni-produkty\/maslo-vershkove","link_target":"_self","is_accented":0},{"id":130,"title":"Десерти молочні, йогурти","parent_id":126,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/83d89dfa2fb1880b609e1df88879d728.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/molochni-produkty\/deserty-molochni-yogurty","link_target":"_self","is_accented":0},{"id":131,"title":"Кисломолочні продукти","parent_id":126,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/4685cc09e550d9988ba29e3a908b0228.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/molochni-produkty\/kyslomolochna-produktsiya","link_target":"_self","is_accented":0},{"id":132,"title":"Яйця","parent_id":126,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/5ec56e9c9af5b92d00461bbfb104ab6f.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/molochni-produkty\/yaytsya","link_target":"_self","is_accented":0},{"id":134,"title":"Вареники, пельмені","parent_id":133,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/f8d80ca23d18efb95bc4aebb2f149f4d.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/pelmeni-varenyky","link_target":"_self","is_accented":0},{"id":136,"title":"Напівфабрикати","parent_id":133,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/f6b1790c36490e2e7403668df470f23e.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/zamorozheni-produkty\/napivfabrykaty","link_target":"_self","is_accented":0},{"id":138,"title":"Солона та солодка випічка","parent_id":133,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/6f733b2b42c2e1ab121f3f56a2a33c08.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/zamorozheni-produkty\/solona-ta-solodka-vypichka","link_target":"_self","is_accented":0},{"id":307,"title":"Заморожені овочі, фрукти","parent_id":133,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/b57fc7410c771b94caa499825132ff8e.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/zamorozheni-produkty\/zamorozheni-ovochi-frukty","link_target":"_self","is_accented":0},{"id":142,"title":"Фрукти","parent_id":141,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/0aee985420324f3fc5885ed30a7e4dba.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/svizhi-ovochi-frukty\/frukti","link_target":"_self","is_accented":0},{"id":143,"title":"Овочі","parent_id":141,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/deae93dfceeca331eb4f2e2cfdd639f7.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/svizhi-ovochi-frukty\/ovochi","link_target":"_self","is_accented":0},{"id":145,"title":"Птиця","parent_id":144,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/741a87429208c2987b572e66cedca8c5.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/svizhe-myaso\/ptytsya","link_target":"_self","is_accented":0},{"id":146,"title":"Свинина","parent_id":144,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/d88a1887af4ced27ae739a61fb6f99ef.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/svizhe-myaso\/svynyna","link_target":"_self","is_accented":0},{"id":147,"title":"Яловичина","parent_id":144,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/b62e98b410b03c95e2931b9f9ce80f62.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/svizhe-myaso\/yalovychyna","link_target":"_self","is_accented":0},{"id":148,"title":"Баранина","parent_id":144,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/7714044cb47ad1f34bcbeb7f6730df2d.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/svizhe-myaso\/baranyna","link_target":"_self","is_accented":0},{"id":149,"title":"Кролик","parent_id":144,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/448859f0254178d629bdff3c1dff9d3e.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/svizhe-myaso\/krolyk","link_target":"_self","is_accented":0},{"id":309,"title":"Стейки","parent_id":144,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/3d8ef91c31f43d7834b562f37c3bbdbb.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/svizhe-myaso\/steyky","link_target":"_self","is_accented":0},{"id":310,"title":"Шашлик","parent_id":144,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/0d1c87cbef6c521b405b6096d7fe153b.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/svizhe-myaso\/shashlyk","link_target":"_self","is_accented":0},{"id":151,"title":"Аксесуари","parent_id":null,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/4f4aeb0a6f9b37c60fd0b34d4a5d6070.png","template":"3_levels","depth":1,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary","link_target":"_self","is_accented":0},{"id":161,"title":"Акції","parent_id":null,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/fb2f3b7613262e738920a35a7c171946.jpeg","template":"2_levels","depth":1,"link_href":"https:\/\/winetime.com.ua\/ua\/aktsionnye-tovary","link_target":"_self","is_accented":0},{"id":163,"title":"Знижки на напої","parent_id":161,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/4c7d54c5ee963a89422d037e66cf7d7f.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/napoyi-slaboalkogolni\/promotional","link_target":"_self","is_accented":0},{"id":164,"title":"Знижки на продукти","parent_id":161,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/ff6209f11e9f3809ff636f292b297ad1.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/promotional","link_target":"_self","is_accented":0},{"id":165,"title":"Знижки на аксесуари","parent_id":161,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/ab8f6f7c729708e6179fcf896dd1f888.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/promotional","link_target":"_self","is_accented":0},{"id":168,"title":"Солодкість","parent_id":1,"group_id":null,"image":"https:\/\/winetime.com.ua\/img\/no-photo-available.png","template":"group","depth":2,"link_href":null,"link_target":"_self","is_accented":0},{"id":177,"title":"Книги","parent_id":157,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/c08c5817dd018209e8d1cc0718c963aa.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/literatura\/knyzhky","link_target":"_self","is_accented":0},{"id":178,"title":"Пакети","parent_id":160,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/248d775a34d35731715d06c9d3afbe90.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/upakovka\/pakety","link_target":"_self","is_accented":0},{"id":179,"title":"Корзини","parent_id":160,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/17ca9396e1692f258a24d74c5d94ed38.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/upakovka\/korzyny","link_target":"_self","is_accented":0},{"id":180,"title":"Короби","parent_id":160,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/609c77f6cc0441f7e39d954984e14818.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/upakovka\/koroby","link_target":"_self","is_accented":0},{"id":181,"title":"Сумки для шопінгу","parent_id":160,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/277bb37d351c652a60c165d3ee85ebac.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/upakovka\/sumky-dlya-shopingu","link_target":"_self","is_accented":0},{"id":182,"title":"Ігри та іграшки","parent_id":156,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/5634f20786a6472661262cd6d0027a3f.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/igry-ta-suveniry\/igri-ta-igrashki","link_target":"_self","is_accented":0},{"id":183,"title":"Новорічні іграшки","parent_id":156,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/888776029dc00c18b2d71b8659257fb3.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/igry-ta-suveniry\/novorichni-igrashky","link_target":"_self","is_accented":0},{"id":185,"title":"Сувеніри","parent_id":156,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/f13a48cd7fb183e6035bc59877ff8586.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/igry-ta-suveniry\/suveniry","link_target":"_self","is_accented":0},{"id":186,"title":"Сертифікати","parent_id":159,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/54d58706760243af1276e423e4ddefc0.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/sertyfikaty","link_target":"_self","is_accented":0},{"id":188,"title":"Крем","parent_id":187,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/526fc86f396c74efaae18c603591b930.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/kosmetyka\/krem","link_target":"_self","is_accented":0},{"id":335,"title":"Арома рідке мило","parent_id":187,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/f5af308ebaaa0e9255f01c17e1a30532.png","template":"1_level","depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/kosmetyka\/aroma-ridke-mylo","link_target":"_self","is_accented":0},{"id":189,"title":"Парфумоване мило","parent_id":187,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/f6b95a9eadfde22dac3cbbd63cba04f6.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/kosmetyka\/parfumovane-mylo","link_target":"_self","is_accented":0},{"id":336,"title":"Гель для душу","parent_id":187,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/99e30e5cd93c42e57ca670f81b523223.png","template":"1_level","depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/kosmetyka\/gel-dlya-dushu","link_target":"_self","is_accented":0},{"id":337,"title":"Кондиціонер для волосся","parent_id":187,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/27cd51001f799526de540952fa6d13cf.png","template":"1_level","depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/kosmetyka\/kondytsioner-dlya-volossya","link_target":"_self","is_accented":0},{"id":338,"title":"Лосьйон для тіла","parent_id":187,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/6e285878d23357a691c1c2cfe4b43185.png","template":"1_level","depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/kosmetyka\/losyon-dlya-tila","link_target":"_self","is_accented":0},{"id":339,"title":"Шампунь для волосся","parent_id":187,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/3a22d72c9a50723d42d56334d8acee86.png","template":"1_level","depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/kosmetyka\/shampun-dlya-volossya","link_target":"_self","is_accented":0},{"id":340,"title":"Подарункові набори косметики","parent_id":187,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/e167af5b7e56c14c01c63b4757f03c9e.png","template":"1_level","depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/kosmetyka\/podarunkovi-nabory-kosmetyky","link_target":"_self","is_accented":0},{"id":331,"title":"Товари для здоров'я","parent_id":187,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/cdaecbb47840eed8d60d1474d5ec6b7d.jpeg","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/kosmetyka\/tovary-dlya-zdorovya","link_target":"_self","is_accented":0},{"id":191,"title":"Свічки та підсвічники","parent_id":190,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/7e3ece5b22debd5972192694089fd5bd.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/zatyshok\/svichky-ta-pidsvichnyky","link_target":"_self","is_accented":0},{"id":192,"title":"Дифузори та  арома рідина","parent_id":190,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/5317597e7d7bffc55e62c5e542890bf8.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/zatyshok\/dyfuzory-ta-aroma-ridyna","link_target":"_self","is_accented":0},{"id":193,"title":"Світильники","parent_id":190,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/ed14cd21f9a42131983328c3250fa43b.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/zatyshok\/svitylnyky","link_target":"_self","is_accented":0},{"id":194,"title":"Арома спреї","parent_id":190,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/e24aacc1987243beb1ec954e905e30d3.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/zatyshok\/aroma-spreyi","link_target":"_self","is_accented":0},{"id":195,"title":"Серветки","parent_id":190,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/b37450d5bb2f5db9f954ffee1ba263df.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/zatyshok\/servetky","link_target":"_self","is_accented":0},{"id":196,"title":"Дифузори для авто","parent_id":190,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/76c788158a6807ad685ef92941e35c50.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/zatyshok\/dyfuzory-dlya-avto","link_target":"_self","is_accented":0},{"id":197,"title":"Для барбекю","parent_id":190,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/33c797b06b6d9ac6af2792084bb34ff8.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/zatyshok\/dlya-barbekyu","link_target":"_self","is_accented":0},{"id":199,"title":"Ножі та столові прибори","parent_id":198,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/ba2ffedd67002a87f11ddf36eb887c6b.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/posud-ta-kuhonne-pryladdya\/nozhi-ta-stolovi-prybory","link_target":"_self","is_accented":0},{"id":200,"title":"Кухонне приладдя та органайзери","parent_id":198,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/dd10ddef6fe05474c9060135a3d13117.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/posud-ta-kuhonne-pryladdya\/kuhonne-pryladdya-ta-organayzery","link_target":"_self","is_accented":0},{"id":201,"title":"Посуд для приготування та запікання","parent_id":198,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/6cc103575bd520f00aa229ced16e3670.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/posud-ta-kuhonne-pryladdya\/posud-dlya-prygotuvannya-ta-zapikannya","link_target":"_self","is_accented":0},{"id":202,"title":"Посуд для сервірування","parent_id":198,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/fb8b9269adc04dc1863810321877f0f4.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/posud-ta-kuhonne-pryladdya\/posud-dlya-serviruvannya","link_target":"_self","is_accented":0},{"id":203,"title":"Ланчбокси, термобокси, термопакети","parent_id":198,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/154e930f329ebf0b82462fc4bf1eb29d.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/posud-ta-kuhonne-pryladdya\/lanchboksy-termoboksy-termopakety","link_target":"_self","is_accented":0},{"id":204,"title":"Посуд дитячий","parent_id":198,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/946891c2e82dfcf661818501d289351e.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/posud-ta-kuhonne-pryladdya\/posud-dytyachyy","link_target":"_self","is_accented":0},{"id":205,"title":"Побутова техніка","parent_id":198,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/381681b5256d02fc61f68a5279d09abb.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/posud-ta-kuhonne-pryladdya\/pobutova-tehnika","link_target":"_self","is_accented":0},{"id":207,"title":"Келихи для білого вина","parent_id":206,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/1cb74c5095e1cf7be865ba342086a7e8.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/bokaly-dlya-bilogo-vyna","link_target":"_self","is_accented":0},{"id":208,"title":"Келихи для червоного вина","parent_id":206,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/e36132808beeb2704fee6c2ad1336836.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/bar\/bokaly-dlya-chervonogo-vyna","link_target":"_self","is_accented":0},{"id":209,"title":"Келихи для ігристого вина","parent_id":206,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/b7b733ba779695fcd489cd40d9930f66.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/bar\/bokaly-dlya-igrystogo-vyna","link_target":"_self","is_accented":0},{"id":210,"title":"Келихи для міцних напоїв","parent_id":206,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/f2d30ccb7643f6c545a41c9aef7e3447.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/bar\/bokaly-dlya-mitsnyh-napoyiv","link_target":"_self","is_accented":0},{"id":211,"title":"Келихи для коктейлів","parent_id":206,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/a4b7a619b4baf42229588b44c560cbeb.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/bar\/bokaly-dlya-kokteyliv","link_target":"_self","is_accented":0},{"id":212,"title":"Келихи для напоїв","parent_id":206,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/bf9e9a0ac4af656910d0b1534b4e3e9d.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/bar\/bokaly-dlya-napoyiv","link_target":"_self","is_accented":0},{"id":213,"title":"Декантери","parent_id":206,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/87c550745bfc99e8602f6d972bf2ce2f.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/bar\/dekantery","link_target":"_self","is_accented":0},{"id":214,"title":"Аксесуари для вина та бару","parent_id":206,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/bf787dded96b340c3669725a2270edf7.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/bar\/aksesuary-dlya-vyna-ta-baru","link_target":"_self","is_accented":0},{"id":215,"title":"Штопори","parent_id":206,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/4f66dcf394c3d95952dde0855781792f.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/bar\/shtopory","link_target":"_self","is_accented":0},{"id":218,"title":"Засоби для прання","parent_id":216,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/b0c464eb948dad1d867d4b8efb5e05cc.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/gospodarski-tovary\/zasoby-dlya-prannya","link_target":"_self","is_accented":0},{"id":219,"title":"Засоби для прибирання","parent_id":216,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/9bee43ac3b67c7047bf39a565d5e8f5c.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/gospodarski-tovary\/zasoby-dlya-prybyrannya","link_target":"_self","is_accented":0},{"id":220,"title":"Листівки","parent_id":157,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/4db4a776489f5de082d541fd588d31ba.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary\/literatura\/lystivky","link_target":"_self","is_accented":0},{"id":225,"title":"Набори","parent_id":null,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/3f570b9a6506122bad9a3d660b30d8e7.jpeg","template":"2_levels","depth":1,"link_href":"https:\/\/winetime.com.ua\/ua\/sets","link_target":"_self","is_accented":0},{"id":311,"title":"Готові страви","parent_id":null,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/813278958c9de417ba96fb1b5b40da76.png","template":"2_levels","depth":null,"link_href":"https:\/\/winetime.com.ua\/ua\/gotovi-stravy","link_target":"_self","is_accented":0},{"id":6,"title":"Готові страви","parent_id":null,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/044f214252aa1a238a8e5116db688ed7.jpeg","template":"1_level","depth":1,"link_href":"https:\/\/food.winetime.com.ua\/","link_target":"_blank","is_accented":1},{"id":296,"title":"Garage sale","parent_id":null,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/d7e14aa9a71269f23b5cd482121506c4.jpeg","template":"1_level","depth":1,"link_href":"https:\/\/winetime.com.ua\/ua\/garage-sale","link_target":"_self","is_accented":0},{"id":226,"title":"Подарункові набори","parent_id":225,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/a7cd88b99e771f7507e4dc739717e5c0.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/nabory\/podarunkovi-nabory","link_target":"_self","is_accented":0},{"id":227,"title":"Знижки на міцні напої","parent_id":161,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/aa0dbe1022eab49edf53ee1f88262684.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/mitsnyy-alkogol\/promotional","link_target":"_self","is_accented":0},{"id":256,"title":"Колір","parent_id":55,"group_id":null,"image":"https:\/\/winetime.com.ua\/img\/no-photo-available.png","template":"group","depth":2,"link_href":null,"link_target":"_self","is_accented":0},{"id":257,"title":"Класифікація","parent_id":55,"group_id":null,"image":"https:\/\/winetime.com.ua\/img\/no-photo-available.png","template":"group","depth":2,"link_href":null,"link_target":"_self","is_accented":0},{"id":229,"title":"Ель","parent_id":228,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/be33ceb321cd109bab3737a655773e9c.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/el","link_target":"_self","is_accented":0},{"id":230,"title":"Пілснер","parent_id":228,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/e3f5b576703f68b0184074a082245de3.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/pilsner","link_target":"_self","is_accented":0},{"id":231,"title":"Темне","parent_id":228,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/ab04e78cd6eee92ab2eac729f71c23d3.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/temne","link_target":"_self","is_accented":0},{"id":232,"title":"Світле","parent_id":228,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/80bb31d6a14acbd779f55a24e8194e16.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/svitle","link_target":"_self","is_accented":0},{"id":233,"title":"Лагер","parent_id":228,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/b94451a7dcae733dd1f062bdc82fdf6d.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/lager","link_target":"_self","is_accented":0},{"id":234,"title":"IPA","parent_id":228,"group_id":null,"image":"https:\/\/winetime.com.ua\/img\/no-photo-available.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/ipa","link_target":"_self","is_accented":0},{"id":235,"title":"Безалкогольне","parent_id":228,"group_id":null,"image":"https:\/\/winetime.com.ua\/img\/no-photo-available.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/bezalkogolne","link_target":"_self","is_accented":0},{"id":238,"title":"Чай","parent_id":237,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/dae6639751bea75534556f1cca2314a6.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/chay-kava\/chay","link_target":"_self","is_accented":0},{"id":239,"title":"Кава","parent_id":237,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/91f8064bed6528688dd18e236e3c0729.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/chay-kava\/kava","link_target":"_self","is_accented":0},{"id":240,"title":"Какао","parent_id":237,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/a89e6f93624645864b3fc4ac8b336d4c.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/chay-kava\/kakao","link_target":"_self","is_accented":0},{"id":242,"title":"Консервовані фрукти","parent_id":241,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/971b9e710623dd1921b26eacd9416425.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/konservatsiya\/konservovani-frukty","link_target":"_self","is_accented":0},{"id":243,"title":"Консерви овочеві","parent_id":241,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/4f18b4ebbef0ca1372719edb56a06a46.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/konservatsiya\/konservy-ovochevi","link_target":"_self","is_accented":0},{"id":244,"title":"Оливки","parent_id":241,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/6d0876712817fec6df890ad4717aa92b.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/konservatsiya\/olyvky","link_target":"_self","is_accented":0},{"id":245,"title":"Консерви м'ясні","parent_id":241,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/07cc41f7ee20f86b8f52dda54fd57ed6.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/konservatsiya\/konservy-myasni","link_target":"_self","is_accented":0},{"id":246,"title":"Альтернативні напої","parent_id":107,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/1132d52065fbb8d4f66de1eeaf4bcf38.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/veganski-produkty\/alternatyvni-napoyi","link_target":"_self","is_accented":0},{"id":247,"title":"Хумус","parent_id":107,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/6508de84612d40fcaf1564b1147eac68.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/veganski-produkty\/humus","link_target":"_self","is_accented":0},{"id":248,"title":"Сир копчений","parent_id":114,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/87dddb47293c2bf328b2eaacbb7ad724.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/syry\/syr-kopchenyy","link_target":"_self","is_accented":0},{"id":249,"title":"Консерви рибні","parent_id":121,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/9ab82dd54a688b45085a79f875931a97.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/ryba-moreprodukty\/konservy-rybni","link_target":"_self","is_accented":0},{"id":250,"title":"Безлактозна продукція","parent_id":126,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/75477f6a7b4e5944db838d3b07e08d83.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/molochni-produkty\/bezlaktozna-produktsiya","link_target":"_self","is_accented":0},{"id":251,"title":"Зелень","parent_id":141,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/fbb3535c6ce131b07acacb60e3c25c30.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/svizhi-ovochi-frukty\/zelen","link_target":"_self","is_accented":0},{"id":252,"title":"Батончики","parent_id":74,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/9c5ea5340c5e1b8a26c9dc06ffd412b1.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/kondyterski-vyroby\/batonchyky","link_target":"_self","is_accented":0},{"id":253,"title":"Мед","parent_id":74,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/252489236a13b215aba7cf79eb0299dc.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/kondyterski-vyroby\/med","link_target":"_self","is_accented":0},{"id":254,"title":"Варення","parent_id":74,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/14f58efac5095b4c6045441b3eabc380.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/kondyterski-vyroby\/varennya","link_target":"_self","is_accented":0},{"id":255,"title":"Торти","parent_id":67,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/a9d6f156e79d6ab962ffe43af7e4b2d3.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/hlibobulochni-vyroby\/torty","link_target":"_self","is_accented":0},{"id":261,"title":"Теннессі віскі","parent_id":38,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/5b9e68f3699563e76206bccdf31b1c83.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/viski\/tennessi-viski","link_target":"_self","is_accented":0},{"id":262,"title":"Мескаль","parent_id":39,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/d503e1c51c3fcd3005fc2c3f8e735bda.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/mitsnyy-alkogol\/meskal","link_target":"_self","is_accented":0},{"id":263,"title":"Спиртні дива світу","parent_id":39,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/3ae7cbf3c397cbf7b91fd90e2d21d149.png","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/mitsnyy-alkogol\/spyrtni-dyva-svitu","link_target":"_self","is_accented":0},{"id":265,"title":"Вино та ігристі","parent_id":264,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/45f78edb91d5875751c6947a995fd75d.jfif","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/vyno-ta-igrysti-do-velykodnogo-koshyka","link_target":"_blank","is_accented":0},{"id":266,"title":"Міцні напої","parent_id":264,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/13fdef3e47f54c2c7f92039733c1aedc.jfif","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/mitsni-napoyi-do-velykodnogo-koshyka","link_target":"_blank","is_accented":0},{"id":267,"title":"Паски","parent_id":264,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/bac340ae9a6b47a2b0f9c01a1a6c7a24.jfif","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/hlibobulochni-vyroby\/pasky-panettone","link_target":"_blank","is_accented":0},{"id":268,"title":"Солодощі","parent_id":264,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/fc11c87fd8613bbe579db190a242cc0f.jfif","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/solodoshchi-do-velykodnogo-koshyka","link_target":"_blank","is_accented":0},{"id":269,"title":"Продукти","parent_id":264,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/c4d0da940731ba055944e99a15278d73.jfif","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/produkty-do-velykodnogo-koshyka","link_target":"_blank","is_accented":0},{"id":270,"title":"Аксесуари","parent_id":264,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/aaef8b9551398261384cc0de457f2831.jfif","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/aksesuary-do-velykodnogo-koshyka","link_target":"_blank","is_accented":0},{"id":271,"title":"Набори","parent_id":264,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/d83251986afa19d3a777b73d4e5e0a11.jfif","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/nabory\/podarunkovi-nabory","link_target":"_blank","is_accented":0},{"id":278,"title":"Пиво 02.08.2024","parent_id":274,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/fb1262721a87eb719177670addafb173.jfif","template":null,"depth":2,"link_href":null,"link_target":"_self","is_accented":0},{"id":280,"title":"Коктейль «Мартіні версія «007»»","parent_id":279,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/588bafb1074183ef2014f460e6e3550f.jpg","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/kokteyl-martini-versiya-007","link_target":"_self","is_accented":0},{"id":281,"title":"Коктейль «Cosmopolitan light»","parent_id":279,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/78f434fbb889a11afb6305361cbdc704.jpg","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/kokteyl-cosmopolitan-light","link_target":"_self","is_accented":0},{"id":282,"title":"Коктейль «Tropical Blue Lagoon»","parent_id":279,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/f9ea5a8bd564ec959675a43312b9e590.jpg","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/kokteyl-tropical-blue-lagoon","link_target":"_self","is_accented":0},{"id":283,"title":"Коктейль «Tropical Sunset Mai Tai»","parent_id":279,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/2bf50974a6b0838f57b997747c5aaa5b.jpg","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/kokteyl-tropical-sunset-mai-tai","link_target":"_self","is_accented":0},{"id":284,"title":"Коктейль «French 75 версия «Gossip Girl»»","parent_id":279,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/34863a22e51ea88298fdf7236d1a8d83.jpg","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/kokteyl-french-75-versiya-gossip-girl","link_target":"_self","is_accented":0},{"id":285,"title":"Коктейль «Tequila Sunrise»","parent_id":279,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/0400a6bd853b9d661a7a58a31d8c42dc.jpg","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/kokteyl-tequila-sunrise","link_target":"_self","is_accented":0},{"id":286,"title":"Коктейль «Kir Royale»","parent_id":279,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/4b61aa9d8a12489267f8d7c27f1f0bd6.jpg","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/kokteyl-kir-royale","link_target":"_self","is_accented":0},{"id":287,"title":"Коктейль «Pink Mojito»","parent_id":279,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/69caac517dc559e8c69431a0c1f9cb12.jpg","template":null,"depth":2,"link_href":"https:\/\/winetime.com.ua\/ua\/kokteyl-pink-mojito","link_target":"_self","is_accented":0},{"id":288,"title":"Гриби","parent_id":141,"group_id":null,"image":"https:\/\/winetime.com.ua\/storage\/51a3b046cbb9e04b66657734c52d5514.png","template":null,"depth":3,"link_href":"https:\/\/winetime.com.ua\/ua\/food\/svizhi-ovochi-frukty\/gryby","link_target":"_self","is_accented":0}],
+        default_cities: [{"id":1605,"ref":"8d5a980d-391c-11dd-90d9-001a92567626","title":"Київ","type":"місто","has_timeslots":true},{"id":702,"ref":"db5c88de-391c-11dd-90d9-001a92567626","title":"Вінниця","type":"місто","has_timeslots":true},{"id":1104,"ref":"db5c88f0-391c-11dd-90d9-001a92567626","title":"Дніпро","type":"місто","has_timeslots":false},{"id":1333,"ref":"db5c88c6-391c-11dd-90d9-001a92567626","title":"Запоріжжя","type":"місто","has_timeslots":false},{"id":1462,"ref":"db5c8904-391c-11dd-90d9-001a92567626","title":"Івано-Франківськ","type":"місто","has_timeslots":true},{"id":1862,"ref":"db5c890d-391c-11dd-90d9-001a92567626","title":"Кривий Ріг","type":"місто","has_timeslots":false},{"id":1879,"ref":"db5c891b-391c-11dd-90d9-001a92567626","title":"Кропивницький","type":"місто","has_timeslots":false},{"id":2082,"ref":"db5c893b-391c-11dd-90d9-001a92567626","title":"Луцьк","type":"місто","has_timeslots":false},{"id":2084,"ref":"db5c88f5-391c-11dd-90d9-001a92567626","title":"Львів","type":"місто","has_timeslots":false},{"id":2263,"ref":"db5c888c-391c-11dd-90d9-001a92567626","title":"Миколаїв","type":"місто","has_timeslots":false},{"id":2698,"ref":"db5c88d0-391c-11dd-90d9-001a92567626","title":"Одеса","type":"місто","has_timeslots":false},{"id":3834,"ref":"db5c8900-391c-11dd-90d9-001a92567626","title":"Тернопіль","type":"місто","has_timeslots":false},{"id":4017,"ref":"db5c88e0-391c-11dd-90d9-001a92567626","title":"Харків","type":"місто","has_timeslots":false},{"id":4135,"ref":"db5c8902-391c-11dd-90d9-001a92567626","title":"Черкаси","type":"місто","has_timeslots":true},{"id":4150,"ref":"db5c897c-391c-11dd-90d9-001a92567626","title":"Чернігів","type":"місто","has_timeslots":false}],
+        city: {"id":1605,"ref":"8d5a980d-391c-11dd-90d9-001a92567626","title":"Київ","type":"місто","has_timeslots":false},
+        top_menu: [{"title":"","url":"","children":[{"title":"Акції","url":"https:\/\/winetime.com.ua\/ua\/aktsiyni-tovary"},{"title":"Магазини","url":"https:\/\/winetime.com.ua\/ua\/magaziny"},{"title":"Онлайн магазин","url":""},{"title":"Доставка з магазину","url":"https:\/\/winetime.com.ua\/ua\/o-dostavke"},{"title":"Фудкорт та суші","url":"https:\/\/food.winetime.com.ua\/"},{"title":"Школа сомельє","url":"https:\/\/winetimeacademy.com.ua\/"},{"title":"Морепродукти Fish Time","url":"https:\/\/winetime.com.ua\/ua\/food\/ryba-moreprodukty\/brand=fish-time"},{"title":"Перші ціни","url":"https:\/\/winetime.com.ua\/ua\/love-price"}]},{"title":"Власне виробництво WINETIME","url":"","children":[{"title":"Пекарня Жорна","url":"https:\/\/winetime.com.ua\/ua\/pekarnya-zhornova"},{"title":"Пивоварня John Barleycorn","url":"https:\/\/winetime.com.ua\/ua\/pyvovarnya-john-barleycorn"},{"title":"Тростинка","url":"https:\/\/winetime.com.ua\/ua\/trostynka"},{"title":"Гастромайстерня","url":"https:\/\/winetime.com.ua\/ua\/gastromaysternya-winetime:-kraft-shcho-govoryt-sam-za-sebe"},{"title":"Кава WINETIME","url":"\/ua\/kava-winetime"}]},{"title":"Тематичні та унікальні пропозиції","url":"","children":[{"title":"Обирайте свою країну дня зі знижкою до -50%!","url":"https:\/\/winetime.com.ua\/ua\/obyrayte-svoyu-krayinu-dnya-zi-znyzhkoyu-do-50"},{"title":"До -50% на вино та міцні напої тільки на сайті!","url":"https:\/\/winetime.com.ua\/ua\/do-50-na-vyno-mitsni-napoyi-tilky-na-sayti"},{"title":"Garage sale","url":"https:\/\/winetime.com.ua\/ua\/garage-sale"},{"title":"ТОП ціни на продукти!","url":"https:\/\/winetime.com.ua\/ua\/top-tsiny-na-produkty"}]}],
+        additional_menu: [{"title":"Для гостей","url":"http:\/\/winetime.redentu.top\/ua","children":[{"title":"Контакти","url":"https:\/\/winetime.com.ua\/ua\/contactsim"},{"title":"Магазини","url":"https:\/\/winetime.com.ua\/ua\/magaziny"},{"title":"Компанія","url":"https:\/\/winetime.com.ua\/ua\/pro-kompaniyu"},{"title":"Події","url":"https:\/\/winetime.com.ua\/ua\/events"},{"title":"ЗМІ про нас","url":"https:\/\/winetime.com.ua\/ua\/media-about-us"},{"title":"Блог","url":"https:\/\/www.red-on-white.com.ua\/"},{"title":"Корпоративним клієнтам","url":"https:\/\/winetime.com.ua\/ua\/korporativnim-klientam"},{"title":"Каталог корпоративних подарунків","url":"https:\/\/winetime.com.ua\/\/uploads\/contents\/WINETIME%202026__1770726992.pdf"},{"title":"Програма лояльності офлайн магазинів","url":"https:\/\/winetime.com.ua\/ua\/programa-loyalnosti-oflayn-magaziniv"}]},{"title":"Акції та пропозиції","url":"","children":[{"title":"Від -20% на пиво Meteor!","url":"https:\/\/winetime.com.ua\/ua\/vid-20-na-pyvo-meteor"},{"title":"До -50% на тихі вина та ігристі!","url":"https:\/\/winetime.com.ua\/ua\/do-50-na-tyhi-vyna-ta-igrysti"},{"title":"1+1 на форми Peugeot!","url":"https:\/\/winetime.com.ua\/ua\/11-na-formy-dlya-zapikannya-peugeot"},{"title":"-15% на блендери SMEG!","url":"https:\/\/winetime.com.ua\/ua\/-15-na-blendery-vysokoyi-potuzhnosti-smeg"},{"title":"-20% на тостер SMEG!","url":"https:\/\/winetime.com.ua\/ua\/-20-na-toster-smeg-chervonogo-koloru"},{"title":"До -30% на оливкову олію!","url":"https:\/\/winetime.com.ua\/ua\/food\/bakaliya\/oliya\/promotional"},{"title":"2+1 паста Rummo!","url":"https:\/\/winetime.com.ua\/ua\/21-pasta-rummo"},{"title":"Всі акційні товари","url":"https:\/\/winetime.com.ua\/ua\/aktsiyni-tovary"}]},{"title":"Цікавинки","url":"","children":[{"title":"Новини","url":"https:\/\/winetime.com.ua\/ua\/novosti"},{"title":"Новинки","url":"https:\/\/winetime.com.ua\/ua\/novynky"},{"title":"Бестселери","url":"https:\/\/winetime.com.ua\/ua\/khity"},{"title":"Подарункові набори","url":"https:\/\/winetime.com.ua\/ua\/nabory\/podarunkovi-nabory"}]},{"title":"Кар'єра у WINETIME","url":"https:\/\/winetime.com.ua\/ua\/vakancii","children":[]},{"title":"Подарункові сертифікати","url":"https:\/\/winetime.com.ua\/ua\/aksesuary\/sertyfikaty","children":[]},{"title":"Для постачальників","url":"https:\/\/winetime.com.ua\/pdf\/guide_vendor_ts_plus.pdf","children":[]}],
+        banners: [{"title":"\u041f\u0435\u0440\u0448\u0456 \u0446\u0456\u043d\u0438 \u043d\u0430 \u0432\u0438\u043d\u043e \u0442\u0430 \u043c\u0456\u0446\u043d\u0456 \u043d\u0430\u043f\u043e\u0457!","url":"https:\/\/winetime.com.ua\/ua\/love-price","image":"https:\/\/winetime.com.ua\/uploads\/symlink\/66000-67000\/\u043b\u0430\u0432_\u043f\u0440\u0430\u0439\u0441_\u043a\u0430\u0442\u0430\u043b\u043e\u0433.jpg"},{"title":"\u0414\u043e -50% \u043d\u0430 \u0442\u0438\u0445\u0456 \u0432\u0438\u043d\u0430 \u0442\u0430 \u0456\u0433\u0440\u0438\u0441\u0442\u0456!","url":"https:\/\/winetime.com.ua\/ua\/do-50-na-tyhi-vyna-ta-igrysti","image":"https:\/\/winetime.com.ua\/uploads\/symlink\/66000-67000\/\u0456\u0433\u0438\u0440\u0441\u0442\u0435_\u0432\u0438\u043d\u043e_\u043a\u0430\u0442\u0430\u043b\u043e\u04331.jpg"}],
+        brands: [{"title":"\u0416\u043e\u0440\u043d\u043e\u0432\u0430","url":"https:\/\/winetime.com.ua\/ua\/pekarnya-zhornova","image":"https:\/\/winetime.com.ua\/uploads\/symlink\/66000-67000\/\u0436\u043e\u0440\u043e\u043d\u043e\u0432\u0430_\u043f\u043b\u0430\u0448\u043a\u0430_2.jpg"},{"title":"John Barleycorn","url":"https:\/\/winetime.com.ua\/ua\/pyvovarnya-john-barleycorn","image":"https:\/\/winetime.com.ua\/uploads\/symlink\/66000-67000\/Barleycorn3.png"},{"title":"\u0422\u0440\u043e\u0441\u0442\u0438\u043d\u043a\u0430","url":"https:\/\/winetime.com.ua\/ua\/trostynka","image":"https:\/\/winetime.com.ua\/uploads\/symlink\/66000-67000\/\u0442\u0440\u043e\u0441\u0442\u0438\u043d\u043a\u0430.jpg"},{"title":"Masottina","url":"https:\/\/winetime.com.ua\/ua\/masottina-pevno-naykrashche-proseko","image":"https:\/\/winetime.com.ua\/uploads\/symlink\/66000-67000\/\u043c\u0430\u0441\u043e\u0442\u0438\u043d\u043e.jpg"}],
+        header_banners: [{"path":"https:\/\/winetime.com.ua\/uploads\/public\/banners\/MykD4DFhbb9ySrOl7EKaritdn925FYLBDAdyIpUu.jpg","active":true,"action_type":"url","text_ua":null,"text_ru":null,"url":"https:\/\/winetime.com.ua\/ua\/o-dostavke"}],
+        app_install_popup_enabled: false,
+    }
+</script>
+
+<script type="text/javascript">
+    // name of the cookie that stores the source
+    // change if you have another name
+    var cookie_name = 'deduplication_cookie';
+    // cookie lifetime
+    var days_to_store = 90;
+    // expected deduplication_cookie value for Admitad
+    var deduplication_cookie_value = 'admitad';
+    // name of GET parameter for deduplication
+    // change if you have another name
+    var channel_name = 'utm_source';
+    // a function to get the source from the GET parameter
+    getSourceParamFromUri = function () {
+        var pattern = channel_name + '=([^&]+)';
+        var re = new RegExp(pattern);
+        return (re.exec(document.location.search) || [])[1] || '';
+    };
+    // a function to get the source from the cookie named cookie_name
+    getSourceCookie = function () {
+        var matches = document.cookie.match(new RegExp(
+            '(?:^|; )' + cookie_name.replace(/([\.$?*|{}\(\)\[\]\\\/\+^])/g, '\\$1') + '=([^;]*)'
+        ));
+        return matches ? decodeURIComponent(matches[1]) : undefined;
+    };
+    // a function to set the source in the cookie named cookie_name
+    setSourceCookie = function () {
+        var param = getSourceParamFromUri();
+        var params = (new URL(document.location)).searchParams;
+        if (!params.get(channel_name) && params.get('gclid')) { param = 'google' }
+        else if (!params.get(channel_name) && params.get('fbclid')) { param = 'facebook' }
+        else if (!param) { return; }
+        var period = days_to_store * 60 * 60 * 24 * 1000; // in seconds
+        var expiresDate = new Date((period) + +new Date);
+        var cookieString = cookie_name + '=' + param + '; path=/; expires=' + expiresDate.toGMTString();
+        document.cookie = cookieString;
+        document.cookie = cookieString + '; domain=.' + location.host;
+    };
+    // set cookie
+    setSourceCookie();
+</script>
+<script>
+    !function (t, e, c, n) {
+        var s = e.createElement(c);
+        s.async = 1, s.src = 'https://statics.esputnik.com/scripts/' + n + '.js';
+        var r = e.scripts[0];
+        r.parentNode.insertBefore(s, r);
+        var f = function () {
+            f.c(arguments);
+        };
+        f.q = [];
+        f.c = function () {
+            f.q.push(arguments);
+        };
+        t['eS'] = t['eS'] || f;
+    }(window, document, 'script', 'DA1B8F9B05CF498790712AB865001125');
+</script><script>eS('init');</script>
+
+    <script>
+        window.initialData.category = {"id":187,"title":"Каталог з пивом","title_feed":"Пиво","type":"category","description":"<h2>Пиво це ...<\/h2><p><strong>Пиво<\/strong> є одним із найпоширеніших слабоалкогольних напоїв у світі. Крім того, це дуже давній напій, який вживали у Стародавньому Єгипті, Римі та Греції. А ширшу популярність пивоваріння набуло у європейських країнах, оскільки на той час ще не виготовлялися гарні вина. І одним із лідерів було німецьке пиво.<\/p><h2>Коротка історія виникнення пива<\/h2><p>Вважають, що пивоваріння з'явилося приблизно 10 000 років тому. І є припущення, що цей напій із ячмінних зерен змогли виготовити раніше за хліб, який випікали вже з відходів пивоваріння. Приблизно 1600 року до н.е. цар Вавилона Хаммурапі випустив Регламент, на підставі якого потрібно було виготовляти та пити пиво. Приблизно у 1200-1300 роках до н. у Стародавньому Єгипті вперше виготовили пшеничне пиво.<\/p><p>Оскільки ченці називали пиво рідким хлібом, а рідина не може порушити піст, то навіть найміцніше пиво можна було вживати під час посту. Тоді пиво вважалося цілющим напоєм, здатним вилікувати від багатьох недуг. Є монастирські броварні тих часів, які продовжують займатися пивоварінням і зараз.<\/p><p>І лише у 13 столітті н.е. стали з'являтися професійні пивоварні, які почали виготовляти цей напій високої якості, як чеське пиво. Для створення різних уподобань, у процесі виготовлення стали додавати різні складові: кмин, кору дуба, різні ягоди та інше. А на початку 16 століття нашої ери було закладено фундамент з культури виробництва пива і було встановлено, що цей слабоалкогольний напій потрібно виготовляти із солоду ячменю, хмелю та води.<\/p><p>Якщо ви надаєте перевагу тільки якісній продукції, то купити пиво відмінного виробництва можна в нашому інтернет-магазині winetime.com.ua, де представлений широкий асортимент пива за доступними цінами.<\/p><h2>Склад та де замовити пиво за найкращою ціною<\/h2><p>Найголовніше у виготовленні – це суворе дотримання пропорцій та температури. Все впливає на пиво – калорійність, ступінь гіркоти та солодкості. Мало хто замислюється, що пивоваріння є дуже трудомістким та складним процесом.<\/p><h3>Розглянемо найголовніші складові під час виготовлення пива:<\/h3><ol><li><i><strong>Хміль<\/strong><\/i> – сімейство конопельних рослин, які застосовуються завдяки тому, що мають антибактеріальну властивість, здатні врегулювати смак солодкість\/гіркоту (наприклад, створити пиво м'яке) і підвищити термін зберігання. Також на запах та смак пива може залежати від того, в якому регіоні вирощувався хміль.<\/li><li><i><strong>Дріжджі<\/strong><\/i> – їх класифікують як гриби, а основною їх функцією є процес бродіння: цукор перетворюється на алкоголь. Завдяки різним сортам дріжджів можна виготовити живе пиво з різними смаковими відтінками.<\/li><li><i><strong>Солод із ячменю<\/strong><\/i>. Сьогодні у пивоварстві використовуються зерна пшениці, жита, рису, кукурудзи. Але саме ячмінні зерна вважаються лідером процесу складання. Зерна замочуються, проростають, а при збільшенні температури їхнє зростання зупиняється. Важливо знати, що температурний показник безпосередньо впливає на зовнішній вигляд та смак солоду, а отже, і на сам смак напою.<\/li><li><i><strong>Вода<\/strong>.<\/i> Це важливий компонент у пивоварінні, який повинен відповідати певним показникам (рН, мінерали та інше). Залежно від того, де виготовляється пиво, і яка вода використовується присмаком пива може значно відрізнятися. Бажано використовувати лише дистильовану воду, до якої додають різні сполуки.<\/li><\/ol><p>Таким чином, на смак, колір та якість пива впливають компоненти, з яких воно вариться. Купити пиво онлайн можна у нас на сайті Winetime, де кожен зможе вибрати напій виходячи зі своїх смакових уподобань.<\/p><h2>Класифікація та як вигідно купити пиво<\/h2><p>Якої єдиної класифікації пива немає, але воно може поділятися на дві групи на кшталт бродіння:<\/p><ul><li>нижче – бродильний процес здійснюється під дією невисокої температури від 5 до 100С, виходять лагери та інші аналоги;<\/li><li>верхнє – бродіння здійснюється при підвищеній температурі від 15 до 250С, виходять елі, портери та стаути.<\/li><\/ul><p>Крім того, пиво може підрозділятися на 2 категорії: макро – виробництво великих пивоварних компаній, що випускають марочне пиво та крафтове – від невеликих виробників, які можуть експериментувати із виробництвом цього напою.<\/p><p>Ви можете купити пиво у нас будь-яких марок та на будь-який смак <a href=\"\/ua\/napoyi-slaboalkogolni\/svitle\">світле пиво<\/a>, <a href=\"\/ua\/napoyi-slaboalkogolni\/temne\">темне пиво<\/a> як у бляшанках, так і в пляшках. Зробити замовлення можна на сайті товару або зателефонуємо нашим операторам.<\/p><h2>Технологія пивоваріння<\/h2><p>Процес пивоваріння налічує кілька тисяч років. Але, звісно, сучасна технологія значно відрізняється від тих часів.<\/p><h3>Розглянемо основні етапи пивоваріння:<\/h3><ol><li><i><strong>Подрібнення зерен солоду<\/strong><\/i> так, щоб не дуже дрібно розмоловся центр зерна, де міститься крохмаль, інакше пиво буде в'язким. Але й не дуже велико, щоб забезпечити потрібну кількість цукрів для бродильного процесу.<\/li><li><i><strong>Затирання<\/strong>.<\/i> Дроблені зерна змішують із водою, температура якої становить 50-70 С. Завдяки цьому активізуються ферменти ячменю і крохмаль перетворюється на бродильні цукри. Таким чином виходить сусло – густа та солодка рідина.<\/li><li><i><strong>Фільтрація<\/strong>.<\/i> Потім сусло фільтрується і від нього відокремлюється пивна дробина, що дозволяє стати суслу прозорішим.<\/li><li><i><strong>Кип'ячення<\/strong>.<\/i> Далі сусло кип'ятиться протягом 1,5-2 годин. Це дозволяє позбутися різних бактерій. У період кип'ятіння в сусло додається хміль, а його кількість залежить від того, яке пиво марки готується.<\/li><li><i><strong>Процес ферментації<\/strong>.<\/i> Охолоджене сусло поміщають у ферментер і додають до нього дріжджі, які споживають цукор і утворюється алкоголь та вуглекислота. Ферментація триває від 1,5-2 тижнів, якщо готується елі і приблизно 2 місяці, якщо лагер. Потім забираються дріжджі і виходить готовий напій для тари на продаж: пиво в банку бляшаній або пляшці (скляній або пластиковій).<\/li><\/ol><p>Як видно не тільки від складових компонентів залежатиме якість напою та його марка, а й від дотримання технологічного процесу.<\/p><p>У нашому магазині на&nbsp;<a href=\"\/ua\/napoyi-slaboalkogolni\/bezalkogolne\">безалкогольне пиво<\/a> ціна доступна, а якість висока. При виборі товару ми можемо проконсультувати вас за телефоном, вказаним на сайті winetime.com.ua. Також у нас є фото пиво для всього асортименту. Замовлення здійснюється по Україні.<\/p>","slug":"pyvo","url":"https:\/\/winetime.com.ua\/ua\/napoyi-slaboalkogolni\/pyvo","is_root":false,"filters":[{"id":9,"title":"Країна","slug":"country","type":null,"source":"geos","values":[{"id":"61","title":"Австрія","slug":"avstriya","property_id":9,"quantity":6},{"id":"199","title":"Бельгія","slug":"belgiya","property_id":9,"quantity":49},{"id":"149","title":"Великобританія","slug":"velikobritaniya","property_id":9,"quantity":7},{"id":"202","title":"Данія","slug":"daniya","property_id":9,"quantity":23},{"id":"4","title":"Естонія","slug":"estoniya","property_id":9,"quantity":12},{"id":"226","title":"Ірландія","slug":"irlandiya","property_id":9,"quantity":19},{"id":"2","title":"Іспанія","slug":"ispaniya","property_id":9,"quantity":14},{"id":"156","title":"Італія","slug":"italiya","property_id":9,"quantity":8},{"id":"3","title":"Китай","slug":"kitay","property_id":9,"quantity":3},{"id":"136","title":"Литва","slug":"litva","property_id":9,"quantity":5},{"id":"97","title":"Нідерланди","slug":"niderlandi","property_id":9,"quantity":34},{"id":"181","title":"Німеччина","slug":"nimechchina","property_id":9,"quantity":156},{"id":"111","title":"Польща","slug":"polshcha","property_id":9,"quantity":22},{"id":"167","title":"Словаччина","slug":"slovachchina","property_id":9,"quantity":3},{"id":"51","title":"США","slug":"ssha","property_id":9,"quantity":3},{"id":"75","title":"Україна","slug":"ukraina","property_id":9,"quantity":331},{"id":"26","title":"Фінляндія","slug":"finlyandiya","property_id":9,"quantity":4},{"id":"6","title":"Франція","slug":"frantsiya","property_id":9,"quantity":26},{"id":"8","title":"Чехія","slug":"chekhiya","property_id":9,"quantity":14},{"id":"197","title":"Швеція","slug":"shvetsiya","property_id":9,"quantity":4}]},{"id":31,"title":"Тип","slug":"type","type":null,"source":"selects","values":[{"id":"1817","title":"Безалкогольне","slug":"bezalkogolne","property_id":31,"quantity":34},{"id":"3173","title":"Напівтемне","slug":"napivtemne","property_id":31,"quantity":26},{"id":"5550","title":"Пшеничне","slug":"pshenychne","property_id":31,"quantity":1},{"id":"3175","title":"Світле","slug":"svitle","property_id":31,"quantity":516},{"id":"3179","title":"Темне","slug":"temne","property_id":31,"quantity":117},{"id":"4984","title":"Червоне","slug":"chervone","property_id":31,"quantity":2},{"id":"4985","title":"Янтарне","slug":"yantarne","property_id":31,"quantity":1}]},{"id":5,"title":"Класифікація","slug":"classification","type":null,"source":"selects","values":[{"id":"5616","title":"нефільтроване","slug":"nefiltrovane","property_id":5,"quantity":416},{"id":"5617","title":"фільтроване","slug":"filtrovane","property_id":5,"quantity":169}]},{"id":33,"title":"Об `єм","slug":"volume","type":null,"source":"selects","values":[{"id":"2730","title":"0,25 л","slug":"025-l","property_id":33,"quantity":1},{"id":"3418","title":"0,25 л","slug":"025-l-3418","property_id":33,"quantity":7},{"id":"2735","title":"0,33 л","slug":"033-l","property_id":33,"quantity":376},{"id":"4761","title":"0,335 л","slug":"0335-l","property_id":33,"quantity":1},{"id":"2736","title":"0,35 л","slug":"035-l","property_id":33,"quantity":5},{"id":"2737","title":"0,355 л","slug":"0355-l","property_id":33,"quantity":2},{"id":"2738","title":"0,375 л","slug":"0375-l","property_id":33,"quantity":9},{"id":"2740","title":"0,44 л","slug":"044-l","property_id":33,"quantity":42},{"id":"2742","title":"0,5 л","slug":"05-l","property_id":33,"quantity":248},{"id":"2746","title":"0,568 л","slug":"0568-l","property_id":33,"quantity":4},{"id":"2747","title":"0,65 л","slug":"065-l","property_id":33,"quantity":3},{"id":"2749","title":"0,75 л","slug":"075-l-2749","property_id":33,"quantity":32},{"id":"2755","title":"1 л","slug":"1-l","property_id":33,"quantity":2},{"id":"2851","title":"3 л","slug":"3-l","property_id":33,"quantity":1},{"id":"2908","title":"375 мл","slug":"375-ml","property_id":33,"quantity":1},{"id":"2935","title":"5 л","slug":"5-l","property_id":33,"quantity":7}]},{"id":19,"title":"Упаковка","slug":"packaging","type":null,"source":"selects","values":[{"id":"1142","title":"жерстяна банка","slug":"zherstyana-banka","property_id":19,"quantity":382},{"id":"1145","title":"Подарункова коробка","slug":"podarunkova-korobka","property_id":19,"quantity":1},{"id":"1149","title":"скло","slug":"sklo","property_id":19,"quantity":305}]}],"active_filters":[],"products_quantity":747,"pages_count":1,"price_range":{"min":"26","max":"4097"},"brands":[{"id":8779,"title":"100 Mostow","slug":"100-mostow","quantity":3},{"id":8564,"title":"2085","slug":"brand-2085","quantity":15},{"id":7297,"title":"And Union","slug":"brand-and-union","quantity":6},{"id":8630,"title":"Asahi","slug":"brand-asahi","quantity":2},{"id":8778,"title":"Ballast Point","slug":"ballast-point","quantity":1},{"id":3174,"title":"Bavaria","slug":"brand-bavaria","quantity":3},{"id":2499,"title":"Bayreuther","slug":"brand-bayreuther","quantity":3},{"id":3110,"title":"BECK'S","slug":"brand-becks","quantity":2},{"id":470,"title":"BENEDEKTINER","slug":"brand-benedektiner","quantity":1},{"id":526,"title":"Berliner Geschichte","slug":"brand-berliner-geschichte","quantity":1},{"id":8082,"title":"Birra del Borgo","slug":"brand-birra-del-borgo","quantity":1},{"id":9200,"title":"Blanche de Bruxelles","slug":"blanche-de-bruxelles","quantity":2},{"id":1540,"title":"Brew-Dog","slug":"brand-brew-dog","quantity":3},{"id":9742,"title":"Brooklyn Brewery","slug":"brooklyn-brewery","quantity":4},{"id":8300,"title":"BUD","slug":"brand-bud","quantity":2},{"id":1596,"title":"Budweiser","slug":"brand-budweiser","quantity":4},{"id":9954,"title":"Carlsberg","slug":"carlsberg","quantity":1},{"id":8638,"title":"Claro","slug":"brand-claro","quantity":2},{"id":7438,"title":"Clausthaler","slug":"brand-clausthaler","quantity":2},{"id":2799,"title":"Corona Extra","slug":"brand-corona-extra","quantity":3},{"id":5030,"title":"DAB","slug":"brand-dab","quantity":2},{"id":8081,"title":"De Leite","slug":"brand-de-leite","quantity":5},{"id":8097,"title":"Denninghoff's","slug":"brand-denninghoffs","quantity":3},{"id":8783,"title":"Desperados","slug":"desperados","quantity":1},{"id":8796,"title":"Drofa","slug":"drofa","quantity":6},{"id":9324,"title":"Duff","slug":"duff","quantity":1},{"id":5229,"title":"Dutch Windmill","slug":"brand-dutch-windmill","quantity":1},{"id":8719,"title":"Ebony Vale","slug":"ebony-vale","quantity":1},{"id":9653,"title":"Emelisse","slug":"emelisse","quantity":3},{"id":1785,"title":"Erdinger","slug":"brand-erdinger","quantity":8},{"id":1363,"title":"Estrella","slug":"estrella","quantity":9},{"id":7540,"title":"Feldschlosschen","slug":"brand-feldschlosschen","quantity":3},{"id":2128,"title":"Flensburger","slug":"brand-flensburger","quantity":3},{"id":8224,"title":"FOREVER","slug":"brand-forever","quantity":8},{"id":3152,"title":"Franziskaner","slug":"brand-franziskaner","quantity":3},{"id":8704,"title":"Free Star","slug":"brand-free-star","quantity":2},{"id":8428,"title":"Fuerst Wiacek","slug":"brand-fuerst-wiacek","quantity":9},{"id":8784,"title":"Funky Fluid","slug":"funky-fluid","quantity":12},{"id":4456,"title":"Gambrinus","slug":"brand-gambrinus","quantity":1},{"id":8426,"title":"Gamma","slug":"brand-gamma","quantity":4},{"id":9869,"title":"Gava","slug":"gava","quantity":6},{"id":8792,"title":"Gosser","slug":"gosser","quantity":4},{"id":8490,"title":"Grevensteiner","slug":"brand-grevensteiner","quantity":1},{"id":7441,"title":"Grimbergen","slug":"brand-grimbergen","quantity":7},{"id":8552,"title":"Grolsch","slug":"brand-grolsch","quantity":1},{"id":9232,"title":"Guinness","slug":"guinness","quantity":4},{"id":5833,"title":"Heineken International","slug":"brand-heineken-international","quantity":2},{"id":9627,"title":"Heming","slug":"heming","quantity":8},{"id":1795,"title":"Hoegaarden","slug":"brand-hoegaarden","quantity":5},{"id":5479,"title":"Hofbrau Munchen","slug":"brand-hofbrau-munchen","quantity":4},{"id":5034,"title":"Holland Import","slug":"brand-holland-import","quantity":1},{"id":4508,"title":"John Barleycorn","slug":"john-barleycorn","quantity":27},{"id":9565,"title":"Kalea","slug":"kalea","quantity":3},{"id":9235,"title":"Keler","slug":"keler","quantity":2},{"id":5097,"title":"Kwak","slug":"brand-pauwel-kwak","quantity":3},{"id":9819,"title":"Kyiv Local Brewery","slug":"kyiv-local-brewery","quantity":12},{"id":8604,"title":"La Trappe","slug":"brand-la-trappe","quantity":2},{"id":9710,"title":"Lagunitas","slug":"lagunitas","quantity":2},{"id":8418,"title":"Lauterbacher","slug":"brand-lauterbacher","quantity":4},{"id":1006,"title":"Leffe","slug":"brand-leffe","quantity":7},{"id":7475,"title":"Liquor Zaar","slug":"brand-liquor-zaar","quantity":5},{"id":2613,"title":"Lowenbrau","slug":"brand-lowenbrau","quantity":2},{"id":8782,"title":"Maisel & Friends","slug":"maisel-friends","quantity":5},{"id":8341,"title":"Malle","slug":"malle","quantity":10},{"id":9870,"title":"Marie Hausbrendel","slug":"marie-hausbrendel","quantity":2},{"id":5384,"title":"Meteor","slug":"brand-meteor","quantity":23},{"id":7344,"title":"Mikki Brew","slug":"brand-mikki-brew","quantity":11},{"id":9767,"title":"Monastere","slug":"monastere","quantity":4},{"id":8491,"title":"Mort Subite","slug":"brand-mort-subite","quantity":1},{"id":9686,"title":"Mova","slug":"mova","quantity":14},{"id":9827,"title":"Neven","slug":"neven","quantity":1},{"id":7384,"title":"New Yorker","slug":"brand-new-yorker","quantity":1},{"id":9685,"title":"Newcastle","slug":"newcastle","quantity":1},{"id":8607,"title":"O'hara's","slug":"brand-oharas","quantity":10},{"id":5211,"title":"Old Prague","slug":"brand-old-prague","quantity":2},{"id":9690,"title":"Olvi","slug":"olvi","quantity":4},{"id":8430,"title":"Omnipollo","slug":"brand-omnipollo","quantity":5},{"id":9768,"title":"Oranjeboom","slug":"oranjeboom","quantity":3},{"id":3775,"title":"Paderborner","slug":"brand-paderborner","quantity":5},{"id":3154,"title":"PALM","slug":"brand-palm","quantity":1},{"id":7736,"title":"PART Trading","slug":"brand-part-trading","quantity":1},{"id":1366,"title":"Paulaner","slug":"brand-paulaner","quantity":10},{"id":8079,"title":"Peroni","slug":"brand-peroni","quantity":3},{"id":8101,"title":"Pilgerstoff","slug":"brand-pilgerstoff","quantity":1},{"id":898,"title":"Pilsner Urquell","slug":"brand-pilsner-urquell","quantity":3},{"id":8780,"title":"Pohjala","slug":"pohjala","quantity":12},{"id":9940,"title":"Pravda","slug":"pravda","quantity":15},{"id":8011,"title":"Reeper","slug":"brand-reeper","quantity":2},{"id":8095,"title":"Royal Czech Beer","slug":"brand-royal-czech-beer","quantity":2},{"id":9765,"title":"Royal Dutch","slug":"royal-dutch","quantity":3},{"id":8725,"title":"S. Pellegrino","slug":"s-pellegrino","quantity":1},{"id":9876,"title":"Schwarzbrau","slug":"schwarzbrau","quantity":15},{"id":7763,"title":"SHO Brewery","slug":"brand-sho-brewery","quantity":38},{"id":8093,"title":"Sitnan","slug":"brand-sitnan","quantity":1},{"id":8781,"title":"Sol","slug":"sol","quantity":1},{"id":5283,"title":"Spaten ","slug":"brand-spaten","quantity":2},{"id":9871,"title":"St-Feuillien","slug":"st-feuillien","quantity":10},{"id":8013,"title":"Stammgast","slug":"brand-stammgast","quantity":2},{"id":8099,"title":"Steiger","slug":"brand-steiger","quantity":2},{"id":3109,"title":"Stella Artois","slug":"brand-stella-artois","quantity":1},{"id":9435,"title":"Stone Brewing","slug":"stone-brewing","quantity":1},{"id":8220,"title":"Ten Men brewery","slug":"brand-ten-men-brewery","quantity":48},{"id":8610,"title":"Thornbridge","slug":"brand-thornbridge","quantity":1},{"id":8424,"title":"TO OL","slug":"brand-to-ol","quantity":19},{"id":9769,"title":"Trio Stout","slug":"trio-stout","quantity":1},{"id":5099,"title":"Tripel Karmeliet","slug":"brand-tripel-karmeliet","quantity":1},{"id":9730,"title":"Underwood Brewery","slug":"underwood-brewery","quantity":27},{"id":9762,"title":"United Dutch Breweries","slug":"united-dutch-breweries","quantity":1},{"id":560,"title":"Varvar","slug":"brand-varvar","quantity":39},{"id":9912,"title":"Volfas Engelman","slug":"volfas-engelman","quantity":5},{"id":7442,"title":"Warsteiner","slug":"brand-warsteiner","quantity":6},{"id":1097,"title":"Weihenstephaner","slug":"brand-weihenstephaner","quantity":8},{"id":8791,"title":"WeissMuller","slug":"weissmuller","quantity":3},{"id":7812,"title":"Welde","slug":"brand-welde","quantity":16},{"id":9654,"title":"Whitewater Brewery","slug":"whitewater-brewery","quantity":1},{"id":7791,"title":"Wieninger","slug":"brand-wieninger","quantity":4},{"id":8010,"title":"Wild Monkeys","slug":"brand-wild-monkeys","quantity":2},{"id":8103,"title":"Will-Bräu","slug":"brand-will-brau","quantity":5},{"id":8750,"title":"Winnica Turnau","slug":"winnica-turnau","quantity":3},{"id":9766,"title":"X-mark","slug":"x-mark","quantity":6},{"id":4899,"title":"Xibeca","slug":"brand-xibeca","quantity":1},{"id":8793,"title":"Zipfer","slug":"zipfer","quantity":1},{"id":8912,"title":"Блукач","slug":"blukach","quantity":11},{"id":7273,"title":"Волинський Бровар","slug":"brand-volinskiy-brovar","quantity":16},{"id":9882,"title":"Дідько","slug":"didko","quantity":3},{"id":9875,"title":"Ципа","slug":"tsypa","quantity":17}],"categories":[{"id":66,"title":"Снеки","slug":"sneky","url":"https:\/\/winetime.com.ua\/ua\/food\/sneky","image":{"src":"https:\/\/winetime.com.ua\/storage\/3ab1efc5fb28dde325c0833465107151.png","type":"image"},"type":"category","products_quantity":512},{"id":26,"title":"Горілка","slug":"gorilka","url":"https:\/\/winetime.com.ua\/ua\/mitsnyy-alkogol\/gorilka","image":{"src":"https:\/\/winetime.com.ua\/storage\/47aa27051703943b344e6a2d1cb766f3.png","type":"image"},"type":"frontview","products_quantity":312},{"id":100,"title":"М'ясні делікатеси","slug":"myasni-delikatesy","url":"https:\/\/winetime.com.ua\/ua\/food\/myasni-delikatesy","image":{"src":"https:\/\/winetime.com.ua\/storage\/3c13cd5025ea9ebd196172d7458c2d46.png","type":"image"},"type":"category","products_quantity":553}],"products":[{"id":59191,"title":"Пиво Дідько Travmato світле нефільтроване 0,5 л","slug":"pyvo-didko-travmato-svitle-nefiltrovane-05-l","url":"https:\/\/winetime.com.ua\/ua\/pyvo-didko-travmato-svitle-nefiltrovane-05-l","category_id":252,"preset_id":10,"image":{"src":"https:\/\/winetime.com.ua\/storage\/78fc6c6baf88041a3d7f18b3961eb811.jpeg","original":"https:\/\/winetime.com.ua\/storage\/78fc6c6baf88041a3d7f18b3961eb811.jpeg","alt":"Пиво Дідько Travmato світле нефільтроване 0,5 л","type":"image"},"availability":1,"vendor_code":"21622853","rating":85.3932584269663,"reviews":0,"use_discount":false,"discount_price":119,"price":119,"discount":0,"is_import":0,"is_online_price":false,"is_top":false,"is_new":true,"is_recommended":false,"in_wishlist":false,"manufacturer":{"id":9882,"title":"Дідько","url":null,"href":"https:\/\/didko.beer\/","slug":"didko","description":"<p>Дідько — яскравий український крафтовий бренд пива, який народився як домашній проєкт і виріс у несподіване й експериментальне явище в пивній культурі. Назва походить від образу дідька — хитрого, але не злого персонажа української міфології, і цей характер чудово передається у напоях бренду: вони сміливі, непередбачувані і водночас доброзичливі до поціновувачів справжнього крафту. Історія почалася з кількох варок, представлених на київському пивному фестивалі, де позитивний відгук змусив творців перейти від домашньої броварні до контрактного пивоваріння, а згодом — до власної міні‑пивоварні з обладнанням.<br>Дідько варить пиво в найрізноманітніших стилях — від класичних IPA чи Baltic Porter до радикальних експериментів із незвичними інгредієнтами — так, щоб кожен сорт ставав окремою історією смаку. Цей підхід робить Дідька не просто пивом, а гастрономічним досвідом для тих, хто хоче чогось нового.<br>Бренд поєднав українську авантюрність і світові пивні тренди, створивши стиль, у якому традиції й креатив живуть поруч і перетворюють кожну банку на маленьку подорож.<\/p>","since":null,"host":"didko.beer","image":{"src":"https:\/\/winetime.com.ua\/storage\/1943ecfa0b609da373c392106a71bba3.jpeg","alt":"Дідько"}},"characteristics":[],"gastro_pair":[],"country_image":"https:\/\/winetime.com.ua\/storage\/geos\/lCmdi_1621837253.png","has_promo":false,"promo_labels":[],"has_wholesale_promo":false,"wholesale_promo":null,"promo":null},{"id":59174,"title":"Пиво Kyiv Local Brewery Alco Free IPA безалкогольне нефільтроване 0,33 л","slug":"pyvo-kyiv-local-brewery-alco-free-ipa-bezalkogolne-nefiltrovane-033-l","url":"https:\/\/winetime.com.ua\/ua\/pyvo-kyiv-local-brewery-alco-free-ipa-bezalkogolne-nefiltrovane-033-l","category_id":252,"preset_id":10,"image":{"src":"https:\/\/winetime.com.ua\/storage\/8c83b2273040dd104cf3cf15077a172d.jpeg","original":"https:\/\/winetime.com.ua\/storage\/8c83b2273040dd104cf3cf15077a172d.jpeg","alt":"Пиво Kyiv Local Brewery Alco Free IPA безалкогольне нефільтроване 0,33 л","type":"image"},"availability":1,"vendor_code":"21552899","rating":85.3932584269663,"reviews":0,"use_discount":false,"discount_price":89,"price":89,"discount":0,"is_import":0,"is_online_price":false,"is_top":false,"is_new":true,"is_recommended":false,"in_wishlist":false,"manufacturer":{"id":9819,"title":"Kyiv Local Brewery","url":null,"href":"https:\/\/kyivlocalbrewery.com\/","slug":"kyiv-local-brewery","description":"<p>Kyiv Local Brewery — українська крафтова пивоварня, зареєстрована 16 березня 2018 року.<\/p><p>Броварня виникла з ідеї Євгена Нартенка та Дмитра Самойлова у 2017 році, спочатку як бізнес-проєкт, а згодом перейшла в повноцінне виробництво пива, яке вже з перших років здобуло увагу локальної спільноти та поціновувачів крафтового пива.<\/p><p>Вони виробляють як постійні сорти, так і сміливі новинки, не боячись змішувати жанри, спробувати обробку чи використання нетрадиційних інгредієнтів.<\/p><p>Особливістю бренду є його відданість культурі та спільноті: Kyiv Local Brewery не просто варить пиво — вони активно залучені у життя міста, проводять колаборації, фестивалі, запрошують любителів пива пробувати нові смачні експерименти.<\/p><p>В їхньому асортименті — пиво з впізнаваним ароматом хвої і тропічних фруктів, високою питкістю, збалансованою гірчинкою, а також більш складні стилі, які змінюються залежно від сезону чи смакових імпульсів виробників.<\/p><p>Kyiv Local Brewery — це про поєднання українського крафту, уважності до деталей і прагнення до якості, якістю сировини (імпорт солоду, хмелю), сміливістю в експериментах і одночасно збереженням читкості смаку.<\/p>","since":2018,"host":"kyivlocalbrewery.com","image":{"src":"https:\/\/winetime.com.ua\/storage\/99955609f52fdca3b4f577fc8e6aee16.jpeg","alt":"Kyiv Local Brewery"}},"characteristics":[],"gastro_pair":[],"country_image":"https:\/\/winetime.com.ua\/storage\/geos\/lCmdi_1621837253.png","has_promo":false,"promo_labels":[],"has_wholesale_promo":false,"wholesale_promo":null,"promo":null},{"id":59170,"title":"Пиво Ципа Орєнтал світле нефільтроване 0,5 л","slug":"pyvo-tsypa-orental-svitle-nefiltrovane-05-l","url":"https:\/\/winetime.com.ua\/ua\/pyvo-tsypa-orental-svitle-nefiltrovane-05-l","category_id":252,"preset_id":10,"image":{"src":"https:\/\/winetime.com.ua\/storage\/c238e6bbaf17fcc82b3189b33cc8ed71.jpeg","original":"https:\/\/winetime.com.ua\/storage\/c238e6bbaf17fcc82b3189b33cc8ed71.jpeg","alt":"Пиво Ципа Орєнтал світле нефільтроване 0,5 л","type":"image"},"availability":1,"vendor_code":"21527958","rating":85.3932584269663,"reviews":0,"use_discount":false,"discount_price":93,"price":93,"discount":0,"is_import":0,"is_online_price":false,"is_top":false,"is_new":true,"is_recommended":false,"in_wishlist":false,"manufacturer":{"id":9875,"title":"Ципа","url":null,"href":"https:\/\/tsypa.beer\/","slug":"tsypa","description":"<p>Ципа — український крафтовий бренд пива, що народився в 2015 році у мальовничому селі Кваси Закарпатської області і швидко здобув статус одного з найпомітніших представників гуцульського крафту.<br>Пивовари «Ципи» поєднують багатовікові традиції карпатського пивоваріння з сучасними технологіями та якісною європейською сировиною — кращі солоди, хміль і дріжджі з Німеччини та Чехії, а головна «фішка» — кришталево чиста вода з місцевого високогірного джерела, що зберігає природну структуру й аромат гірської природи у кожному ковтку.<br>Назва бренду походить від гуцульського образу — «ципа», як пташеня, народжене з яйця; фермери варять пиво у спеціальних чавунних чанах яйцеподібної форми, що символічно підкреслює народження нового смаку.&nbsp;<br>Асортимент «Ципи» дуже різноманітний: від класичних світлих та пшеничних елів до IPA та стаутів, включно з експериментальними варіаціями на основі карпатських трав, ягід, молочних нот чи витримки в дубових бочках, як у Sour Beer, що пролежало в бочці з-під бордоського вина.&nbsp;<br>Ципа вирізняється не лише смаком, а й духом Карпат — у кожному сорті відчувається прив’язка до гірського теруару, природної води, місцевих ароматів і гуцульської автентики.<\/p>","since":2015,"host":"tsypa.beer","image":{"src":"https:\/\/winetime.com.ua\/storage\/82dac1bdf2a9f579d0c7c7a95f10be7f.jpeg","alt":"Ципа"}},"characteristics":[],"gastro_pair":[],"country_image":"https:\/\/winetime.com.ua\/storage\/geos\/lCmdi_1621837253.png","has_promo":false,"promo_labels":[],"has_wholesale_promo":false,"wholesale_promo":null,"promo":null},{"id":59169,"title":"Пиво Ципа з огірками світле нефільтроване 0,5 л","slug":"pyvo-tsypa-z-ogirkamy-svitle-nefiltrovane-05-l","url":"https:\/\/winetime.com.ua\/ua\/pyvo-tsypa-z-ogirkamy-svitle-nefiltrovane-05-l","category_id":252,"preset_id":10,"image":{"src":"https:\/\/winetime.com.ua\/storage\/5e29f9dbf396e8b5c91d0a0c149a7997.jpeg","original":"https:\/\/winetime.com.ua\/storage\/5e29f9dbf396e8b5c91d0a0c149a7997.jpeg","alt":"Пиво Ципа з огірками світле нефільтроване 0,5 л","type":"image"},"availability":1,"vendor_code":"21527962","rating":85.3932584269663,"reviews":0,"use_discount":false,"discount_price":93,"price":93,"discount":0,"is_import":0,"is_online_price":false,"is_top":false,"is_new":true,"is_recommended":false,"in_wishlist":false,"manufacturer":{"id":9875,"title":"Ципа","url":null,"href":"https:\/\/tsypa.beer\/","slug":"tsypa","description":"<p>Ципа — український крафтовий бренд пива, що народився в 2015 році у мальовничому селі Кваси Закарпатської області і швидко здобув статус одного з найпомітніших представників гуцульського крафту.<br>Пивовари «Ципи» поєднують багатовікові традиції карпатського пивоваріння з сучасними технологіями та якісною європейською сировиною — кращі солоди, хміль і дріжджі з Німеччини та Чехії, а головна «фішка» — кришталево чиста вода з місцевого високогірного джерела, що зберігає природну структуру й аромат гірської природи у кожному ковтку.<br>Назва бренду походить від гуцульського образу — «ципа», як пташеня, народжене з яйця; фермери варять пиво у спеціальних чавунних чанах яйцеподібної форми, що символічно підкреслює народження нового смаку.&nbsp;<br>Асортимент «Ципи» дуже різноманітний: від класичних світлих та пшеничних елів до IPA та стаутів, включно з експериментальними варіаціями на основі карпатських трав, ягід, молочних нот чи витримки в дубових бочках, як у Sour Beer, що пролежало в бочці з-під бордоського вина.&nbsp;<br>Ципа вирізняється не лише смаком, а й духом Карпат — у кожному сорті відчувається прив’язка до гірського теруару, природної води, місцевих ароматів і гуцульської автентики.<\/p>","since":2015,"host":"tsypa.beer","image":{"src":"https:\/\/winetime.com.ua\/storage\/82dac1bdf2a9f579d0c7c7a95f10be7f.jpeg","alt":"Ципа"}},"characteristics":[],"gastro_pair":[],"country_image":"https:\/\/winetime.com.ua\/storage\/geos\/lCmdi_1621837253.png","has_promo":false,"promo_labels":[],"has_wholesale_promo":false,"wholesale_promo":null,"promo":null},{"id":59168,"title":"Пиво Ten Men Boom 100! світле нефільтроване 0,5 л","slug":"pyvo-ten-men-boom-100-svitle-nefiltrovane-05-l","url":"https:\/\/winetime.com.ua\/ua\/pyvo-ten-men-boom-100-svitle-nefiltrovane-05-l","category_id":252,"preset_id":10,"image":{"src":"https:\/\/winetime.com.ua\/storage\/8d577b38f092438e58821d665c820650.jpeg","original":"https:\/\/winetime.com.ua\/storage\/8d577b38f092438e58821d665c820650.jpeg","alt":"Пиво Ten Men Boom 100! світле нефільтроване 0,5 л","type":"image"},"availability":1,"vendor_code":"21527964","rating":85.3932584269663,"reviews":0,"use_discount":false,"discount_price":126,"price":126,"discount":0,"is_import":0,"is_online_price":false,"is_top":false,"is_new":true,"is_recommended":false,"in_wishlist":false,"manufacturer":{"id":8220,"title":"Ten Men brewery","url":null,"href":"https:\/\/tenmen.beer\/en\/ten-men-brewery-english\/","slug":"brand-ten-men-brewery","description":"<p>Крафтова пивоварня з маленького українського міста Вовчанськ Харківської області. Виробнича філософія – це мистецтво, мистецтво в пиві, мистецтво в етикетці, склянці, у всьому, що пов’язано з пивом. Без рамок, обмежень і єдиних правил, Ten Men brewery варять пиво з різних інгредієнтів, наприклад, пиво з ягодами і зефіром або пиво з помідорами, гострим перцем і цибулею-шалот, як щодо пива з морозивом? Поєднання непоєднуваного, унікальний продукт. Виведіть пиво на інший рівень сприйняття.<\/p>","since":0,"host":"tenmen.beer","image":{"src":"https:\/\/winetime.com.ua\/storage\/f761c9f273b7c8b6d28a7a76212111c9.png","alt":"Ten Men brewery"}},"characteristics":[],"gastro_pair":[],"country_image":"https:\/\/winetime.com.ua\/storage\/geos\/lCmdi_1621837253.png","has_promo":false,"promo_labels":[],"has_wholesale_promo":false,"wholesale_promo":null,"promo":null},{"id":10469,"title":"Пиво Meteor Pils 0,33 л","slug":"meteor-pils","url":"https:\/\/winetime.com.ua\/ua\/meteor-pils","category_id":38,"preset_id":10,"image":{"src":"https:\/\/winetime.com.ua\/storage\/3d6a84f681e61ad95bc60e29a01f717c.jpeg","original":"https:\/\/winetime.com.ua\/storage\/3d6a84f681e61ad95bc60e29a01f717c.jpeg","alt":"Пиво Meteor Pils 0,33 л","type":"image"},"availability":1,"vendor_code":"19429489","rating":85.3932584269663,"reviews":0,"use_discount":true,"discount_price":69,"price":99,"discount":30,"is_import":1,"is_online_price":false,"is_top":true,"is_new":false,"is_recommended":true,"in_wishlist":false,"manufacturer":{"id":5384,"title":"Meteor","url":null,"href":"https:\/\/www.brasserie-meteor.fr\/","slug":"brand-meteor","description":"<p>Meteor варить широкий асортимент продукції з унікальним характером, який запрошує відкрити задоволення від пива. Сімейна та незалежна броварня протягом 8 поколінь втілює в життя свій ідеал пива завдяки різноманітності рецептів та високим стандартам у виборі якісної сировини. У регіоні ось уже майже 4 століття існує незалежна сімейна пивоварня. Це місце, розташоване серед хмільних полів, процвітало з 1640 року, коли Жан Кляйн відкрив комерційну броварню. 1898 року увійшла до своєї історії родина Хааг, яка сьогодні управляє компанією. Пивовар Луї Хааг одружується з дочкою власника: Луїзе Мецгер. Пивоварня Мецгер-Хааг продовжувала розвиватися і в 1925 була перейменована в Meteor.<\/p><p> <\/p><p>Завдяки любові до своєї професії, політики постійних інвестицій, оволодіння своїми ноу-хау, соціальної прихильності до збереження 200 робочих місць, пивоварня змогла захистити свою незалежність та зберегти контроль над ним. доля. Пивоварня також отримала нагороду EY \"Сімейний бізнес року\" у 2019 році. Дбайливо ставлячись до навколишнього середовища, в 2003 році компанія інвестувала 2 мільйони євро в установку комплексного очищення стічних вод, що дозволяє скидати ідеально очищену воду в природне середовище та утилізувати сільськогосподарський мул у фермерів-партнерів.<\/p>","since":1640,"host":"www.brasserie-meteor.fr","image":{"src":"https:\/\/winetime.com.ua\/storage\/a965ee17b55c2128dc198fb00b93c9a8.jpeg","alt":"Meteor"}},"characteristics":[],"gastro_pair":[],"country_image":"https:\/\/winetime.com.ua\/storage\/geos\/LVadY_1621836478.png","has_promo":true,"promo_labels":[],"has_wholesale_promo":false,"wholesale_promo":null,"promo":{"promo_id":3038,"is_online_price":0,"date_end":"2026-06-14T20:59:00.000000Z","without_date":0,"label":{"show_discount_in_uah":true,"show_percent_badge_in_catalog":false},"banner":null,"discount_amount_uah":30}},{"id":56100,"title":"Пиво X-mark Flavoured Beer Agave CAN світле фільтроване 0,5 л","slug":"pyvo-x-mark-flavoured-beer-agave-can-svitle-filtrovane-05-l","url":"https:\/\/winetime.com.ua\/ua\/pyvo-x-mark-flavoured-beer-agave-can-svitle-filtrovane-05-l","category_id":40,"preset_id":10,"image":{"src":"https:\/\/winetime.com.ua\/storage\/853361927fecf250e1ee13e76064b9bd.jpeg","original":"https:\/\/winetime.com.ua\/storage\/853361927fecf250e1ee13e76064b9bd.jpeg","alt":"Пиво X-mark Flavoured Beer Agave CAN світле фільтроване 0,5 л","type":"image"},"availability":1,"vendor_code":"21153032","rating":85.3932584269663,"reviews":0,"use_discount":true,"discount_price":69,"price":95,"discount":27,"is_import":1,"is_online_price":false,"is_top":false,"is_new":false,"is_recommended":true,"in_wishlist":false,"manufacturer":{"id":9766,"title":"X-mark","url":null,"href":"https:\/\/www.xmarkdrinks.com\/","slug":"x-mark","description":"<p>X‑mark — інноваційний бренд зі складу United Dutch Breweries, що базується в Нідерландах. Його створено близько 2019 року як частину стратегії UDB вивести на ринок лінійку ароматизованих пивних напоїв — сучасних, сміливих і яскравих, що поєднують пиво з фруктами, спиртом і травами.<\/p><p>Бренд орієнтований на молодіжну аудиторію з новаторським смаком: X‑mark пропонує не просто пиво, а смакові вибухи — наприклад, Mojito-beer, Tequila-beer, Vodka-lime або навіть Cannabis-beer з екстрактом конопель, що не містить THC. Альфа-версії отримали визнання: X‑Mark Cannabis Beer здобуло срібло на World Beer Awards 2024 за свої збалансовані ноти та освіжаючий профіль.<\/p><p>Бренд вирізняється тим, що руйнує традиційні пивні межі — це не класичне пиво, а сміливі поєднання смаків, які передають відчуття свободи, яскравості та індивідуальності. X‑mark — це “пиво без правил”: від пляшок із флеш-дизайном до варіантів зі слабоалкогольними духами, досягаючи аудиторії з 100+ країн через модель UDB \"brewer without brewery\" — без власного виробництва, але з гнучким контрактним пивоварінням і фокусом на маркетинг і дистрибуцію.<\/p><p>X‑mark — це смілива і сучасна інтерпретація пива, створена для тих, хто цінує звільнення від стандартів і прагне нових сенсорних вражень.<\/p>","since":2019,"host":"www.xmarkdrinks.com","image":{"src":"https:\/\/winetime.com.ua\/storage\/f1bfcf1ea762775ec03eca7c0b8a1539.jpeg","alt":"X-mark"}},"characteristics":[],"gastro_pair":[],"country_image":"https:\/\/winetime.com.ua\/storage\/geos\/Ttuwd_1622202202.png","has_promo":true,"promo_labels":[],"has_wholesale_promo":false,"wholesale_promo":null,"promo":{"promo_id":3038,"is_online_price":0,"date_end":"2026-06-14T20:59:00.000000Z","without_date":0,"label":{"show_discount_in_uah":true,"show_percent_badge_in_catalog":false},"banner":null,"discount_amount_uah":26}},{"id":20402,"title":"Пиво Pohjala Cozy Nights світле нефільтроване 0,33 л","slug":"pohjala-cozy-nights","url":"https:\/\/winetime.com.ua\/ua\/pohjala-cozy-nights","category_id":40,"preset_id":10,"image":{"src":"https:\/\/winetime.com.ua\/storage\/c4ada0ee3ce6244e447f3f905b9ccc4b.jpeg","original":"https:\/\/winetime.com.ua\/storage\/c4ada0ee3ce6244e447f3f905b9ccc4b.jpeg","alt":"Пиво Pohjala Cozy Nights світле нефільтроване 0,33 л","type":"image"},"availability":1,"vendor_code":"20608069","rating":85.3932584269663,"reviews":0,"use_discount":true,"discount_price":299,"price":299,"discount":0,"is_import":1,"is_online_price":false,"is_top":false,"is_new":false,"is_recommended":true,"in_wishlist":false,"manufacturer":{"id":8780,"title":"Pohjala","url":null,"href":"https:\/\/pohjalabeer.com\/","slug":"pohjala","description":"<p>Põhjala Brewery – провідний естонський бренд крафтового пива, заснований у 2011 році в Таллінні. Відомий своєю пристрастю до глибоких, насичених смаків та використанням локальних інгредієнтів.<\/p><p>Põhjala спеціалізується на міцних стаутах, барлівайнах та експериментальних IPA. Серія \"Cellar Series\" включає витримані в бочках сорти, що розкривають багатошарові аромати. Бренд черпає натхнення в північній природі, додаючи у пиво елементи скандинавської кухні – ялівець, смолу, ягоди.<\/p><p>В даний час Põhjala експортує свою продукцію на більш ніж 30 ринків по всьому світу та майже у всі країни Європи.<\/p>","since":2011,"host":"pohjalabeer.com","image":{"src":"https:\/\/winetime.com.ua\/storage\/1a8b8cd3221c8b1346e97b0463689514.jpeg","alt":"Pohjala"}},"characteristics":[],"gastro_pair":[],"country_image":"https:\/\/winetime.com.ua\/storage\/geos\/MzcwQ_1622194483.png","has_promo":false,"promo_labels":[],"has_wholesale_promo":false,"wholesale_promo":null,"promo":null},{"id":10468,"title":"Пиво Meteor Blanche 0,33 л","slug":"meteor-blanche","url":"https:\/\/winetime.com.ua\/ua\/meteor-blanche","category_id":40,"preset_id":10,"image":{"src":"https:\/\/winetime.com.ua\/storage\/638333b8c73b9e07657d1f470473197a.jpeg","original":"https:\/\/winetime.com.ua\/storage\/638333b8c73b9e07657d1f470473197a.jpeg","alt":"Пиво Meteor Blanche 0,33 л","type":"image"},"availability":1,"vendor_code":"19429493","rating":85.3932584269663,"reviews":0,"use_discount":true,"discount_price":69,"price":99,"discount":30,"is_import":1,"is_online_price":false,"is_top":false,"is_new":false,"is_recommended":true,"in_wishlist":false,"manufacturer":{"id":5384,"title":"Meteor","url":null,"href":"https:\/\/www.brasserie-meteor.fr\/","slug":"brand-meteor","description":"<p>Meteor варить широкий асортимент продукції з унікальним характером, який запрошує відкрити задоволення від пива. Сімейна та незалежна броварня протягом 8 поколінь втілює в життя свій ідеал пива завдяки різноманітності рецептів та високим стандартам у виборі якісної сировини. У регіоні ось уже майже 4 століття існує незалежна сімейна пивоварня. Це місце, розташоване серед хмільних полів, процвітало з 1640 року, коли Жан Кляйн відкрив комерційну броварню. 1898 року увійшла до своєї історії родина Хааг, яка сьогодні управляє компанією. Пивовар Луї Хааг одружується з дочкою власника: Луїзе Мецгер. Пивоварня Мецгер-Хааг продовжувала розвиватися і в 1925 була перейменована в Meteor.<\/p><p> <\/p><p>Завдяки любові до своєї професії, політики постійних інвестицій, оволодіння своїми ноу-хау, соціальної прихильності до збереження 200 робочих місць, пивоварня змогла захистити свою незалежність та зберегти контроль над ним. доля. Пивоварня також отримала нагороду EY \"Сімейний бізнес року\" у 2019 році. Дбайливо ставлячись до навколишнього середовища, в 2003 році компанія інвестувала 2 мільйони євро в установку комплексного очищення стічних вод, що дозволяє скидати ідеально очищену воду в природне середовище та утилізувати сільськогосподарський мул у фермерів-партнерів.<\/p>","since":1640,"host":"www.brasserie-meteor.fr","image":{"src":"https:\/\/winetime.com.ua\/storage\/a965ee17b55c2128dc198fb00b93c9a8.jpeg","alt":"Meteor"}},"characteristics":[],"gastro_pair":[],"country_image":"https:\/\/winetime.com.ua\/storage\/geos\/LVadY_1621836478.png","has_promo":true,"promo_labels":[],"has_wholesale_promo":false,"wholesale_promo":null,"promo":{"promo_id":3038,"is_online_price":0,"date_end":"2026-06-14T20:59:00.000000Z","without_date":0,"label":{"show_discount_in_uah":true,"show_percent_badge_in_catalog":false},"banner":null,"discount_amount_uah":30}},{"id":10471,"title":"Пиво Meteor Lager 0,33 л","slug":"meteor-lager","url":"https:\/\/winetime.com.ua\/ua\/meteor-lager","category_id":41,"preset_id":10,"image":{"src":"https:\/\/winetime.com.ua\/storage\/8da81f97a3dec725ba8f46e9877b48a6.jpeg","original":"https:\/\/winetime.com.ua\/storage\/8da81f97a3dec725ba8f46e9877b48a6.jpeg","alt":"Пиво Meteor Lager 0,33 л","type":"image"},"availability":1,"vendor_code":"19429485","rating":85.3932584269663,"reviews":0,"use_discount":true,"discount_price":69,"price":99,"discount":30,"is_import":1,"is_online_price":false,"is_top":true,"is_new":false,"is_recommended":true,"in_wishlist":false,"manufacturer":{"id":5384,"title":"Meteor","url":null,"href":"https:\/\/www.brasserie-meteor.fr\/","slug":"brand-meteor","description":"<p>Meteor варить широкий асортимент продукції з унікальним характером, який запрошує відкрити задоволення від пива. Сімейна та незалежна броварня протягом 8 поколінь втілює в життя свій ідеал пива завдяки різноманітності рецептів та високим стандартам у виборі якісної сировини. У регіоні ось уже майже 4 століття існує незалежна сімейна пивоварня. Це місце, розташоване серед хмільних полів, процвітало з 1640 року, коли Жан Кляйн відкрив комерційну броварню. 1898 року увійшла до своєї історії родина Хааг, яка сьогодні управляє компанією. Пивовар Луї Хааг одружується з дочкою власника: Луїзе Мецгер. Пивоварня Мецгер-Хааг продовжувала розвиватися і в 1925 була перейменована в Meteor.<\/p><p> <\/p><p>Завдяки любові до своєї професії, політики постійних інвестицій, оволодіння своїми ноу-хау, соціальної прихильності до збереження 200 робочих місць, пивоварня змогла захистити свою незалежність та зберегти контроль над ним. доля. Пивоварня також отримала нагороду EY \"Сімейний бізнес року\" у 2019 році. Дбайливо ставлячись до навколишнього середовища, в 2003 році компанія інвестувала 2 мільйони євро в установку комплексного очищення стічних вод, що дозволяє скидати ідеально очищену воду в природне середовище та утилізувати сільськогосподарський мул у фермерів-партнерів.<\/p>","since":1640,"host":"www.brasserie-meteor.fr","image":{"src":"https:\/\/winetime.com.ua\/storage\/a965ee17b55c2128dc198fb00b93c9a8.jpeg","alt":"Meteor"}},"characteristics":[],"gastro_pair":[],"country_image":"https:\/\/winetime.com.ua\/storage\/geos\/LVadY_1621836478.png","has_promo":true,"promo_labels":[],"has_wholesale_promo":false,"wholesale_promo":null,"promo":{"promo_id":3038,"is_online_price":0,"date_end":"2026-06-14T20:59:00.000000Z","without_date":0,"label":{"show_discount_in_uah":true,"show_percent_badge_in_catalog":false},"banner":null,"discount_amount_uah":30}},{"id":56111,"title":"Пиво X-mark Flavoured Beer Mojito CAN світле фільтроване 0,5 л","slug":"pyvo-x-mark-flavoured-beer-mojito-can-svitle-filtrovane-05-l","url":"https:\/\/winetime.com.ua\/ua\/pyvo-x-mark-flavoured-beer-mojito-can-svitle-filtrovane-05-l","category_id":40,"preset_id":10,"image":{"src":"https:\/\/winetime.com.ua\/storage\/f38c2ac5b62a04993e83bd000b23a959.jpeg","original":"https:\/\/winetime.com.ua\/storage\/f38c2ac5b62a04993e83bd000b23a959.jpeg","alt":"Пиво X-mark Flavoured Beer Mojito CAN світле фільтроване 0,5 л","type":"image"},"availability":1,"vendor_code":"21153036","rating":85.3932584269663,"reviews":0,"use_discount":true,"discount_price":69,"price":95,"discount":27,"is_import":1,"is_online_price":false,"is_top":false,"is_new":false,"is_recommended":true,"in_wishlist":false,"manufacturer":{"id":9766,"title":"X-mark","url":null,"href":"https:\/\/www.xmarkdrinks.com\/","slug":"x-mark","description":"<p>X‑mark — інноваційний бренд зі складу United Dutch Breweries, що базується в Нідерландах. Його створено близько 2019 року як частину стратегії UDB вивести на ринок лінійку ароматизованих пивних напоїв — сучасних, сміливих і яскравих, що поєднують пиво з фруктами, спиртом і травами.<\/p><p>Бренд орієнтований на молодіжну аудиторію з новаторським смаком: X‑mark пропонує не просто пиво, а смакові вибухи — наприклад, Mojito-beer, Tequila-beer, Vodka-lime або навіть Cannabis-beer з екстрактом конопель, що не містить THC. Альфа-версії отримали визнання: X‑Mark Cannabis Beer здобуло срібло на World Beer Awards 2024 за свої збалансовані ноти та освіжаючий профіль.<\/p><p>Бренд вирізняється тим, що руйнує традиційні пивні межі — це не класичне пиво, а сміливі поєднання смаків, які передають відчуття свободи, яскравості та індивідуальності. X‑mark — це “пиво без правил”: від пляшок із флеш-дизайном до варіантів зі слабоалкогольними духами, досягаючи аудиторії з 100+ країн через модель UDB \"brewer without brewery\" — без власного виробництва, але з гнучким контрактним пивоварінням і фокусом на маркетинг і дистрибуцію.<\/p><p>X‑mark — це смілива і сучасна інтерпретація пива, створена для тих, хто цінує звільнення від стандартів і прагне нових сенсорних вражень.<\/p>","since":2019,"host":"www.xmarkdrinks.com","image":{"src":"https:\/\/winetime.com.ua\/storage\/f1bfcf1ea762775ec03eca7c0b8a1539.jpeg","alt":"X-mark"}},"characteristics":[],"gastro_pair":[],"country_image":"https:\/\/winetime.com.ua\/storage\/geos\/Ttuwd_1622202202.png","has_promo":true,"promo_labels":[],"has_wholesale_promo":false,"wholesale_promo":null,"promo":{"promo_id":3038,"is_online_price":0,"date_end":"2026-06-14T20:59:00.000000Z","without_date":0,"label":{"show_discount_in_uah":true,"show_percent_badge_in_catalog":false},"banner":null,"discount_amount_uah":26}},{"id":56101,"title":"Пиво X-mark Flavoured Beer Cannabis світле фільтроване 0,33 л","slug":"pyvo-x-mark-flavoured-beer-cannabis-svitle-filtrovane-033-l","url":"https:\/\/winetime.com.ua\/ua\/pyvo-x-mark-flavoured-beer-cannabis-svitle-filtrovane-033-l","category_id":40,"preset_id":10,"image":{"src":"https:\/\/winetime.com.ua\/storage\/f1a8398fb8192898bc723520935919a6.jpeg","original":"https:\/\/winetime.com.ua\/storage\/f1a8398fb8192898bc723520935919a6.jpeg","alt":"Пиво X-mark Flavoured Beer Cannabis світле фільтроване 0,33 л","type":"image"},"availability":1,"vendor_code":"21153028","rating":85.3932584269663,"reviews":0,"use_discount":true,"discount_price":69,"price":85,"discount":19,"is_import":1,"is_online_price":false,"is_top":false,"is_new":false,"is_recommended":true,"in_wishlist":false,"manufacturer":{"id":9766,"title":"X-mark","url":null,"href":"https:\/\/www.xmarkdrinks.com\/","slug":"x-mark","description":"<p>X‑mark — інноваційний бренд зі складу United Dutch Breweries, що базується в Нідерландах. Його створено близько 2019 року як частину стратегії UDB вивести на ринок лінійку ароматизованих пивних напоїв — сучасних, сміливих і яскравих, що поєднують пиво з фруктами, спиртом і травами.<\/p><p>Бренд орієнтований на молодіжну аудиторію з новаторським смаком: X‑mark пропонує не просто пиво, а смакові вибухи — наприклад, Mojito-beer, Tequila-beer, Vodka-lime або навіть Cannabis-beer з екстрактом конопель, що не містить THC. Альфа-версії отримали визнання: X‑Mark Cannabis Beer здобуло срібло на World Beer Awards 2024 за свої збалансовані ноти та освіжаючий профіль.<\/p><p>Бренд вирізняється тим, що руйнує традиційні пивні межі — це не класичне пиво, а сміливі поєднання смаків, які передають відчуття свободи, яскравості та індивідуальності. X‑mark — це “пиво без правил”: від пляшок із флеш-дизайном до варіантів зі слабоалкогольними духами, досягаючи аудиторії з 100+ країн через модель UDB \"brewer without brewery\" — без власного виробництва, але з гнучким контрактним пивоварінням і фокусом на маркетинг і дистрибуцію.<\/p><p>X‑mark — це смілива і сучасна інтерпретація пива, створена для тих, хто цінує звільнення від стандартів і прагне нових сенсорних вражень.<\/p>","since":2019,"host":"www.xmarkdrinks.com","image":{"src":"https:\/\/winetime.com.ua\/storage\/f1bfcf1ea762775ec03eca7c0b8a1539.jpeg","alt":"X-mark"}},"characteristics":[],"gastro_pair":[],"country_image":"https:\/\/winetime.com.ua\/storage\/geos\/Ttuwd_1622202202.png","has_promo":true,"promo_labels":[],"has_wholesale_promo":false,"wholesale_promo":null,"promo":{"promo_id":3038,"is_online_price":0,"date_end":"2026-06-14T20:59:00.000000Z","without_date":0,"label":{"show_discount_in_uah":true,"show_percent_badge_in_catalog":false},"banner":null,"discount_amount_uah":16}},{"id":16652,"title":"Пиво Warsteiner Premium світле фільтроване 0,5 л","slug":"warsteiner-premium-16652","url":"https:\/\/winetime.com.ua\/ua\/warsteiner-premium-16652","category_id":41,"preset_id":10,"image":{"src":"https:\/\/winetime.com.ua\/storage\/087aec7106c36d61610f9ad9ded4ab0c.jpeg","original":"https:\/\/winetime.com.ua\/storage\/087aec7106c36d61610f9ad9ded4ab0c.jpeg","alt":"Пиво Warsteiner Premium світле фільтроване 0,5 л","type":"image"},"availability":1,"vendor_code":"09952686","rating":85.3932584269663,"reviews":0,"use_discount":true,"discount_price":64,"price":99,"discount":35,"is_import":0,"is_online_price":false,"is_top":false,"is_new":false,"is_recommended":true,"in_wishlist":false,"manufacturer":{"id":7442,"title":"Warsteiner","url":null,"href":"https:\/\/www.warsteiner.com\/","slug":"brand-warsteiner","description":"<p>Warsteiner - бренд пива, який походить з містечка Варштайн у Північному Рейні-Вестфалії, Німеччина. Цей бренд є одним з найстаріших пивоварних підприємств у Німеччині, що залишається в сімейній власності протягом восьми поколінь. Пиво Warsteiner виготовляється з використанням високоякісних інгредієнтів, таких як вода з джерела Kaiserquelle, вибрані сорти ячменю та хмелю. Warsteiner відоме своїм класичним сортом - Warsteiner Premium Verum, яке є прикладом лагеру в німецькому стилі, відзначаючись чистим, освіжаючим смаком з ніжною гіркотою хмелю.&nbsp;<\/p><p>Зобов’язання до збереження традицій та якості, поєднаних з сучасними технологіями пивоваріння робить Warsteiner винятковим. Компанія активно інвестує в новітнє обладнання та підтримує високу культуру пивоваріння. Warsteiner також відоме своєю увагою до екології - використовуються енергоефективні методи виробництва, а також здійснюються проекти з підтримки навколишнього середовища. &nbsp;Warsteiner пропонує широкий асортимент сортів пива, включаючи спеціальні та сезонні варіанти, які задовольняють різні смаки споживачів. Завдяки високій якості, багатій історії та постійному прагненню до вдосконалення, Warsteiner залишається одним з провідних пивних брендів, відомим не тільки в Німеччині, а й у всьому світі.<\/p>","since":1753,"host":"www.warsteiner.com","image":{"src":"https:\/\/winetime.com.ua\/storage\/853f3f60788c4d4a98c31d3245624297.png","alt":"Warsteiner"}},"characteristics":[],"gastro_pair":[],"country_image":"https:\/\/winetime.com.ua\/storage\/geos\/CRQic_1621837665.png","has_promo":true,"promo_labels":[],"has_wholesale_promo":false,"wholesale_promo":null,"promo":{"promo_id":3070,"is_online_price":0,"date_end":"2026-06-14T20:59:00.000000Z","without_date":0,"label":{"show_discount_in_uah":true,"show_percent_badge_in_catalog":false},"banner":null,"discount_amount_uah":35}},{"id":55823,"title":"Пиво Underwood IPA світле нефільтроване 0,33 л","slug":"pyvo-underwood-ipa-svitle-nefiltrovane-033-l","url":"https:\/\/winetime.com.ua\/ua\/pyvo-underwood-ipa-svitle-nefiltrovane-033-l","category_id":252,"preset_id":10,"image":{"src":"https:\/\/winetime.com.ua\/storage\/7cbe778c4f95a40a04243ffc1242b7d4.jpeg","original":"https:\/\/winetime.com.ua\/storage\/7cbe778c4f95a40a04243ffc1242b7d4.jpeg","alt":"Пиво Underwood IPA світле нефільтроване 0,33 л","type":"image"},"availability":1,"vendor_code":"20969204","rating":85.3932584269663,"reviews":0,"use_discount":false,"discount_price":99,"price":99,"discount":0,"is_import":0,"is_online_price":false,"is_top":false,"is_new":false,"is_recommended":true,"in_wishlist":false,"manufacturer":{"id":9730,"title":"Underwood Brewery","url":null,"href":"https:\/\/underwood.beer","slug":"underwood-brewery","description":"<p>Underwood Brewery – &nbsp;українська пивоварня, яка перебуває під керівництвом справжніх майстрів своєї справи. У 2017 році творці бізнесу впіймали себе на думці, що на місцевому ринку найбільший попит мають імпортовані напої. Це наштовхнуло їх на ідею створення власного алкоголю. Сьогодні виробництво значно розрослося, розширилась географія споживачів, а лінійка продукції нараховує близько 20 зразків пива та біля десятка лимонадів.<\/p>","since":2017,"host":"underwood.beer","image":{"src":"https:\/\/winetime.com.ua\/storage\/28333f92b8492f0efbfc2ba4610ae6c8.png","alt":"Underwood Brewery"}},"characteristics":[],"gastro_pair":[],"country_image":"https:\/\/winetime.com.ua\/storage\/geos\/lCmdi_1621837253.png","has_promo":false,"promo_labels":[],"has_wholesale_promo":false,"wholesale_promo":null,"promo":null},{"id":56710,"title":"Пиво Underwood Rising Sun світле нефільтроване 0,33 л","slug":"pyvo-underwood-rising-sun-svitle-nefiltrovane-033-l","url":"https:\/\/winetime.com.ua\/ua\/pyvo-underwood-rising-sun-svitle-nefiltrovane-033-l","category_id":252,"preset_id":10,"image":{"src":"https:\/\/winetime.com.ua\/storage\/480ad8dce9a7952d5a9c8cb4051acbf0.jpeg","original":"https:\/\/winetime.com.ua\/storage\/480ad8dce9a7952d5a9c8cb4051acbf0.jpeg","alt":"Пиво Underwood Rising Sun світле нефільтроване 0,33 л","type":"image"},"availability":1,"vendor_code":"21224184","rating":85.3932584269663,"reviews":0,"use_discount":false,"discount_price":89,"price":89,"discount":0,"is_import":0,"is_online_price":false,"is_top":false,"is_new":false,"is_recommended":true,"in_wishlist":false,"manufacturer":{"id":9730,"title":"Underwood Brewery","url":null,"href":"https:\/\/underwood.beer","slug":"underwood-brewery","description":"<p>Underwood Brewery – &nbsp;українська пивоварня, яка перебуває під керівництвом справжніх майстрів своєї справи. У 2017 році творці бізнесу впіймали себе на думці, що на місцевому ринку найбільший попит мають імпортовані напої. Це наштовхнуло їх на ідею створення власного алкоголю. Сьогодні виробництво значно розрослося, розширилась географія споживачів, а лінійка продукції нараховує близько 20 зразків пива та біля десятка лимонадів.<\/p>","since":2017,"host":"underwood.beer","image":{"src":"https:\/\/winetime.com.ua\/storage\/28333f92b8492f0efbfc2ba4610ae6c8.png","alt":"Underwood Brewery"}},"characteristics":[],"gastro_pair":[],"country_image":"https:\/\/winetime.com.ua\/storage\/geos\/lCmdi_1621837253.png","has_promo":false,"promo_labels":[],"has_wholesale_promo":false,"wholesale_promo":null,"promo":null},{"id":55832,"title":"Пиво Underwood Ukrainian Tomato Gose світле нефільтроване 0,33 л","slug":"pyvo-underwood-ukrainian-tomato-gose-svitle-nefiltrovane-033-l","url":"https:\/\/winetime.com.ua\/ua\/pyvo-underwood-ukrainian-tomato-gose-svitle-nefiltrovane-033-l","category_id":252,"preset_id":10,"image":{"src":"https:\/\/winetime.com.ua\/storage\/d3ae635e3c0f3a35e5add1dd1966f9ce.jpeg","original":"https:\/\/winetime.com.ua\/storage\/d3ae635e3c0f3a35e5add1dd1966f9ce.jpeg","alt":"Пиво Underwood Ukrainian Tomato Gose світле нефільтроване 0,33 л","type":"image"},"availability":1,"vendor_code":"20969212","rating":85.3932584269663,"reviews":0,"use_discount":false,"discount_price":89,"price":89,"discount":0,"is_import":0,"is_online_price":false,"is_top":false,"is_new":false,"is_recommended":true,"in_wishlist":false,"manufacturer":{"id":9730,"title":"Underwood Brewery","url":null,"href":"https:\/\/underwood.beer","slug":"underwood-brewery","description":"<p>Underwood Brewery – &nbsp;українська пивоварня, яка перебуває під керівництвом справжніх майстрів своєї справи. У 2017 році творці бізнесу впіймали себе на думці, що на місцевому ринку найбільший попит мають імпортовані напої. Це наштовхнуло їх на ідею створення власного алкоголю. Сьогодні виробництво значно розрослося, розширилась географія споживачів, а лінійка продукції нараховує близько 20 зразків пива та біля десятка лимонадів.<\/p>","since":2017,"host":"underwood.beer","image":{"src":"https:\/\/winetime.com.ua\/storage\/28333f92b8492f0efbfc2ba4610ae6c8.png","alt":"Underwood Brewery"}},"characteristics":[],"gastro_pair":[],"country_image":"https:\/\/winetime.com.ua\/storage\/geos\/lCmdi_1621837253.png","has_promo":false,"promo_labels":[],"has_wholesale_promo":false,"wholesale_promo":null,"promo":null},{"id":13,"title":"Пиво Pilsner Urquell світле фільтроване 0,5 л","slug":"pilsner-urquell","url":"https:\/\/winetime.com.ua\/ua\/pilsner-urquell","category_id":38,"preset_id":10,"image":{"src":"https:\/\/winetime.com.ua\/storage\/3349eb079e18eec32d73a41c0fa58e98.jpeg","original":"https:\/\/winetime.com.ua\/storage\/3349eb079e18eec32d73a41c0fa58e98.jpeg","alt":"Пиво Pilsner Urquell світле фільтроване 0,5 л","type":"image"},"availability":1,"vendor_code":"17657878","rating":85.3932584269663,"reviews":0,"use_discount":false,"discount_price":85,"price":85,"discount":0,"is_import":0,"is_online_price":false,"is_top":false,"is_new":false,"is_recommended":true,"in_wishlist":false,"manufacturer":{"id":898,"title":"Pilsner Urquell","url":null,"href":"https:\/\/www.pilsnerurquell.com\/","slug":"brand-pilsner-urquell","description":"<p>Pilsner Urquell - легендарний бренд пива, відомий своїм історичним значенням і високою якістю. Pilsner Urquell, що в перекладі означає \"первісний пілснер\", є першим пивом у світі, звареним у стилі пілснер. Заснований у 1842 році в місті Пльзень, Чехія, цей бренд змінив світ пивоваріння, створивши новий стандарт для лагера, який надихнув численні пивоварні по всьому світу. Pilsner Urquell став першим світлим лагером, коли був вперше зварений Йозефом Гроллем у 1842 році. Це стало справжньою революцією в пивоварінні, оскільки раніше більшість пива була темною і мутною. Pilsner Urquell встановив новий стандарт чистоти, прозорості та смаку.&nbsp;<\/p><p>Pilsner Urquell не лише символ Чехії, але й ікона світового пивоваріння. Він є джерелом натхнення для численних інших пивоварів, які створюють свої версії пілснеру. Його вплив на пивну культуру важко переоцінити. Pilsner Urquell отримав численні нагороди та визнання на міжнародних конкурсах за свою неперевершену якість і смак. Він користується величезною популярністю не тільки в Чехії, але й по всьому світу.<\/p>","since":1842,"host":"www.pilsnerurquell.com","image":{"src":"https:\/\/winetime.com.ua\/storage\/e792cc4506c52e22b9b6a8d7f818b605.png","alt":"Pilsner Urquell"}},"characteristics":[],"gastro_pair":[],"country_image":"https:\/\/winetime.com.ua\/storage\/geos\/czech-flag.jpg","has_promo":false,"promo_labels":[],"has_wholesale_promo":false,"wholesale_promo":null,"promo":null},{"id":3089,"title":"Пиво Corona Extra світле фільтроване 0,33 л","slug":"corona-extra","url":"https:\/\/winetime.com.ua\/ua\/corona-extra","category_id":40,"preset_id":10,"image":{"src":"https:\/\/winetime.com.ua\/uploads\/symlink\/45000-46000\/1407328476_48897.jpg","original":"https:\/\/winetime.com.ua\/uploads\/symlink\/45000-46000\/1407328476_48897.jpg","alt":"Пиво Corona Extra світле фільтроване 0,33 л","type":"image"},"availability":1,"vendor_code":"08290225","rating":85.3932584269663,"reviews":0,"use_discount":true,"discount_price":59,"price":79,"discount":25,"is_import":0,"is_online_price":false,"is_top":true,"is_new":false,"is_recommended":true,"in_wishlist":false,"manufacturer":{"id":2799,"title":"Corona Extra","url":null,"href":"https:\/\/www.corona.com\/","slug":"brand-corona-extra","description":"<p>Corona Extra – це світле пиво, яке виробляється компанією Grupo Modelo в Мексиці. Заснований у 1925 році, бренд швидко завоював популярність завдяки своєму освіжаючому смаку та легко пізнаваній пляшці з прозорого скла. Corona Extra – одне з найпродаваніших пив у світі, особливо популярне в США, де його споживають як напій для відпочинку та святкувань.<br><br>Унікальність Corona Extra полягає в його легкому і освіжаючому смаку з тонкими нотами солоду та цитрусових. Це пиво часто подають з долькою лайма, яку вставляють у шийку пляшки, що додає напою додатковий аромат і смак. Завдяки цьому ритуалу, пиво стало асоціюватися з літнім настроєм, пляжними вечірками та відпочинком.<br><br>Corona Extra також відома своїм привабливим маркетингом, який підкреслює безтурботний спосіб життя та відпочинок на природі. Бренд активно підтримує екологічні ініціативи та заходи зі збереження природи, що підкреслює його відданість сталому розвитку.<br><br>Завдяки своєму впізнаваному стилю, легко пізнаваній пляшці та освіжаючому смаку, Corona Extra залишається одним з найбільш популярних і улюблених брендів пива у світі.<\/p>","since":1925,"host":"www.corona.com","image":{"src":"https:\/\/winetime.com.ua\/storage\/fd2f4963d44cd04afa8e471e40db4fc5.png","alt":"Corona Extra"}},"characteristics":[],"gastro_pair":[],"country_image":"https:\/\/winetime.com.ua\/storage\/geos\/4fhF6_1622198040.png","has_promo":true,"promo_labels":[],"has_wholesale_promo":false,"wholesale_promo":null,"promo":{"promo_id":3086,"is_online_price":0,"date_end":"2026-06-14T20:59:00.000000Z","without_date":0,"label":{"show_discount_in_uah":true,"show_percent_badge_in_catalog":false},"banner":null,"discount_amount_uah":20}},{"id":55820,"title":"Пиво Underwood Kyiv Lager світле нефільтроване 0,33 л","slug":"pyvo-underwood-kyiv-lager-svitle-nefiltrovane-033-l","url":"https:\/\/winetime.com.ua\/ua\/pyvo-underwood-kyiv-lager-svitle-nefiltrovane-033-l","category_id":252,"preset_id":10,"image":{"src":"https:\/\/winetime.com.ua\/storage\/c040c1b327176a4b17402fdc88ff6763.jpeg","original":"https:\/\/winetime.com.ua\/storage\/c040c1b327176a4b17402fdc88ff6763.jpeg","alt":"Пиво Underwood Kyiv Lager світле нефільтроване 0,33 л","type":"image"},"availability":1,"vendor_code":"20969198","rating":85.3932584269663,"reviews":0,"use_discount":true,"discount_price":64,"price":79,"discount":19,"is_import":0,"is_online_price":false,"is_top":false,"is_new":false,"is_recommended":true,"in_wishlist":false,"manufacturer":{"id":9730,"title":"Underwood Brewery","url":null,"href":"https:\/\/underwood.beer","slug":"underwood-brewery","description":"<p>Underwood Brewery – &nbsp;українська пивоварня, яка перебуває під керівництвом справжніх майстрів своєї справи. У 2017 році творці бізнесу впіймали себе на думці, що на місцевому ринку найбільший попит мають імпортовані напої. Це наштовхнуло їх на ідею створення власного алкоголю. Сьогодні виробництво значно розрослося, розширилась географія споживачів, а лінійка продукції нараховує близько 20 зразків пива та біля десятка лимонадів.<\/p>","since":2017,"host":"underwood.beer","image":{"src":"https:\/\/winetime.com.ua\/storage\/28333f92b8492f0efbfc2ba4610ae6c8.png","alt":"Underwood Brewery"}},"characteristics":[],"gastro_pair":[],"country_image":"https:\/\/winetime.com.ua\/storage\/geos\/lCmdi_1621837253.png","has_promo":true,"promo_labels":[],"has_wholesale_promo":false,"wholesale_promo":null,"promo":{"promo_id":3070,"is_online_price":0,"date_end":"2026-06-14T20:59:00.000000Z","without_date":0,"label":{"show_discount_in_uah":true,"show_percent_badge_in_catalog":false},"banner":null,"discount_amount_uah":15}},{"id":57739,"title":"Пиво Schweden Pils Schwarzbrau світле фільтроване 0,33 л","slug":"pyvo-schweden-pils-schwarzbrau-svitle-filtrovane-033-l","url":"https:\/\/winetime.com.ua\/ua\/pyvo-schweden-pils-schwarzbrau-svitle-filtrovane-033-l","category_id":38,"preset_id":10,"image":{"src":"https:\/\/winetime.com.ua\/storage\/644f4033bd1955bfa7fc04d6c8b63f69.jpeg","original":"https:\/\/winetime.com.ua\/storage\/644f4033bd1955bfa7fc04d6c8b63f69.jpeg","alt":"Пиво Schweden Pils Schwarzbrau світле фільтроване 0,33 л","type":"image"},"availability":1,"vendor_code":"21363479","rating":85.3932584269663,"reviews":0,"use_discount":true,"discount_price":144,"price":144,"discount":0,"is_import":1,"is_online_price":false,"is_top":false,"is_new":false,"is_recommended":false,"in_wishlist":false,"manufacturer":{"id":9876,"title":"Schwarzbrau","url":null,"href":"https:\/\/www.schwarzbraeu.de\/","slug":"schwarzbrau","description":"<p>Schwarzbräu — це сімейна пивоварня, яку багато поколінь розвивали з великою пристрастю та майстерністю, і вона вважається найбільш нагородженою пивоварнею Німеччини з більш ніж 700 медалями за якість та смак на національних і міжнародних конкурсах.&nbsp;<br>Тут варять традиційні баварські лагери та спеціалітети строго за Баварським законом про чистоту пива 1516 року, використовуючи власний солод із міллхаусу, хміль із знаменитих регіонів Hallertau, Spalt і Tettnang, кришталево чисту льодовикову воду із власних свердловин і дріжджі власної селекції.&nbsp;<br>Асортимент Schwarzbräu включає класичні світлі хеллеси, лагери й експортні стилі, темні боки та спеціальні сортові варіації, які протягом тривалого бродіння й витримки розкривають свій багатий аромат і смак.&nbsp;<br>Такий підхід — поєднання традиційного ремесла, власних інгредієнтів і турботи про якість — робить Schwarzbräu помітним на тлі інших німецьких брендів і цікавим як для класичних любителів пива, так і для тих, хто шукає автентичний смак баварської традиції в кожному ковтку.<\/p>","since":1648,"host":"www.schwarzbraeu.de","image":{"src":"https:\/\/winetime.com.ua\/storage\/0236434fc5ddcd2ff597e8a98a46181e.jpeg","alt":"Schwarzbrau"}},"characteristics":[],"gastro_pair":[],"country_image":"https:\/\/winetime.com.ua\/storage\/geos\/CRQic_1621837665.png","has_promo":false,"promo_labels":[],"has_wholesale_promo":false,"wholesale_promo":null,"promo":null},{"id":57719,"title":"Пиво St-Feuillien Saison світле нефільтроване 0,33 л","slug":"pyvo-st-feuillien-saison-svitle-nefiltrovane-033-l","url":"https:\/\/winetime.com.ua\/ua\/pyvo-st-feuillien-saison-svitle-nefiltrovane-033-l","category_id":37,"preset_id":10,"image":{"src":"https:\/\/winetime.com.ua\/storage\/16558965fcf8f16ce65fe527ddf1fdb9.jpeg","original":"https:\/\/winetime.com.ua\/storage\/16558965fcf8f16ce65fe527ddf1fdb9.jpeg","alt":"Пиво St-Feuillien Saison світле нефільтроване 0,33 л","type":"image"},"availability":1,"vendor_code":"21363433","rating":85.3932584269663,"reviews":1,"use_discount":true,"discount_price":167,"price":167,"discount":0,"is_import":1,"is_online_price":false,"is_top":false,"is_new":false,"is_recommended":false,"in_wishlist":false,"manufacturer":{"id":9871,"title":"St-Feuillien","url":null,"href":"https:\/\/st-feuillien.com\/","slug":"st-feuillien","description":"<p>St‑Feuillien — історична бельгійська пивоварня, заснована в 1873 році родиною Friart, яка й досі продовжує сімейні традиції пивоваріння з глибоким корінням у місцевій абатській спадщині.<\/p><p>St-Feuillien відомий класичними бельгійськими абатськими елями, що зберігають стародавню традицію верхового бродіння, вторинної ферментації в пляшці та багатого, складного смакового профілю. Бренд виробляє різні стилі — Blonde, Brune, Triple, Grand Cru, Saison і лінійку Grisette, що відтворює старовинні регіональні елі з характерною хмелевою гірчинкою й фруктовими ароматами.<\/p><p>Унікальність бренду полягає в поєднанні традиційних рецептів абатського пивоваріння та сімейного підходу з сучасними технологіями, завдяки чому кожне пиво не лише відображає історію регіону, а й має чіткий характер і високий рівень якості. Пивоварня також відрізняється увагою до натуральних компонентів — використанням добірного солоду, ароматного хмелю та ретельно підібраних дріжджових культур, а вторинна ферментація в пляшці надає продуктам тонкої ефірної карбонізації і глибокої ароматики.<\/p><p>За понад 150 років існування St-Feuillien здобула численні міжнародні нагороди за свої сорти, які високо оцінюють поціновувачі бельгійського пива.<\/p>","since":1873,"host":"st-feuillien.com","image":{"src":"https:\/\/winetime.com.ua\/storage\/c2d4fe4f30b6d54751395830d04d0b7e.jpeg","alt":"St-Feuillien"}},"characteristics":[],"gastro_pair":[],"country_image":"https:\/\/winetime.com.ua\/storage\/geos\/cpNkT_1622193703.png","has_promo":false,"promo_labels":[],"has_wholesale_promo":false,"wholesale_promo":null,"promo":null},{"id":57728,"title":"Пиво Aged Bock 2018 Schwarzbrau світле фільтроване 0,33 л","slug":"pyvo-aged-bock-2018-schwarzbrau-svitle-filtrovane-033-l","url":"https:\/\/winetime.com.ua\/ua\/pyvo-aged-bock-2018-schwarzbrau-svitle-filtrovane-033-l","category_id":40,"preset_id":10,"image":{"src":"https:\/\/winetime.com.ua\/storage\/2172fac8f9362b1551340d83827062e5.jpeg","original":"https:\/\/winetime.com.ua\/storage\/2172fac8f9362b1551340d83827062e5.jpeg","alt":"Пиво Aged Bock 2018 Schwarzbrau світле фільтроване 0,33 л","type":"image"},"availability":1,"vendor_code":"21363455","rating":85.3932584269663,"reviews":0,"use_discount":true,"discount_price":139,"price":174,"discount":20,"is_import":1,"is_online_price":false,"is_top":false,"is_new":false,"is_recommended":false,"in_wishlist":false,"manufacturer":{"id":9876,"title":"Schwarzbrau","url":null,"href":"https:\/\/www.schwarzbraeu.de\/","slug":"schwarzbrau","description":"<p>Schwarzbräu — це сімейна пивоварня, яку багато поколінь розвивали з великою пристрастю та майстерністю, і вона вважається найбільш нагородженою пивоварнею Німеччини з більш ніж 700 медалями за якість та смак на національних і міжнародних конкурсах.&nbsp;<br>Тут варять традиційні баварські лагери та спеціалітети строго за Баварським законом про чистоту пива 1516 року, використовуючи власний солод із міллхаусу, хміль із знаменитих регіонів Hallertau, Spalt і Tettnang, кришталево чисту льодовикову воду із власних свердловин і дріжджі власної селекції.&nbsp;<br>Асортимент Schwarzbräu включає класичні світлі хеллеси, лагери й експортні стилі, темні боки та спеціальні сортові варіації, які протягом тривалого бродіння й витримки розкривають свій багатий аромат і смак.&nbsp;<br>Такий підхід — поєднання традиційного ремесла, власних інгредієнтів і турботи про якість — робить Schwarzbräu помітним на тлі інших німецьких брендів і цікавим як для класичних любителів пива, так і для тих, хто шукає автентичний смак баварської традиції в кожному ковтку.<\/p>","since":1648,"host":"www.schwarzbraeu.de","image":{"src":"https:\/\/winetime.com.ua\/storage\/0236434fc5ddcd2ff597e8a98a46181e.jpeg","alt":"Schwarzbrau"}},"characteristics":[],"gastro_pair":[],"country_image":"https:\/\/winetime.com.ua\/storage\/geos\/CRQic_1621837665.png","has_promo":true,"promo_labels":[],"has_wholesale_promo":false,"wholesale_promo":null,"promo":{"promo_id":3038,"is_online_price":0,"date_end":"2026-06-14T20:59:00.000000Z","without_date":0,"label":{"show_discount_in_uah":true,"show_percent_badge_in_catalog":false},"banner":null,"discount_amount_uah":35}},{"id":57734,"title":"Пиво Hefe-Weissbier Dunkel Schwarzbrau темне нефільтроване 0,5 л","slug":"pyvo-hefe-weissbier-dunkel-schwarzbrau-temne-nefiltrovane-05-l","url":"https:\/\/winetime.com.ua\/ua\/pyvo-hefe-weissbier-dunkel-schwarzbrau-temne-nefiltrovane-05-l","category_id":39,"preset_id":10,"image":{"src":"https:\/\/winetime.com.ua\/storage\/c9b93f7c4e52110517c433db475012a2.jpeg","original":"https:\/\/winetime.com.ua\/storage\/c9b93f7c4e52110517c433db475012a2.jpeg","alt":"Пиво Hefe-Weissbier Dunkel Schwarzbrau темне нефільтроване 0,5 л","type":"image"},"availability":1,"vendor_code":"21363475","rating":85.3932584269663,"reviews":0,"use_discount":true,"discount_price":149,"price":177,"discount":16,"is_import":1,"is_online_price":false,"is_top":false,"is_new":false,"is_recommended":false,"in_wishlist":false,"manufacturer":{"id":9876,"title":"Schwarzbrau","url":null,"href":"https:\/\/www.schwarzbraeu.de\/","slug":"schwarzbrau","description":"<p>Schwarzbräu — це сімейна пивоварня, яку багато поколінь розвивали з великою пристрастю та майстерністю, і вона вважається найбільш нагородженою пивоварнею Німеччини з більш ніж 700 медалями за якість та смак на національних і міжнародних конкурсах.&nbsp;<br>Тут варять традиційні баварські лагери та спеціалітети строго за Баварським законом про чистоту пива 1516 року, використовуючи власний солод із міллхаусу, хміль із знаменитих регіонів Hallertau, Spalt і Tettnang, кришталево чисту льодовикову воду із власних свердловин і дріжджі власної селекції.&nbsp;<br>Асортимент Schwarzbräu включає класичні світлі хеллеси, лагери й експортні стилі, темні боки та спеціальні сортові варіації, які протягом тривалого бродіння й витримки розкривають свій багатий аромат і смак.&nbsp;<br>Такий підхід — поєднання традиційного ремесла, власних інгредієнтів і турботи про якість — робить Schwarzbräu помітним на тлі інших німецьких брендів і цікавим як для класичних любителів пива, так і для тих, хто шукає автентичний смак баварської традиції в кожному ковтку.<\/p>","since":1648,"host":"www.schwarzbraeu.de","image":{"src":"https:\/\/winetime.com.ua\/storage\/0236434fc5ddcd2ff597e8a98a46181e.jpeg","alt":"Schwarzbrau"}},"characteristics":[],"gastro_pair":[],"country_image":"https:\/\/winetime.com.ua\/storage\/geos\/CRQic_1621837665.png","has_promo":true,"promo_labels":[],"has_wholesale_promo":false,"wholesale_promo":null,"promo":{"promo_id":3038,"is_online_price":0,"date_end":"2026-06-14T20:59:00.000000Z","without_date":0,"label":{"show_discount_in_uah":true,"show_percent_badge_in_catalog":false},"banner":null,"discount_amount_uah":28}},{"id":11476,"title":"Пиво Meteor IPA CAN світле 0,5 л","slug":"meteor-ipa-can","url":"https:\/\/winetime.com.ua\/ua\/meteor-ipa-can","category_id":188,"preset_id":10,"image":{"src":"https:\/\/winetime.com.ua\/storage\/d47272a306a4c3c93d7a9dcb68658166.jpeg","original":"https:\/\/winetime.com.ua\/storage\/d47272a306a4c3c93d7a9dcb68658166.jpeg","alt":"Пиво Meteor IPA CAN світле 0,5 л","type":"image"},"availability":1,"vendor_code":"19644136","rating":85.3932584269663,"reviews":1,"use_discount":true,"discount_price":189,"price":189,"discount":0,"is_import":1,"is_online_price":false,"is_top":false,"is_new":false,"is_recommended":false,"in_wishlist":false,"manufacturer":{"id":5384,"title":"Meteor","url":null,"href":"https:\/\/www.brasserie-meteor.fr\/","slug":"brand-meteor","description":"<p>Meteor варить широкий асортимент продукції з унікальним характером, який запрошує відкрити задоволення від пива. Сімейна та незалежна броварня протягом 8 поколінь втілює в життя свій ідеал пива завдяки різноманітності рецептів та високим стандартам у виборі якісної сировини. У регіоні ось уже майже 4 століття існує незалежна сімейна пивоварня. Це місце, розташоване серед хмільних полів, процвітало з 1640 року, коли Жан Кляйн відкрив комерційну броварню. 1898 року увійшла до своєї історії родина Хааг, яка сьогодні управляє компанією. Пивовар Луї Хааг одружується з дочкою власника: Луїзе Мецгер. Пивоварня Мецгер-Хааг продовжувала розвиватися і в 1925 була перейменована в Meteor.<\/p><p> <\/p><p>Завдяки любові до своєї професії, політики постійних інвестицій, оволодіння своїми ноу-хау, соціальної прихильності до збереження 200 робочих місць, пивоварня змогла захистити свою незалежність та зберегти контроль над ним. доля. Пивоварня також отримала нагороду EY \"Сімейний бізнес року\" у 2019 році. Дбайливо ставлячись до навколишнього середовища, в 2003 році компанія інвестувала 2 мільйони євро в установку комплексного очищення стічних вод, що дозволяє скидати ідеально очищену воду в природне середовище та утилізувати сільськогосподарський мул у фермерів-партнерів.<\/p>","since":1640,"host":"www.brasserie-meteor.fr","image":{"src":"https:\/\/winetime.com.ua\/storage\/a965ee17b55c2128dc198fb00b93c9a8.jpeg","alt":"Meteor"}},"characteristics":[],"gastro_pair":[],"country_image":"https:\/\/winetime.com.ua\/storage\/geos\/LVadY_1621836478.png","has_promo":false,"promo_labels":[],"has_wholesale_promo":false,"wholesale_promo":null,"promo":null},{"id":57723,"title":"Пиво St-Feuillien Blonde світле фільтроване 0,75 л","slug":"pyvo-st-feuillien-blonde-svitle-filtrovane-075-l","url":"https:\/\/winetime.com.ua\/ua\/pyvo-st-feuillien-blonde-svitle-filtrovane-075-l","category_id":40,"preset_id":10,"image":{"src":"https:\/\/winetime.com.ua\/storage\/71ed693a50ee55c910e59b41a30bc890.jpeg","original":"https:\/\/winetime.com.ua\/storage\/71ed693a50ee55c910e59b41a30bc890.jpeg","alt":"Пиво St-Feuillien Blonde світле фільтроване 0,75 л","type":"image"},"availability":1,"vendor_code":"21363445","rating":85.3932584269663,"reviews":0,"use_discount":true,"discount_price":329,"price":399,"discount":18,"is_import":1,"is_online_price":false,"is_top":false,"is_new":false,"is_recommended":false,"in_wishlist":false,"manufacturer":{"id":9871,"title":"St-Feuillien","url":null,"href":"https:\/\/st-feuillien.com\/","slug":"st-feuillien","description":"<p>St‑Feuillien — історична бельгійська пивоварня, заснована в 1873 році родиною Friart, яка й досі продовжує сімейні традиції пивоваріння з глибоким корінням у місцевій абатській спадщині.<\/p><p>St-Feuillien відомий класичними бельгійськими абатськими елями, що зберігають стародавню традицію верхового бродіння, вторинної ферментації в пляшці та багатого, складного смакового профілю. Бренд виробляє різні стилі — Blonde, Brune, Triple, Grand Cru, Saison і лінійку Grisette, що відтворює старовинні регіональні елі з характерною хмелевою гірчинкою й фруктовими ароматами.<\/p><p>Унікальність бренду полягає в поєднанні традиційних рецептів абатського пивоваріння та сімейного підходу з сучасними технологіями, завдяки чому кожне пиво не лише відображає історію регіону, а й має чіткий характер і високий рівень якості. Пивоварня також відрізняється увагою до натуральних компонентів — використанням добірного солоду, ароматного хмелю та ретельно підібраних дріжджових культур, а вторинна ферментація в пляшці надає продуктам тонкої ефірної карбонізації і глибокої ароматики.<\/p><p>За понад 150 років існування St-Feuillien здобула численні міжнародні нагороди за свої сорти, які високо оцінюють поціновувачі бельгійського пива.<\/p>","since":1873,"host":"st-feuillien.com","image":{"src":"https:\/\/winetime.com.ua\/storage\/c2d4fe4f30b6d54751395830d04d0b7e.jpeg","alt":"St-Feuillien"}},"characteristics":[],"gastro_pair":[],"country_image":"https:\/\/winetime.com.ua\/storage\/geos\/cpNkT_1622193703.png","has_promo":true,"promo_labels":[],"has_wholesale_promo":false,"wholesale_promo":null,"promo":{"promo_id":3038,"is_online_price":0,"date_end":"2026-06-14T20:59:00.000000Z","without_date":0,"label":{"show_discount_in_uah":true,"show_percent_badge_in_catalog":false},"banner":null,"discount_amount_uah":70}},{"id":56104,"title":"Пиво Trio Stout Extra CAN темне фільтроване 0,5 л","slug":"pyvo-trio-stout-extra-can-staut-filtrovane-05-l","url":"https:\/\/winetime.com.ua\/ua\/pyvo-trio-stout-extra-can-staut-filtrovane-05-l","category_id":192,"preset_id":10,"image":{"src":"https:\/\/winetime.com.ua\/storage\/8942330cd89f6ecfd6ed401aab59382b.jpeg","original":"https:\/\/winetime.com.ua\/storage\/8942330cd89f6ecfd6ed401aab59382b.jpeg","alt":"Пиво Trio Stout Extra CAN темне фільтроване 0,5 л","type":"image"},"availability":1,"vendor_code":"21153022","rating":85.3932584269663,"reviews":0,"use_discount":true,"discount_price":69,"price":84,"discount":18,"is_import":1,"is_online_price":false,"is_top":false,"is_new":false,"is_recommended":false,"in_wishlist":false,"manufacturer":{"id":9769,"title":"Trio Stout","url":null,"href":"https:\/\/www.triostout.com","slug":"trio-stout","description":"<p>Trio Stout — це м'який, класичний голландський стаут із глибоким смаком і багатою історією. Походження з Нідерландів підтверджує його європейське коріння та високі стандарти якості.<\/p><p>Trio Stout представлено трьома варіантами: Extra (7,2 %): насичений і бархатистий з нотами кави та карамелі; Classic (4,5 %): ніжний, з солодовим відтінком; Caramel Stout (2,8 %): солодкий карамельний, легкий і освіжаючий.<\/p><p>Бренд популярний у 28 країнах і лідирує на ринках імпортних стаутів у багатьох державах.<\/p><p>Його головна цінність — поєднання традиційного рецепту з сучасною інтерпретацією: використання високоякісного обсмаженого солоду, ретельно підібраного хмелю, що забезпечує баланс між солодкістю та гіркуватістю. Завдяки цьому Trio Stout поєднує глибину смаку та легкість у питті, роблячи його ідеальним як для вечорів, так і для споживання у великій компанії.<\/p><p>Trio Stout — це класика стауту з багатошаровим ароматом кави, шоколаду і карамелі, винно насичене, але не обтяжливе, що підкорює своєю доступністю та стабільною якістю по всьому світу.<\/p>","since":1919,"host":"www.triostout.com","image":{"src":"https:\/\/winetime.com.ua\/storage\/840074b3093ad1e1a38b3c1501e3f3e5.jpeg","alt":"Trio Stout"}},"characteristics":[],"gastro_pair":[],"country_image":"https:\/\/winetime.com.ua\/storage\/geos\/Ttuwd_1622202202.png","has_promo":true,"promo_labels":[],"has_wholesale_promo":false,"wholesale_promo":null,"promo":{"promo_id":3038,"is_online_price":0,"date_end":"2026-06-14T20:59:00.000000Z","without_date":0,"label":{"show_discount_in_uah":true,"show_percent_badge_in_catalog":false},"banner":null,"discount_amount_uah":15}},{"id":56856,"title":"Пиво Набір Meteor Christmas Beer + 2 бокала Gift Pack світле фільтроване 0,65 л","slug":"pyvo-nabir-meteor-christmas-beer-2-bokala-gift-pack-svitle-filtrovane-065-l","url":"https:\/\/winetime.com.ua\/ua\/pyvo-nabir-meteor-christmas-beer-2-bokala-gift-pack-svitle-filtrovane-065-l","category_id":40,"preset_id":10,"image":{"src":"https:\/\/winetime.com.ua\/storage\/8f5097281db83e6018cfd06ca4085f09.jpeg","original":"https:\/\/winetime.com.ua\/storage\/8f5097281db83e6018cfd06ca4085f09.jpeg","alt":"Пиво Набір Meteor Christmas Beer + 2 бокала Gift Pack світле фільтроване 0,65 л","type":"image"},"availability":1,"vendor_code":"21266308","rating":85.3932584269663,"reviews":0,"use_discount":true,"discount_price":990,"price":990,"discount":0,"is_import":1,"is_online_price":false,"is_top":false,"is_new":false,"is_recommended":false,"in_wishlist":false,"manufacturer":{"id":5384,"title":"Meteor","url":null,"href":"https:\/\/www.brasserie-meteor.fr\/","slug":"brand-meteor","description":"<p>Meteor варить широкий асортимент продукції з унікальним характером, який запрошує відкрити задоволення від пива. Сімейна та незалежна броварня протягом 8 поколінь втілює в життя свій ідеал пива завдяки різноманітності рецептів та високим стандартам у виборі якісної сировини. У регіоні ось уже майже 4 століття існує незалежна сімейна пивоварня. Це місце, розташоване серед хмільних полів, процвітало з 1640 року, коли Жан Кляйн відкрив комерційну броварню. 1898 року увійшла до своєї історії родина Хааг, яка сьогодні управляє компанією. Пивовар Луї Хааг одружується з дочкою власника: Луїзе Мецгер. Пивоварня Мецгер-Хааг продовжувала розвиватися і в 1925 була перейменована в Meteor.<\/p><p> <\/p><p>Завдяки любові до своєї професії, політики постійних інвестицій, оволодіння своїми ноу-хау, соціальної прихильності до збереження 200 робочих місць, пивоварня змогла захистити свою незалежність та зберегти контроль над ним. доля. Пивоварня також отримала нагороду EY \"Сімейний бізнес року\" у 2019 році. Дбайливо ставлячись до навколишнього середовища, в 2003 році компанія інвестувала 2 мільйони євро в установку комплексного очищення стічних вод, що дозволяє скидати ідеально очищену воду в природне середовище та утилізувати сільськогосподарський мул у фермерів-партнерів.<\/p>","since":1640,"host":"www.brasserie-meteor.fr","image":{"src":"https:\/\/winetime.com.ua\/storage\/a965ee17b55c2128dc198fb00b93c9a8.jpeg","alt":"Meteor"}},"characteristics":[],"gastro_pair":[],"country_image":"https:\/\/winetime.com.ua\/storage\/geos\/LVadY_1621836478.png","has_promo":false,"promo_labels":[],"has_wholesale_promo":false,"wholesale_promo":null,"promo":null},{"id":57738,"title":"Пиво Marie Hausbrendel Hell світле фільтроване 0,5 л","slug":"pyvo-marie-hausbrendel-hell-svitle-filtrovane-05-l","url":"https:\/\/winetime.com.ua\/ua\/pyvo-marie-hausbrendel-hell-svitle-filtrovane-05-l","category_id":41,"preset_id":10,"image":{"src":"https:\/\/winetime.com.ua\/storage\/8aecd8829e07307d977d825c877f665c.jpeg","original":"https:\/\/winetime.com.ua\/storage\/8aecd8829e07307d977d825c877f665c.jpeg","alt":"Пиво Marie Hausbrendel Hell світле фільтроване 0,5 л","type":"image"},"availability":1,"vendor_code":"21363461","rating":85.3932584269663,"reviews":0,"use_discount":true,"discount_price":177,"price":177,"discount":0,"is_import":1,"is_online_price":false,"is_top":false,"is_new":false,"is_recommended":false,"in_wishlist":false,"manufacturer":{"id":9870,"title":"Marie Hausbrendel","url":null,"href":"https:\/\/marie.bayern\/","slug":"marie-hausbrendel","description":"<p>Marie Hausbrendel — це німецький пивний бренд, що виник як романтична історія кохання і сімейної традиції, а не просто маркетинговий хід. Він належить сімейній броварні Schwarzbräu GmbH, одній із найславетніших пивоварень Баварії, яка працює з 1648 року і має десятки престижних нагород за якість і класичні стилі пива.<\/p><p>Назва й образ бренду походять від реальної Марі Хаусбрендель, дочки пивовара з Аугсбурга 1920‑х років, яка була відома своєю харизмою та гостинністю, а пізніше стала дружиною пивовара з Schwarzbräu — Конрада Шварца. Її онук, нинішній власник Леопольд Шварц, присвятив їй цей сорт світлого лагера, який нагадує легкість і радість моменту за келихом з друзями.<\/p><p>Пиво Marie Hausbrendel Hell вариться традиційно без пастеризації з баварського солоду й хмелю, витримується кілька тижнів і має чистий, збалансований смак із м’якими солодовими й хмелевими нотами — типовий для класичного Helles.<\/p><p>Цей бренд вирізняється поєднанням історичної оповідки, сімейної спадщини та традиційного баварського пивоваріння, що робить його не просто напоєм, а живою історією зі смаком і характером місця й часу.<\/p>","since":1648,"host":"marie.bayern","image":{"src":"https:\/\/winetime.com.ua\/storage\/1ecd1e2fb4ee2f985c4279bc993b1af8.jpeg","alt":"Marie Hausbrendel"}},"characteristics":[],"gastro_pair":[],"country_image":"https:\/\/winetime.com.ua\/storage\/geos\/CRQic_1621837665.png","has_promo":false,"promo_labels":[],"has_wholesale_promo":false,"wholesale_promo":null,"promo":null},{"id":57718,"title":"Пиво St-Feuillien Belgian Coast IPA світле фільтроване 0,33 л","slug":"pyvo-st-feuillien-belgian-coast-ipa-svitle-filtrovane-033-l","url":"https:\/\/winetime.com.ua\/ua\/pyvo-st-feuillien-belgian-coast-ipa-svitle-filtrovane-033-l","category_id":188,"preset_id":10,"image":{"src":"https:\/\/winetime.com.ua\/storage\/c82703f73626a9bcb3cfcb80c59d5467.jpeg","original":"https:\/\/winetime.com.ua\/storage\/c82703f73626a9bcb3cfcb80c59d5467.jpeg","alt":"Пиво St-Feuillien Belgian Coast IPA світле фільтроване 0,33 л","type":"image"},"availability":1,"vendor_code":"21363435","rating":85.3932584269663,"reviews":1,"use_discount":true,"discount_price":177,"price":177,"discount":0,"is_import":1,"is_online_price":false,"is_top":false,"is_new":false,"is_recommended":false,"in_wishlist":false,"manufacturer":{"id":9871,"title":"St-Feuillien","url":null,"href":"https:\/\/st-feuillien.com\/","slug":"st-feuillien","description":"<p>St‑Feuillien — історична бельгійська пивоварня, заснована в 1873 році родиною Friart, яка й досі продовжує сімейні традиції пивоваріння з глибоким корінням у місцевій абатській спадщині.<\/p><p>St-Feuillien відомий класичними бельгійськими абатськими елями, що зберігають стародавню традицію верхового бродіння, вторинної ферментації в пляшці та багатого, складного смакового профілю. Бренд виробляє різні стилі — Blonde, Brune, Triple, Grand Cru, Saison і лінійку Grisette, що відтворює старовинні регіональні елі з характерною хмелевою гірчинкою й фруктовими ароматами.<\/p><p>Унікальність бренду полягає в поєднанні традиційних рецептів абатського пивоваріння та сімейного підходу з сучасними технологіями, завдяки чому кожне пиво не лише відображає історію регіону, а й має чіткий характер і високий рівень якості. Пивоварня також відрізняється увагою до натуральних компонентів — використанням добірного солоду, ароматного хмелю та ретельно підібраних дріжджових культур, а вторинна ферментація в пляшці надає продуктам тонкої ефірної карбонізації і глибокої ароматики.<\/p><p>За понад 150 років існування St-Feuillien здобула численні міжнародні нагороди за свої сорти, які високо оцінюють поціновувачі бельгійського пива.<\/p>","since":1873,"host":"st-feuillien.com","image":{"src":"https:\/\/winetime.com.ua\/storage\/c2d4fe4f30b6d54751395830d04d0b7e.jpeg","alt":"St-Feuillien"}},"characteristics":[],"gastro_pair":[],"country_image":"https:\/\/winetime.com.ua\/storage\/geos\/cpNkT_1622193703.png","has_promo":false,"promo_labels":[],"has_wholesale_promo":false,"wholesale_promo":null,"promo":null},{"id":56099,"title":"Пиво X-mark Flavoured Beer Cannabis CAN світле фільтроване 0,5 л","slug":"pyvo-x-mark-flavoured-beer-cannabis-can-svitle-filtrovane-05-l","url":"https:\/\/winetime.com.ua\/ua\/pyvo-x-mark-flavoured-beer-cannabis-can-svitle-filtrovane-05-l","category_id":40,"preset_id":10,"image":{"src":"https:\/\/winetime.com.ua\/storage\/e78db70859e00f0cae48ef31ae259b78.jpeg","original":"https:\/\/winetime.com.ua\/storage\/e78db70859e00f0cae48ef31ae259b78.jpeg","alt":"Пиво X-mark Flavoured Beer Cannabis CAN світле фільтроване 0,5 л","type":"image"},"availability":1,"vendor_code":"21153034","rating":85.3932584269663,"reviews":0,"use_discount":true,"discount_price":69,"price":95,"discount":27,"is_import":1,"is_online_price":false,"is_top":false,"is_new":false,"is_recommended":false,"in_wishlist":false,"manufacturer":{"id":9766,"title":"X-mark","url":null,"href":"https:\/\/www.xmarkdrinks.com\/","slug":"x-mark","description":"<p>X‑mark — інноваційний бренд зі складу United Dutch Breweries, що базується в Нідерландах. Його створено близько 2019 року як частину стратегії UDB вивести на ринок лінійку ароматизованих пивних напоїв — сучасних, сміливих і яскравих, що поєднують пиво з фруктами, спиртом і травами.<\/p><p>Бренд орієнтований на молодіжну аудиторію з новаторським смаком: X‑mark пропонує не просто пиво, а смакові вибухи — наприклад, Mojito-beer, Tequila-beer, Vodka-lime або навіть Cannabis-beer з екстрактом конопель, що не містить THC. Альфа-версії отримали визнання: X‑Mark Cannabis Beer здобуло срібло на World Beer Awards 2024 за свої збалансовані ноти та освіжаючий профіль.<\/p><p>Бренд вирізняється тим, що руйнує традиційні пивні межі — це не класичне пиво, а сміливі поєднання смаків, які передають відчуття свободи, яскравості та індивідуальності. X‑mark — це “пиво без правил”: від пляшок із флеш-дизайном до варіантів зі слабоалкогольними духами, досягаючи аудиторії з 100+ країн через модель UDB \"brewer without brewery\" — без власного виробництва, але з гнучким контрактним пивоварінням і фокусом на маркетинг і дистрибуцію.<\/p><p>X‑mark — це смілива і сучасна інтерпретація пива, створена для тих, хто цінує звільнення від стандартів і прагне нових сенсорних вражень.<\/p>","since":2019,"host":"www.xmarkdrinks.com","image":{"src":"https:\/\/winetime.com.ua\/storage\/f1bfcf1ea762775ec03eca7c0b8a1539.jpeg","alt":"X-mark"}},"characteristics":[],"gastro_pair":[],"country_image":"https:\/\/winetime.com.ua\/storage\/geos\/Ttuwd_1622202202.png","has_promo":true,"promo_labels":[],"has_wholesale_promo":false,"wholesale_promo":null,"promo":{"promo_id":3038,"is_online_price":0,"date_end":"2026-06-14T20:59:00.000000Z","without_date":0,"label":{"show_discount_in_uah":true,"show_percent_badge_in_catalog":false},"banner":null,"discount_amount_uah":26}}],"children":[{"id":252,"title":"Український крафт","slug":"ukrayinskyy-kraft","url":"https:\/\/winetime.com.ua\/ua\/napoyi-slaboalkogolni\/pyvo\/ukrayinskyy-kraft","image":null,"type":"frontview","products_quantity":330},{"id":188,"title":"IPA","slug":"ipa","url":"https:\/\/winetime.com.ua\/ua\/napoyi-slaboalkogolni\/pyvo\/ipa","image":{"src":"https:\/\/winetime.com.ua\/storage\/fc1c4f37319bd1845fc62ef7fe56187d.png","type":"image"},"type":"frontview","products_quantity":24},{"id":189,"title":"Безалкогольне","slug":"bezalkogolne","url":"https:\/\/winetime.com.ua\/ua\/napoyi-slaboalkogolni\/pyvo\/bezalkogolne","image":{"src":"https:\/\/winetime.com.ua\/storage\/df0af6e281ceb4d0653675a417641c7b.png","type":"image"},"type":"frontview","products_quantity":29},{"id":192,"title":"Стаут","slug":"staut","url":"https:\/\/winetime.com.ua\/ua\/napoyi-slaboalkogolni\/pyvo\/staut","image":{"src":"https:\/\/winetime.com.ua\/storage\/fb8be85f739a759164cbdf49d8fce6e3.png","type":"image"},"type":"frontview","products_quantity":8},{"id":37,"title":"Ель","slug":"el","url":"https:\/\/winetime.com.ua\/ua\/napoyi-slaboalkogolni\/pyvo\/el","image":{"src":"https:\/\/winetime.com.ua\/storage\/dba4201dde0316c5467d02045021c628.png","type":"image"},"type":"frontview","products_quantity":11},{"id":39,"title":"Темне","slug":"temne","url":"https:\/\/winetime.com.ua\/ua\/napoyi-slaboalkogolni\/pyvo\/temne","image":{"src":"https:\/\/winetime.com.ua\/storage\/1c5694b4d595812ffaaa28b61531201b.png","type":"image"},"type":"frontview","products_quantity":45},{"id":38,"title":"Пілснер","slug":"pilsner","url":"https:\/\/winetime.com.ua\/ua\/napoyi-slaboalkogolni\/pyvo\/pilsner","image":{"src":"https:\/\/winetime.com.ua\/storage\/8ebf7f246fc8d78a18dabf522fca4884.png","type":"image"},"type":"frontview","products_quantity":20},{"id":40,"title":"Світле","slug":"svitle","url":"https:\/\/winetime.com.ua\/ua\/napoyi-slaboalkogolni\/pyvo\/svitle","image":{"src":"https:\/\/winetime.com.ua\/storage\/4080c37eee9ea0fbb8649261ab478124.png","type":"image"},"type":"frontview","products_quantity":242},{"id":41,"title":"Лагер","slug":"lager","url":"https:\/\/winetime.com.ua\/ua\/napoyi-slaboalkogolni\/pyvo\/lager","image":{"src":"https:\/\/winetime.com.ua\/storage\/da4ff84ab91692288f3ee800baed0397.png","type":"image"},"type":"frontview","products_quantity":38}],"reviews":[{"id":57718,"title":"Пиво St-Feuillien Belgian Coast IPA світле фільтроване 0,33 л","slug":"pyvo-st-feuillien-belgian-coast-ipa-svitle-filtrovane-033-l","url":"https:\/\/winetime.com.ua\/ua\/pyvo-st-feuillien-belgian-coast-ipa-svitle-filtrovane-033-l","image":{"src":"https:\/\/winetime.com.ua\/storage\/c82703f73626a9bcb3cfcb80c59d5467.jpeg","original":"https:\/\/winetime.com.ua\/storage\/c82703f73626a9bcb3cfcb80c59d5467.jpeg","alt":"Пиво St-Feuillien Belgian Coast IPA світле фільтроване 0,33 л","type":"image"},"preset_id":10,"review":{"text":"Інтерпретація IPA у бельгійському стилі, дуже цікаво, по бельгійськи смачно, але з нотками претензії на крафт, сподобалось, смачно","name":"Дмитро","date":"12.12.2025","rating":5}},{"id":57725,"title":"Пиво St-Feuillien Brune темне фільтроване 0,33 л","slug":"pyvo-st-feuillien-brune-el-filtrovane-033-l","url":"https:\/\/winetime.com.ua\/ua\/pyvo-st-feuillien-brune-el-filtrovane-033-l","image":{"src":"https:\/\/winetime.com.ua\/storage\/fba29de32a541730c803502fbd38c0c8.jpeg","original":"https:\/\/winetime.com.ua\/storage\/fba29de32a541730c803502fbd38c0c8.jpeg","alt":"Пиво St-Feuillien Brune темне фільтроване 0,33 л","type":"image"},"preset_id":10,"review":{"text":"Чудовий брюн, насичений солодовий, пряний, родзинки, фінік, алкогольний, трохи лікерний, сбалансований, дуже смачно","name":"Дмитро","date":"12.12.2025","rating":5}},{"id":57719,"title":"Пиво St-Feuillien Saison світле нефільтроване 0,33 л","slug":"pyvo-st-feuillien-saison-svitle-nefiltrovane-033-l","url":"https:\/\/winetime.com.ua\/ua\/pyvo-st-feuillien-saison-svitle-nefiltrovane-033-l","image":{"src":"https:\/\/winetime.com.ua\/storage\/16558965fcf8f16ce65fe527ddf1fdb9.jpeg","original":"https:\/\/winetime.com.ua\/storage\/16558965fcf8f16ce65fe527ddf1fdb9.jpeg","alt":"Пиво St-Feuillien Saison світле нефільтроване 0,33 л","type":"image"},"preset_id":10,"review":{"text":"Дуже бельгійський, із приємними, легко впізнаванами естерами, сухий, алкоголльний, зразок стилю сейзон","name":"Дмитро","date":"12.12.2025","rating":5}},{"id":57720,"title":"Пиво St-Feuillien Five світле фільтроване 0,33 л","slug":"pyvo-st-feuillien-five-svitle-filtrovane-033-l","url":"https:\/\/winetime.com.ua\/ua\/pyvo-st-feuillien-five-svitle-filtrovane-033-l","image":{"src":"https:\/\/winetime.com.ua\/storage\/751673d209b8c2189ac93d4dce7410e9.jpeg","original":"https:\/\/winetime.com.ua\/storage\/751673d209b8c2189ac93d4dce7410e9.jpeg","alt":"Пиво St-Feuillien Five світле фільтроване 0,33 л","type":"image"},"preset_id":10,"review":{"text":"Базовий бельгійський блонд, ароматний, приємний, без надмірного алкоголю, питкий, освіжаючий, простенький але смачний","name":"Дмитро","date":"12.12.2025","rating":5}},{"id":57737,"title":"Пиво Marie Hausbrendel Hell світле фільтроване 0,33 л","slug":"pyvo-marie-hausbrendel-hell-svitle-filtrovane-033-l","url":"https:\/\/winetime.com.ua\/ua\/pyvo-marie-hausbrendel-hell-svitle-filtrovane-033-l","image":{"src":"https:\/\/winetime.com.ua\/storage\/66ea2509cc706837916d4fcb3a6e43e6.jpeg","original":"https:\/\/winetime.com.ua\/storage\/66ea2509cc706837916d4fcb3a6e43e6.jpeg","alt":"Пиво Marie Hausbrendel Hell світле фільтроване 0,33 л","type":"image"},"preset_id":10,"review":{"text":"Чистий, легкий, з приємною, відчутною гірчинкою, дуже питкий, чудовий хель","name":"Дмитро","date":"12.12.2025","rating":5}},{"id":57717,"title":"Пиво St-Feuillien Blonde світле фільтроване 0,33 л","slug":"pyvo-st-feuillien-blonde-svitle-filtrovane-033-l","url":"https:\/\/winetime.com.ua\/ua\/pyvo-st-feuillien-blonde-svitle-filtrovane-033-l","image":{"src":"https:\/\/winetime.com.ua\/storage\/8fd56d2b723bb4fbe44cfeef358311ef.jpeg","original":"https:\/\/winetime.com.ua\/storage\/8fd56d2b723bb4fbe44cfeef358311ef.jpeg","alt":"Пиво St-Feuillien Blonde світле фільтроване 0,33 л","type":"image"},"preset_id":10,"review":{"text":"Дуже гарний блонд, чудовий баланс, приємні естери в ароматі, алкоголь приємно зігріває, прекрасне пиво","name":"Дмитро","date":"12.12.2025","rating":5}},{"id":57716,"title":"Пиво St-Feuillien Triple світле фільтроване 0,33 л","slug":"pyvo-st-feuillien-triple-svitle-filtrovane-033-l","url":"https:\/\/winetime.com.ua\/ua\/pyvo-st-feuillien-triple-svitle-filtrovane-033-l","image":{"src":"https:\/\/winetime.com.ua\/storage\/e244468baedae7323efffd8b67b367de.jpeg","original":"https:\/\/winetime.com.ua\/storage\/e244468baedae7323efffd8b67b367de.jpeg","alt":"Пиво St-Feuillien Triple світле фільтроване 0,33 л","type":"image"},"preset_id":10,"review":{"text":"Насичений елегантний, приємний алкоголь, зразок стилю, справжній бельгійський тріпель","name":"Дмитро","date":"12.12.2025","rating":5}},{"id":56703,"title":"Пиво Kyiv Local Brewery CRUSH TOMATO світле 0,33 л","slug":"pyvo-kyiv-local-brewery-crush-tomato-svitle-033-l","url":"https:\/\/winetime.com.ua\/ua\/pyvo-kyiv-local-brewery-crush-tomato-svitle-033-l","image":{"src":"https:\/\/winetime.com.ua\/storage\/36db89a2001d874262877f7172800bec.jpeg","original":"https:\/\/winetime.com.ua\/storage\/36db89a2001d874262877f7172800bec.jpeg","alt":"Пиво Kyiv Local Brewery CRUSH TOMATO світле 0,33 л","type":"image"},"preset_id":10,"review":{"text":"Мені це пиво найсмачніше зі всіх томатних, які коштувала досі. В міру кисле, добре приправлено та відчутна сіль і, власне, смак томатів. Немає відчуття, що пиво та томати - окремо, все гармонійно.","name":"Снежана","date":"28.11.2025","rating":5}},{"id":137,"title":"Пиво Weihenstephaner Vitus світле нефільтроване 0,5 л","slug":"weihenstephaner-vitus","url":"https:\/\/winetime.com.ua\/ua\/weihenstephaner-vitus","image":{"src":"https:\/\/winetime.com.ua\/storage\/a18d3b656b5c9fe079eda0c466e126ad.jpeg","original":"https:\/\/winetime.com.ua\/storage\/a18d3b656b5c9fe079eda0c466e126ad.jpeg","alt":"Пиво Weihenstephaner Vitus світле нефільтроване 0,5 л","type":"image"},"preset_id":10,"review":{"text":"Зразок стилю. Перфектно!","name":"Дмитро","date":"15.08.2025","rating":5}},{"id":56580,"title":"Пиво Weihenstephaner Hefe-Weissbier світле нефільтроване 0,5 л","slug":"pyvo-weihenstephaner-hefe-weissbier-svitle-nefiltrovane-05-l","url":"https:\/\/winetime.com.ua\/ua\/pyvo-weihenstephaner-hefe-weissbier-svitle-nefiltrovane-05-l","image":{"src":"https:\/\/winetime.com.ua\/storage\/12fa2e097abd840957c4366fdc7e837e.jpeg","original":"https:\/\/winetime.com.ua\/storage\/12fa2e097abd840957c4366fdc7e837e.jpeg","alt":"Пиво Weihenstephaner Hefe-Weissbier світле нефільтроване 0,5 л","type":"image"},"preset_id":10,"review":{"text":"Одне  з найкращих безалкогольних пив, яке кушував. Насичена повнотіла пшеничка, може трохи занадто кисле, але в спеку гарно втамовує спрагу, дуже добре.","name":"Дмитро","date":"15.08.2025","rating":5}},{"id":56579,"title":"Пиво Weihenstephaner Korbinian DoppelBock темне 0,5 л","slug":"pyvo-weihenstephaner-korbinian-doppelbock-temne-05-l","url":"https:\/\/winetime.com.ua\/ua\/pyvo-weihenstephaner-korbinian-doppelbock-temne-05-l","image":{"src":"https:\/\/winetime.com.ua\/storage\/dd8ff18ecbfcf863f59cfa8e3f7a84e4.jpeg","original":"https:\/\/winetime.com.ua\/storage\/dd8ff18ecbfcf863f59cfa8e3f7a84e4.jpeg","alt":"Пиво Weihenstephaner Korbinian DoppelBock темне 0,5 л","type":"image"},"preset_id":10,"review":{"text":"Зразок стилю. Вершина досконалості, починаючи з аромату, закінчуючи довгим післясмаком. Нотки шоколаду, сушена слива і фіга, карамель і ще якісь смачні багатогранні тони.","name":"Дмитро","date":"15.08.2025","rating":5}},{"id":55536,"title":"Пиво Guinness Draught темне пастеризоване безалкогольне 0,44 л","slug":"pyvo-guinness-draught-temne-pasteryzovane-bezalkogolne-044-l","url":"https:\/\/winetime.com.ua\/ua\/pyvo-guinness-draught-temne-pasteryzovane-bezalkogolne-044-l","image":{"src":"https:\/\/winetime.com.ua\/storage\/dccc738ac8d9f1f032c7632f691cf5fd.jpeg","original":"https:\/\/winetime.com.ua\/storage\/dccc738ac8d9f1f032c7632f691cf5fd.jpeg","alt":"Пиво Guinness Draught темне пастеризоване безалкогольне 0,44 л","type":"image"},"preset_id":10,"review":{"text":"Перевага, що безалкогольне і темне, сухе, приємне, але пити трба охолодженим, тоді більш питке, на літо і покращення водно-електролітного балансу.","name":"Дмитро","date":"03.05.2025","rating":5}}]}
+        eS('sendEvent', 'CategoryPage', {
+            'CategoryPage': {
+                'categoryKey': 'Пиво'
+            }});
+    </script>
+
+<script src="https://winetime.com.ua/client/js/app--jot.js?v=1781121123" defer></script>
+
+
+</body>
+</html>

--- a/spec.md
+++ b/spec.md
@@ -729,7 +729,12 @@ test-БД, §3.2 «no `await` ⇒ no race», §3.3 визначення «extern
   `[data-information-type="brand-name"]`, назва `a.product__title`; `°` у тайтлі це
   Плато, не ABV → `abv` опускається; має `waitForGrid`), `beerfreak` (Horoshop SSR —
   `.catalogCard`, brewery/name з embedded `products` metadata, домен
-  `beerfreak.org`). `registry.pickAdapter(url)`. Опційний `reRenderContainerSelector` —
+  `beerfreak.org`), `bierloods22` (Bierloods22 SSR — `.product-block`,
+  brewery/name з title split на ` - `, домен `bierloods22.nl`), `winetime` (WineTime SSR — `a.product-micro`,
+  brewery/name з `window.initialData.category.products` metadata keyed by
+  `data-productkey`, fallback на видимий title/brewery, ABV опускається,
+  домен `winetime.com.ua`). `registry.pickAdapter(url)`.
+  Опційний `reRenderContainerSelector` —
   **звуження скоупу re-parse**, НЕ вмикач re-render (див. нижче). Як додати
   адаптер: `docs/adapter-authoring.md`.
 - **Потік:** content script парсить видиму сітку → short-TTL кеш


### PR DESCRIPTION
## Summary
- add a WineTime site adapter for winetime.com.ua SSR product cards
- register WineTime in the extension manifest and adapter registry
- document the plan/design, update spec and changelog, and record the isolated-worktree rule in AGENTS.md

Closes #88

## Test plan
- npm test -- src/sites/winetime.test.ts src/sites/conformance.test.ts src/sites/registry.test.ts src/manifest.test.ts
- npm test
- npm run build