### PR TITLE
fix(api): tune keep-alive to fix sporadic Cloudflare 502 (#124)

### DIFF
--- a/src/api/index.test.ts
+++ b/src/api/index.test.ts
@@ -3,7 +3,7 @@ import { openDb } from '../storage/db';
 import { migrate } from '../storage/schema';
 import { ensureProfile } from '../storage/user_profiles';
 import { rotateToken, hashToken } from '../storage/api_tokens';
-import { createApiApp } from './index';
+import { createApiApp, createApiServer } from './index';
 
 function deps() {
   const db = openDb(':memory:');
@@ -35,5 +35,23 @@ describe('createApiApp', () => {
     const app = createApiApp(deps());
     const res = await app.request('/health', { headers: { Origin: 'https://shop.example' } });
     expect(res.headers.get('access-control-allow-origin')).toBe('*');
+  });
+});
+
+describe('createApiServer', () => {
+  it('tunes keep-alive to outlast the cloudflared proxy (avoids 502 socket races)', async () => {
+    // Node's default keepAliveTimeout (5s) closes idle keep-alive sockets that
+    // cloudflared still holds in its pool, racing a concurrent write → Cloudflare 502
+    // (issue #124). Make the origin outlast the proxy so the proxy closes first;
+    // headersTimeout must exceed keepAliveTimeout.
+    const app = createApiApp(deps());
+    const server = createApiServer(app, { API_PORT: 0 } as never, pino({ level: 'silent' })) as import('node:http').Server;
+    try {
+      expect(server.keepAliveTimeout).toBe(120_000);
+      expect(server.headersTimeout).toBe(125_000);
+      expect(server.headersTimeout).toBeGreaterThan(server.keepAliveTimeout);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
   });
 });

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { serve } from '@hono/node-server';
 import type { ServerType } from '@hono/node-server';
+import type { Server as HttpServer } from 'node:http';
 import type pino from 'pino';
 import type { Env } from '../config/env';
 import type { ApiDeps, ApiEnv } from './types';
@@ -38,8 +39,18 @@ export function createApiServer(
   env: Env,
   log: pino.Logger,
 ): ServerType {
-  return serve(
+  const server = serve(
     { fetch: app.fetch, hostname: '127.0.0.1', port: env.API_PORT },
     (info) => log.info({ port: info.port }, 'api listening'),
   );
+  // The Cloudflare tunnel (cloudflared) pools keep-alive connections to this
+  // origin (~90s idle). Node's default keepAliveTimeout (5s) would close an idle
+  // socket out from under cloudflared, racing a concurrent write → "use of closed
+  // network connection" → Cloudflare 502 (issue #124). Outlast the proxy so it
+  // always closes idle connections first; headersTimeout must exceed keepAliveTimeout.
+  // serve() is invoked without an http2 option, so this is always a node:http server.
+  const http = server as HttpServer;
+  http.keepAliveTimeout = 120_000;
+  http.headersTimeout = 125_000;
+  return server;
 }


### PR DESCRIPTION
## Summary
Fixes **#124**. The reported "500" was a sporadic Cloudflare **502 Bad gateway** from a Node↔cloudflared keep-alive race — not a beer-processing bug.

cloudflared at the failure timestamp logged `write tcp …->127.0.0.1:3000: use of closed network connection` on `/enrich/result`. The origin (in-process `@hono/node-server`) used Node's default `keepAliveTimeout` (5s) and closed idle keep-alive sockets that cloudflared still held in its ~90s pool; a concurrent write onto a just-closed socket → 502. No crash/restart; the request never reached the app layer (hence no app logs, and the benign payload was irrelevant).

Fix: in `createApiServer`, set `keepAliveTimeout = 120s` and `headersTimeout = 125s` so the proxy always closes idle connections first (`headersTimeout` must exceed `keepAliveTimeout`).

## Test Plan
- [x] New test asserts `createApiServer` sets `keepAliveTimeout=120000`, `headersTimeout=125000`, and `headersTimeout > keepAliveTimeout`
- [x] Full suite green (594), typecheck clean
- [ ] Deploy; confirm cloudflared no longer logs "use of closed network connection" 502s

🤖 Generated with [Claude Code](https://claude.com/claude-code)