### PR TITLE
release(extension): cut 0.5.2

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-06-11
+
+- Fixed Bierloods22 product parsing for breweries whose name contains " - " (e.g. "Kykao - Handcrafted") — those beers now match instead of showing as unmatched.
+- Fixed WineTime product titles that repeat the brewery name as a suffix.
+
 ## [0.5.1] - 2026-06-10
 
 - Fix: Untappd enrichment now runs on large shop pages — it searches a bounded number of beers per page instead of skipping the page entirely.

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "warsaw-beer-extension",
   "private": true,
-  "version": "0.5.1",
+  "version": "0.5.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
Cuts extension **0.5.2**, bundling the two adapter fixes landed since 0.5.1:
- **#122** — Bierloods22 brewery parsing for names containing ` - ` (e.g. `Kykao - Handcrafted`); those beers match instead of orphaning.
- **#121** — WineTime titles that repeat the brewery as a suffix.

`extension_releases` row already written to prod (v0.5.2, sha `1f03ccf399a8…`) and zip staged at `~/extension-releases/warsaw-beer-overlay-0.5.2.zip`.

## Test Plan
- [x] `npm run release` succeeded — deterministic zip (10531 bytes), RELEASE_NOTES from CHANGELOG, DB row written via privileged applier
- [ ] Admin forwards staged zip to bot → 📣 broadcast

🤖 Generated with [Claude Code](https://claude.com/claude-code)