### PR TITLE
release(extension): cut 0.5.0

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-06-10
+
 - Added WineTime shop support.
 - Orphan beers (no Untappd match yet) now show a ⚪ badge.
 - Optional (off by default): find missing beers via Untappd search in your own session and contribute ratings back; enable it in the extension options.

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "warsaw-beer-extension",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Що це

Реліз розширення **0.5.0**. Згортає `[Unreleased]` у версіоновану секцію та піднімає `extension/package.json` до 0.5.0.

## Реліз-нотатки (0.5.0)
- Added WineTime shop support. (#114)
- Orphan beers (no Untappd match yet) now show a ⚪ badge. (#115)
- Optional (off by default): find missing beers via Untappd search in your own session and contribute ratings back; enable it in the extension options. (#115, on top of server #113)

## Перевірка
- `npm run package` ✅ → `warsaw-beer-overlay-0.5.0.zip` (manifest v0.5.0, key запінено)
- `npm test` ✅ 124/124 · `npm run typecheck` ✅

## Далі (поза PR — `docs/extension-release.md`)
1. `cd extension && DATABASE_PATH=/var/lib/warsaw-beer-bot/bot.db npm run release`
2. Форвард застейдженого zip боту → 📣 Розіслати.

🤖 Generated with [Claude Code](https://claude.com/claude-code)