### PR TITLE
fix(extension): trim repeated WineTime brewery suffix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,8 @@ Before making changes, always read:
 
 - "spec.md"
 
+Documented solutions live under `docs/solutions/` with YAML frontmatter (`module`, `tags`, `problem_type`) and capture past bugs, workflow issues, and implementation patterns. `CONCEPTS.md` defines shared project vocabulary. These are relevant when implementing or debugging in documented areas.
+
 The project specification is maintained in OpenSpec format and is the primary source of truth for expected behavior.
 
 If implementation details and assumptions conflict with "spec.md", follow "spec.md".

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -1,0 +1,24 @@
+# Concepts
+
+Shared domain vocabulary for this project — entities, named processes, and status concepts with project-specific meaning. Seeded with core domain vocabulary, then accretes as ce-compound and ce-compound-refresh process learnings; direct edits are fine. Glossary only, not a spec or catch-all.
+
+## Browser Extension
+
+### Browser Extension Client
+The read-only extension surface that overlays a user's beer history and ratings onto supported craft shop catalog pages.
+
+### Supported Shop
+A storefront whose catalog pages the Browser Extension Client is expected to recognize, parse, and decorate with beer-history overlays.
+
+### Site Adapter
+A shop-specific parser contract that decides whether a page belongs to a Supported Shop and extracts Product Cards into normalized brewery/name pairs for matching.
+
+### Product Card
+The repeated catalog item on a Supported Shop page that represents one beer candidate for overlay matching.
+
+### Fixture
+A captured storefront page used to make a Site Adapter testable without depending on the live shop during test runs.
+
+## Flagged ambiguities
+
+- "Shop adapter" and "site adapter" refer to the same concept in adapter work; prefer Site Adapter in durable documentation.

--- a/docs/solutions/workflow-issues/building-shop-adapters-from-live-fixtures.md
+++ b/docs/solutions/workflow-issues/building-shop-adapters-from-live-fixtures.md
@@ -1,0 +1,99 @@
+---
+title: Building Shop Adapters From Live Fixtures
+date: 2026-06-11
+category: workflow-issues
+module: Browser extension shop adapters
+problem_type: workflow_issue
+component: development_workflow
+severity: medium
+applies_when:
+  - "Adding a supported shop to the browser extension"
+  - "Building a parser from captured storefront HTML"
+  - "Reviewing adapter PRs that touch registry, manifest, fixtures, and spec"
+tags: [shop-adapter, parser, browser-extension, fixtures, review-workflow, worktrees]
+---
+
+# Building Shop Adapters From Live Fixtures
+
+## Context
+
+The WineTime adapter work solved issue #88 by adding support for `winetime.com.ua` to the browser extension. The implementation itself was straightforward after the storefront shape was understood, but the session exposed several workflow and parser-design traps that can recur when adding future shop adapters.
+
+The final WineTime adapter parses SSR product cards, prefers embedded product metadata keyed by product id, falls back to visible DOM text, registers the shop in the adapter registry and manifest, and adds fixture-backed tests plus changelog/spec updates.
+
+## Guidance
+
+Start adapter work in an isolated worktree from the correct base branch before making code changes. During the WineTime work, the first implementation branch was accidentally based on an unrelated Bierloods22 branch, which made the diff contain unrelated adapter changes. The fix was to rebase the WineTime branch onto `main`, resolve conflicts, and explicitly keep only the intended WineTime work. This is now reinforced in `AGENTS.md`: always set up an isolated worktree when developing a change.
+
+Use the live storefront fixture to identify the most stable data source, not just the visible DOM. WineTime rendered visible cards as `a.product-micro`, but the most reliable brewery/title data lived in `window.initialData.category.products` and was connected to cards through `data-productkey`. The adapter therefore used metadata as the primary source:
+
+```ts
+const id = Number(el.querySelector<HTMLElement>('[data-productkey]')?.dataset.productkey);
+const product = Number.isFinite(id) ? meta.get(id) : undefined;
+const rawTitle = product?.title ?? text(el.querySelector('.product-micro--title'));
+const brewery = product?.manufacturer?.title?.trim() || visibleBrewery(el);
+```
+
+Keep DOM fallback behavior even when metadata is available. A storefront can remove or rename embedded globals without changing visible HTML. WineTime tests disabled the `window.initialData.category` assignment and asserted that visible title/brewery parsing still returned usable cards.
+
+Make metadata-preference tests prove the preference. The first metadata test was weak because the visible DOM and embedded metadata produced the same `Meteor / Pils` result; the test would have passed even if metadata parsing broke. The fix was to mutate a local parsed fixture document so the visible brewery was wrong, then assert that the parsed result still used embedded metadata:
+
+```ts
+function withVisibleBrewery(source: string, productKey: string, brewery: string): string {
+  const doc = new DOMParser().parseFromString(source, 'text/html');
+  const card = doc.querySelector(`[data-productkey="${productKey}"]`)?.closest('a.product-micro');
+  if (!card) throw new Error(`Missing WineTime fixture card for product key ${productKey}`);
+
+  const rows = Array.from(card.querySelectorAll('.j-grow-1-xs.j-size-0\\.75-xs'));
+  const row = rows[rows.length - 1];
+  if (!row) throw new Error(`Missing visible brewery row for product key ${productKey}`);
+
+  row.textContent = brewery;
+  return doc.documentElement.outerHTML;
+}
+```
+
+Treat product-title cleanup as conservative normalization, not a full taxonomy parser. WineTime titles included category prefixes, brewery names, Ukrainian descriptors, packaging words, and volume suffixes. The final implementation stripped only the known category prefix, exact brewery prefixes, trailing volume, and trailing Ukrainian descriptors such as `світле`, `темне`, `нефільтроване`, and `фільтроване`. It deliberately preserved label words such as `CAN` because those may be part of the product name.
+
+When the PR is open, wait for automatic review and evaluate findings technically. The WineTime automatic review produced one useful test-helper finding and two suggestions that did not justify more code: a local DOM mutation was already isolated to a per-test document, and a custom error class or full HTML dump would add noise to a fixture helper. The useful finding was fixed; the others were answered in review threads with the technical rationale and then resolved.
+
+After merge, clean up only the completed adapter work. In this session, `main` also contained unrelated merged work, and local branches/worktrees for other issues existed. Cleanup removed the WineTime worktree, local branch, and remote branch, switched the root checkout to `main`, and pulled the merge commit, while leaving unrelated issue branches untouched.
+
+## Why This Matters
+
+Shop adapters are narrow changes, but they touch many integration surfaces: captured fixtures, parser logic, conformance tests, registry, manifest matches, changelog, and spec documentation. Small base-branch mistakes or weak tests can make a PR look correct while either dragging unrelated work into the diff or failing to prove the parser uses the intended data source.
+
+The metadata-first plus fallback pattern makes adapters resilient to storefront markup changes without overfitting to every visible text row. The review discipline keeps automatic comments useful without turning every suggestion into unnecessary complexity.
+
+## When to Apply
+
+- Add a new browser-extension supported shop.
+- Update an existing shop adapter after storefront markup changes.
+- Review adapter PRs that add fixtures and parser cleanup rules.
+- Rebase adapter work after another shop adapter lands on `main`.
+
+## Examples
+
+For SSR storefronts, prefer this workflow:
+
+1. Capture the live page as a fixture.
+2. Inspect repeated card nodes and embedded product state.
+3. Parse cards from stable selectors.
+4. Prefer embedded metadata when it has product identity and manufacturer/title.
+5. Keep DOM fallback tests.
+6. Add a metadata-preference test where DOM text is intentionally wrong.
+7. Run targeted adapter/conformance/manifest tests, then the full extension test suite and build.
+
+Avoid this workflow:
+
+1. Start from an unrelated feature branch.
+2. Parse only the visible card text.
+3. Add a test whose expected metadata value also matches the fallback DOM value.
+4. Accept every automated review suggestion without checking whether it improves this codebase.
+
+## Related
+
+- Issue #88: Add WineTime to the supported shops.
+- PR #114: WineTime adapter implementation and follow-up review fixes.
+- `docs/adapter-authoring.md`: baseline adapter-authoring guide.
+- `spec.md` section 6: browser extension adapter contract.

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added WineTime shop support.
 - Orphan beers (no Untappd match yet) now show a ⚪ badge.
 - Optional (off by default): find missing beers via Untappd search in your own session and contribute ratings back; enable it in the extension options.
+- Fixed WineTime parsing when product titles repeat the brewery name at the end.
 
 ## [0.4.0] - 2026-06-10
 

--- a/extension/src/sites/winetime.test.ts
+++ b/extension/src/sites/winetime.test.ts
@@ -74,6 +74,36 @@ describe('winetime adapter', () => {
     );
   });
 
+  it('removes a repeated trailing brewery from embedded product titles', () => {
+    const doc = new DOMParser().parseFromString(
+      `
+        <a class="product-micro">
+          <span data-productkey="119"></span>
+          <div class="product-micro--title">Пиво Varvar Blanche de Blanche Varvar світле фільтроване 0,33 л</div>
+          <div class="j-grow-1-xs j-size-0.75-xs">Varvar</div>
+        </a>
+        <script>
+          window.initialData = {};
+          window.initialData.category = {
+            "products": [{
+              "id": 119,
+              "title": "Пиво Varvar Blanche de Blanche Varvar світле фільтроване 0,33 л",
+              "manufacturer": { "title": "Varvar" }
+            }]
+          };
+        </script>
+      `,
+      'text/html',
+    );
+
+    expect(winetime.parseCards(doc)).toContainEqual(
+      expect.objectContaining({
+        brewery: 'Varvar',
+        name: 'Blanche de Blanche',
+      }),
+    );
+  });
+
   it('falls back to visible DOM text when embedded product metadata is unavailable', () => {
     const doc = new DOMParser().parseFromString(withoutInitialData(html), 'text/html');
     const parsed = winetime.parseCards(doc);

--- a/extension/src/sites/winetime.ts
+++ b/extension/src/sites/winetime.ts
@@ -88,6 +88,19 @@ function stripPrefix(value: string, prefix: string): string {
   return trimmed;
 }
 
+function stripSuffix(value: string, suffix: string): string {
+  const trimmed = value.trim();
+  const normalizedSuffix = suffix.trim();
+  if (!normalizedSuffix) return trimmed;
+  const lower = trimmed.toLocaleLowerCase('uk-UA');
+  const suffixLower = normalizedSuffix.toLocaleLowerCase('uk-UA');
+  if (lower === suffixLower || lower.endsWith(` ${suffixLower}`)) {
+    const next = trimmed.slice(0, -normalizedSuffix.length).trim();
+    if (next) return next;
+  }
+  return trimmed;
+}
+
 function breweryPrefixes(brewery: string): string[] {
   const base = brewery.trim();
   const withoutBrewerySuffix = base.replace(/\s+(?:brewery|броварня)$/iu, '').trim();
@@ -104,6 +117,9 @@ function cleanName(rawTitle: string, brewery: string): string {
 
   let cleaned = name.replace(/\s+(?:\d+(?:[,.]\d+)?\s*(?:л|l|ml|мл))$/iu, '').trim();
   while (DESCRIPTOR_RE.test(cleaned)) cleaned = cleaned.replace(DESCRIPTOR_RE, '').trim();
+  for (const suffix of breweryPrefixes(brewery)) {
+    cleaned = stripSuffix(cleaned, suffix);
+  }
 
   return cleaned || name || original;
 }


### PR DESCRIPTION
## Summary

WineTime cards that repeat the brewery at the end of the product title now send the actual beer name to matching. The reported Varvar card now parses as `Varvar / Blanche de Blanche` instead of `Varvar / Blanche de Blanche Varvar`, which keeps Untappd search from over-constraining the query.

The cleanup remains conservative: it only removes an exact trailing brewery token after the existing prefix, volume, and catalog descriptor cleanup.

Fixes #119

## Tests

- `cd extension && npm test -- src/sites/winetime.test.ts`
- `cd extension && npm run typecheck`
- `cd extension && npm test`
- `cd extension && npm run build`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
