### PR TITLE
fix(extension): per-page enrich limit + checkbox layout (0.5.1)

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-06-10
+
+- Fix: Untappd enrichment now runs on large shop pages — it searches a bounded number of beers per page instead of skipping the page entirely.
+- Fix: options page checkbox layout (no longer stretched/misplaced).
+
 ## [0.5.0] - 2026-06-10
 
 - Added WineTime shop support.

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "warsaw-beer-extension",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/extension/src/content/enrich.test.ts
+++ b/extension/src/content/enrich.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { runEnrichment, PAGE_NO_ID_CAP, type EnrichDeps } from './enrich';
+import { runEnrichment, MAX_SEARCHES_PER_PAGE, type EnrichDeps } from './enrich';
 import type { EnrichResult } from '../api/types';
 
 function deps(over: Partial<EnrichDeps> = {}): EnrichDeps {
@@ -23,10 +23,11 @@ const beers = (n: number) =>
   Array.from({ length: n }, (_, i) => ({ key: `k${i}`, brewery: 'B', name: `N${i}` }));
 
 describe('runEnrichment', () => {
-  it('does nothing when the page has >= PAGE_NO_ID_CAP orphans', async () => {
+  it('registers all orphans but searches at most MAX_SEARCHES_PER_PAGE (no abstain on big pages)', async () => {
     const d = deps();
-    await runEnrichment(beers(PAGE_NO_ID_CAP), d);
-    expect(d.getCandidates).not.toHaveBeenCalled();
+    await runEnrichment(beers(MAX_SEARCHES_PER_PAGE + 5), d); // 25 orphans, all eligible
+    expect(d.getCandidates).toHaveBeenCalledTimes(1); // all registered, not abstained
+    expect(d.fetchSearch).toHaveBeenCalledTimes(MAX_SEARCHES_PER_PAGE); // search capped at 20
   });
 
   it('searches eligible beers, throttling between them, and resolves matched → setEnriched', async () => {

--- a/extension/src/content/enrich.ts
+++ b/extension/src/content/enrich.ts
@@ -1,6 +1,6 @@
 import type { EnrichResult } from '../api/types';
 
-export const PAGE_NO_ID_CAP = 20;
+export const MAX_SEARCHES_PER_PAGE = 20;
 export const DEFAULT_DELAY_MS = 4000;
 
 export interface OrphanBeer {
@@ -25,16 +25,17 @@ export interface EnrichDeps {
 
 const pairKey = (brewery: string, name: string) => `${brewery} ${name}`;
 
-// Searches the page's orphan beers on Untappd (via deps) one at a time, throttled. Gated:
-// if the page has >= PAGE_NO_ID_CAP orphans, abstains entirely (leave it to the server).
+// Registers every page orphan, then searches Untappd one at a time, throttled — but at
+// most MAX_SEARCHES_PER_PAGE per page so a big shop page doesn't drain the user's session.
+// The rest stay ⚪ for a later load / the server cron (same orphan pool + backoff).
 export async function runEnrichment(orphans: OrphanBeer[], deps: EnrichDeps): Promise<void> {
-  if (orphans.length === 0 || orphans.length >= PAGE_NO_ID_CAP) return;
+  if (orphans.length === 0) return;
 
   const candidates = await deps.getCandidates(
     orphans.map((o) => ({ brewery: o.brewery, name: o.name })),
   );
   const byPair = new Map(orphans.map((o) => [pairKey(o.brewery, o.name), o]));
-  const eligible = candidates.filter((c) => c.eligible);
+  const eligible = candidates.filter((c) => c.eligible).slice(0, MAX_SEARCHES_PER_PAGE);
 
   const delayMs = deps.delayMs ?? DEFAULT_DELAY_MS;
   const sleep = deps.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));

--- a/extension/src/options/options.css
+++ b/extension/src/options/options.css
@@ -3,6 +3,8 @@ body { font: 15px/1.45 system-ui, sans-serif; margin: 0; padding: 24px; backgrou
 h1 { font-size: 18px; margin: 0 0 16px; }
 label { display: block; margin: 14px 0 4px; font-weight: 600; font-size: 13px; }
 input { width: 100%; box-sizing: border-box; padding: 8px 10px; border: 1px solid #ccc; border-radius: 8px; }
+.checkbox { display: flex; align-items: center; gap: 8px; margin: 18px 0 4px; font-weight: 400; font-size: 13px; }
+.checkbox input { width: auto; flex: none; margin: 0; }
 .row { display: flex; gap: 10px; margin-top: 16px; }
 button { padding: 8px 14px; border: 0; border-radius: 8px; background: #d9822b; color: #fff; font-weight: 600; cursor: pointer; }
 button:hover { background: #c2741f; }


### PR DESCRIPTION
## Summary

Two fixes reported on 0.5.0, released as 0.5.1.

1. **Enrichment never ran on large shop pages.** `runEnrichment` abstained entirely when a page had ≥20 orphans, so on beerrepublic (~48 products) and winetime (~60) the client only did `/match` and never searched. Changed the page cap from an **abstain-gate** to a **per-page search limit**: all page orphans are still registered (so they show ⚪ / enter the pool), but the client searches at most `MAX_SEARCHES_PER_PAGE` (20) eligible beers, throttled; the rest wait for a later load or the server cron (same orphan pool + backoff). Small pages (onemorebeer ~14) were unaffected.
2. **Options checkbox was stretched/misplaced** — `input { width: 100% }` was stretching the checkbox and `label { display: block }` floated it above the text. Added a `.checkbox` flex rule + `.checkbox input { width: auto }`.

## Test Plan

- [x] `cd extension && npm test` — 124/124 (enrich queue test now asserts: all registered + search capped at 20, no abstain)
- [x] `npm run typecheck` + `npm run build` — clean; `warsaw-beer-overlay-0.5.1.zip`
- [ ] manual: beerrepublic/winetime now show ⏳→⭐ on the first ~20 eligible orphans; checkbox renders inline-left

🤖 Generated with [Claude Code](https://claude.com/claude-code)