### PR TITLE
feat(enrich): log orphan enrich failures to a queryable table

### DIFF
--- a/docs/superpowers/plans/2026-06-11-orphan-enrich-failure-logging.md
+++ b/docs/superpowers/plans/2026-06-11-orphan-enrich-failure-logging.md
@@ -1,0 +1,607 @@
+# Orphan enrich-failure logging — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist every `not_found`/`blocked` enrichment failure (both channels) into a queryable `enrich_failures` table — input + `searchUrl` + candidate summary — so matching bugs are debuggable without manually reproducing/attaching Untappd HTML.
+
+**Architecture:** A v10 SQLite table keyed by `beer_id` (one row per failing beer, upserted, CASCADE-deleted with the beer). `lookupBeer` returns diagnostics (URLs tried + parsed candidates) on `not_found`/`blocked`; the shared `applyLookupOutcome` hook upserts the failure row (and clears it on `matched`), so the server cron and client-relay log identically.
+
+**Tech Stack:** Node 20, TypeScript (strict), better-sqlite3, Jest.
+
+**Spec:** `docs/superpowers/specs/2026-06-11-orphan-enrich-failure-logging-design.md`. Read it first.
+
+**File structure:**
+- `src/storage/schema.ts` — add migration v10.
+- `src/storage/enrich_failures.ts` (new) — `recordEnrichFailure` (upsert), `clearEnrichFailure`.
+- `src/domain/untappd-lookup.ts` — extend `LookupOutcome`, return diagnostics.
+- `src/domain/lookup-outcome.ts` — `summarizeCandidates`, write/clear failures, new `input` param.
+- `src/api/routes/enrich.ts` + `src/jobs/untappd-enrich.ts` — pass `input` to `applyLookupOutcome`.
+- `spec.md` — §3 table + §3.15 + §4 note.
+
+---
+
+## Task 1: Migration v10 — `enrich_failures` table
+
+**Files:**
+- Modify: `src/storage/schema.ts` (MIGRATIONS array, after the v9 entry ~line 162)
+- Test: `src/storage/schema.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/storage/schema.test.ts` (inside the top-level `describe('schema migrations', …)` block, before its closing `});`):
+
+```typescript
+  test('migration v10 creates enrich_failures table with beer_id PK', () => {
+    const db = openDb(':memory:');
+    migrate(db);
+    const cols = db.prepare('PRAGMA table_info(enrich_failures)').all() as { name: string; pk: number }[];
+    const names = cols.map((c) => c.name);
+    expect(names).toEqual(
+      expect.arrayContaining([
+        'beer_id', 'brewery', 'name', 'search_url', 'outcome',
+        'candidates_count', 'candidates_summary', 'fail_count', 'last_at',
+      ]),
+    );
+    expect(cols.find((c) => c.name === 'beer_id')?.pk).toBe(1);
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest src/storage/schema.test.ts -t "v10"`
+Expected: FAIL — `PRAGMA table_info(enrich_failures)` returns `[]`, so `beer_id` pk is undefined.
+
+- [ ] **Step 3: Add the v10 migration**
+
+In `src/storage/schema.ts`, add this object to the `MIGRATIONS` array immediately after the v9 entry (the `extension_releases` block), before the array's closing `]`:
+
+```typescript
+  {
+    version: 10,
+    sql: `
+      CREATE TABLE enrich_failures (
+        beer_id            INTEGER NOT NULL PRIMARY KEY
+                           REFERENCES beers(id) ON DELETE CASCADE,
+        brewery            TEXT NOT NULL,
+        name               TEXT NOT NULL,
+        search_url         TEXT NOT NULL,
+        outcome            TEXT NOT NULL CHECK (outcome IN ('not_found','blocked')),
+        candidates_count   INTEGER NOT NULL,
+        candidates_summary TEXT NOT NULL,
+        fail_count         INTEGER NOT NULL DEFAULT 1,
+        last_at            TEXT NOT NULL
+      );
+    `,
+  },
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest src/storage/schema.test.ts`
+Expected: PASS (new v10 test + idempotency test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/storage/schema.ts src/storage/schema.test.ts
+git commit -m "feat(db): migration v10 — enrich_failures table (#orphan-logging)"
+```
+
+---
+
+## Task 2: `storage/enrich_failures.ts` — record + clear
+
+**Files:**
+- Create: `src/storage/enrich_failures.ts`
+- Test: `src/storage/enrich_failures.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/storage/enrich_failures.test.ts`:
+
+```typescript
+import { openDb } from './db';
+import { migrate } from './schema';
+import { upsertBeer } from './beers';
+import { normalizeName, normalizeBrewery } from '../domain/normalize';
+import { recordEnrichFailure, clearEnrichFailure, type EnrichFailureRow } from './enrich_failures';
+
+function freshDbWithBeer() {
+  const db = openDb(':memory:');
+  migrate(db);
+  const id = upsertBeer(db, {
+    untappd_id: null, name: 'Taking Shape', brewery: 'Track', style: null, abv: null, rating_global: null,
+    normalized_name: normalizeName('Taking Shape'), normalized_brewery: normalizeBrewery('Track'),
+  });
+  return { db, id };
+}
+
+const row = (over: Partial<EnrichFailureRow> & { beer_id: number }): EnrichFailureRow => ({
+  brewery: 'Track', name: 'Taking Shape', search_url: 'https://untappd.com/search?q=Track+Taking+Shape&type=beer',
+  outcome: 'not_found', candidates_count: 0, candidates_summary: '', at: '2026-06-11T00:00:00Z', ...over,
+});
+
+describe('enrich_failures', () => {
+  test('record inserts a row', () => {
+    const { db, id } = freshDbWithBeer();
+    recordEnrichFailure(db, row({ beer_id: id }));
+    const got = db.prepare('SELECT * FROM enrich_failures WHERE beer_id = ?').get(id) as any;
+    expect(got).toMatchObject({ beer_id: id, outcome: 'not_found', candidates_count: 0, fail_count: 1 });
+  });
+
+  test('record upserts: bumps fail_count and refreshes fields', () => {
+    const { db, id } = freshDbWithBeer();
+    recordEnrichFailure(db, row({ beer_id: id, last_at: '2026-06-11T00:00:00Z' }));
+    recordEnrichFailure(db, row({ beer_id: id, outcome: 'blocked', candidates_count: 0, last_at: '2026-06-11T01:00:00Z' }));
+    const got = db.prepare('SELECT * FROM enrich_failures WHERE beer_id = ?').get(id) as any;
+    expect(got.fail_count).toBe(2);
+    expect(got.outcome).toBe('blocked');
+    expect(got.last_at).toBe('2026-06-11T01:00:00Z');
+  });
+
+  test('clear deletes the row', () => {
+    const { db, id } = freshDbWithBeer();
+    recordEnrichFailure(db, row({ beer_id: id }));
+    clearEnrichFailure(db, id);
+    expect(db.prepare('SELECT * FROM enrich_failures WHERE beer_id = ?').get(id)).toBeUndefined();
+  });
+
+  test('deleting the beer cascades to enrich_failures', () => {
+    const { db, id } = freshDbWithBeer();
+    recordEnrichFailure(db, row({ beer_id: id }));
+    db.prepare('DELETE FROM beers WHERE id = ?').run(id);
+    expect(db.prepare('SELECT * FROM enrich_failures WHERE beer_id = ?').get(id)).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest src/storage/enrich_failures.test.ts`
+Expected: FAIL — cannot find module `./enrich_failures`.
+
+- [ ] **Step 3: Implement the module**
+
+Create `src/storage/enrich_failures.ts`:
+
+```typescript
+import type { DB } from './db';
+
+export interface EnrichFailureRow {
+  beer_id: number;
+  brewery: string;
+  name: string;
+  search_url: string;
+  outcome: 'not_found' | 'blocked';
+  candidates_count: number;
+  candidates_summary: string;
+  at: string; // ISO timestamp of this failure
+}
+
+// One row per failing beer. Upsert on beer_id: a repeat failure refreshes the
+// diagnostic fields and bumps fail_count. The row is cleared (clearEnrichFailure)
+// when the beer eventually matches, and CASCADE-deleted if the beer row is removed.
+export function recordEnrichFailure(db: DB, r: EnrichFailureRow): void {
+  db.prepare(
+    `INSERT INTO enrich_failures
+       (beer_id, brewery, name, search_url, outcome, candidates_count, candidates_summary, fail_count, last_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?)
+     ON CONFLICT(beer_id) DO UPDATE SET
+       brewery            = excluded.brewery,
+       name               = excluded.name,
+       search_url         = excluded.search_url,
+       outcome            = excluded.outcome,
+       candidates_count   = excluded.candidates_count,
+       candidates_summary = excluded.candidates_summary,
+       fail_count         = enrich_failures.fail_count + 1,
+       last_at            = excluded.last_at`,
+  ).run(
+    r.beer_id, r.brewery, r.name, r.search_url, r.outcome,
+    r.candidates_count, r.candidates_summary, r.at,
+  );
+}
+
+export function clearEnrichFailure(db: DB, beerId: number): void {
+  db.prepare('DELETE FROM enrich_failures WHERE beer_id = ?').run(beerId);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest src/storage/enrich_failures.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/storage/enrich_failures.ts src/storage/enrich_failures.test.ts
+git commit -m "feat(db): enrich_failures storage — upsert record + clear"
+```
+
+---
+
+## Task 3: `lookupBeer` returns diagnostics on not_found / blocked
+
+**Files:**
+- Modify: `src/domain/untappd-lookup.ts`
+- Test: `src/domain/untappd-lookup.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/domain/untappd-lookup.test.ts` (before the file's final closing `});` of the top `describe('lookupBeer', …)`):
+
+```typescript
+  describe('diagnostics (orphan logging)', () => {
+    test('not_found returns the tried search URL(s) and parsed candidates', async () => {
+      const fetch = jest.fn(async () =>
+        htmlFor([{ bid: 1, name: 'Atak Chmielu', brewery: 'Magic Road' }]),
+      );
+      const out = await lookupBeer({ brewery: 'Magic Road', name: 'Totally Different Beer', fetch });
+      expect(out.kind).toBe('not_found');
+      if (out.kind !== 'not_found') return;
+      expect(out.searchUrls[0]).toContain('Magic%20Road');
+      expect(out.candidates.map((c) => c.beer_name)).toContain('Atak Chmielu');
+    });
+
+    test('not_found with zero results returns empty candidates', async () => {
+      const fetch = jest.fn(async () => '<html><body></body></html>');
+      const out = await lookupBeer({ brewery: 'Magic Road', name: 'Whatever', fetch });
+      expect(out.kind).toBe('not_found');
+      if (out.kind !== 'not_found') return;
+      expect(out.candidates).toEqual([]);
+      expect(out.searchUrls.length).toBeGreaterThan(0);
+    });
+
+    test('blocked returns the search URL that tripped the block', async () => {
+      const fetch = jest.fn(async () => '<title>Just a moment...</title>');
+      const out = await lookupBeer({ brewery: 'Magic Road', name: 'X', fetch });
+      expect(out.kind).toBe('blocked');
+      if (out.kind !== 'blocked') return;
+      expect(out.searchUrl).toContain('Magic%20Road');
+    });
+  });
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx jest src/domain/untappd-lookup.test.ts -t "diagnostics"`
+Expected: FAIL — `out.searchUrls` / `out.candidates` / `out.searchUrl` are `undefined` (type error at compile or assertion fail).
+
+- [ ] **Step 3: Extend `LookupOutcome` and capture diagnostics**
+
+In `src/domain/untappd-lookup.ts`, change the `LookupOutcome` type:
+
+```typescript
+export type LookupOutcome =
+  | { kind: 'matched'; result: SearchResult }
+  | { kind: 'not_found'; searchUrls: string[]; candidates: SearchResult[] }
+  | { kind: 'transient'; error: unknown }
+  | { kind: 'blocked'; searchUrl: string };
+```
+
+Then rework the `lookupBeer` loop body to build the URL up front, accumulate tried URLs + parsed candidates, and return them. Replace the existing loop (from `for (const part of parts) {` through the final `return { kind: 'not_found' };`) with:
+
+```typescript
+  const triedUrls: string[] = [];
+  const seenCandidates: SearchResult[] = [];
+
+  for (const part of parts) {
+    const url = buildSearchUrl(`${stripBreweryNoise(part)} ${name}`.trim());
+    triedUrls.push(url);
+
+    let html: string;
+    try {
+      html = await fetch(url);
+    } catch (error) {
+      if (error instanceof HttpError && isBlockStatus(error.status)) {
+        return { kind: 'blocked', searchUrl: url };
+      }
+      return { kind: 'transient', error };
+    }
+
+    if (isBlockPage(html)) return { kind: 'blocked', searchUrl: url };
+
+    const results = parseSearchPage(html);
+    seenCandidates.push(...results);
+    if (results.length === 0) continue;
+
+    // Stage 1: brewery hard-gate — token-boundary prefix overlap.
+    const breweryPassed = results.filter((r) =>
+      breweryAliasesMatch(breweryAliases(r.brewery_name), inputBreweryAliases),
+    );
+    if (breweryPassed.length === 0) continue;
+
+    // Stage 2a: name-keys exact intersection (order-insensitive, collab/bilingual aware).
+    const inputKeys = nameKeys(name, brewery);
+    const keyHits = breweryPassed.filter((r) =>
+      intersects(nameKeys(r.beer_name, r.brewery_name), inputKeys),
+    );
+    if (keyHits.length > 0) {
+      if (abv != null) {
+        const abvHit = keyHits.find(
+          (r) => r.abv != null && Math.abs(r.abv - abv) <= ABV_TOLERANCE,
+        );
+        if (abvHit) return { kind: 'matched', result: abvHit };
+      }
+      return { kind: 'matched', result: keyHits[0] };
+    }
+
+    // Stage 2b: name fuzzy >= 0.85.
+    const searcher = new Searcher(breweryPassed, {
+      keySelector: (r) => normalizeName(r.beer_name),
+      threshold: NAME_FUZZY_THRESHOLD,
+      returnMatchData: true,
+    });
+    const matches = searcher.search(targetName);
+    if (matches.length === 0) continue;
+
+    const topScore = matches[0].score;
+    if (abv != null) {
+      const abvHit = matches.find(
+        (m) =>
+          m.score === topScore &&
+          m.item.abv != null &&
+          Math.abs(m.item.abv - abv) <= ABV_TOLERANCE,
+      );
+      if (abvHit) return { kind: 'matched', result: abvHit.item };
+    }
+
+    return { kind: 'matched', result: matches[0].item };
+  }
+
+  return { kind: 'not_found', searchUrls: triedUrls, candidates: seenCandidates };
+```
+
+> Note: this preserves the existing Stage 1 / 2a / 2b logic verbatim; the only additions are `triedUrls`/`seenCandidates` accumulation, the `searchUrl` on the two `blocked` returns, and the fields on the final `not_found`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest src/domain/untappd-lookup.test.ts`
+Expected: PASS (new diagnostics tests + all pre-existing lookup tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/domain/untappd-lookup.ts src/domain/untappd-lookup.test.ts
+git commit -m "feat(enrich): lookupBeer returns searchUrls+candidates (not_found) / searchUrl (blocked)"
+```
+
+---
+
+## Task 4: Log failures in `applyLookupOutcome` (both channels)
+
+**Files:**
+- Modify: `src/domain/lookup-outcome.ts`
+- Modify: `src/api/routes/enrich.ts:76`
+- Modify: `src/jobs/untappd-enrich.ts:39`
+- Test: `src/domain/lookup-outcome.test.ts` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/domain/lookup-outcome.test.ts`:
+
+```typescript
+import pino from 'pino';
+import { openDb } from '../storage/db';
+import { migrate } from '../storage/schema';
+import { upsertBeer, getBeer } from '../storage/beers';
+import { normalizeName, normalizeBrewery } from './normalize';
+import { applyLookupOutcome } from './lookup-outcome';
+import type { LookupOutcome } from './untappd-lookup';
+import type { SearchResult } from '../sources/untappd/search';
+
+function fresh() {
+  const db = openDb(':memory:');
+  migrate(db);
+  const id = upsertBeer(db, {
+    untappd_id: null, name: 'Taking Shape', brewery: 'Track', style: null, abv: null, rating_global: null,
+    normalized_name: normalizeName('Taking Shape'), normalized_brewery: normalizeBrewery('Track'),
+  });
+  return { db, id, log: pino({ level: 'silent' }) };
+}
+const input = { brewery: 'Track', name: 'Taking Shape' };
+const cand = (over: Partial<SearchResult>): SearchResult => ({
+  bid: 1, beer_name: 'Some Beer', brewery_name: 'Some Brewery', style: null, abv: null, global_rating: null, ...over,
+});
+const failRow = (db: any, id: number) =>
+  db.prepare('SELECT * FROM enrich_failures WHERE beer_id = ?').get(id);
+
+describe('applyLookupOutcome failure logging', () => {
+  test('not_found records a failure row with candidate summary', () => {
+    const { db, id, log } = fresh();
+    const outcome: LookupOutcome = {
+      kind: 'not_found',
+      searchUrls: ['https://untappd.com/search?q=Track+Taking+Shape&type=beer'],
+      candidates: [cand({ brewery_name: 'Track Brewing', beer_name: 'Taking Shape XPA' })],
+    };
+    applyLookupOutcome({ db, log }, id, outcome, '2026-06-11T00:00:00Z', input);
+    const row = failRow(db, id);
+    expect(row).toMatchObject({ outcome: 'not_found', candidates_count: 1, fail_count: 1 });
+    expect(row.candidates_summary).toContain('Track Brewing — Taking Shape XPA');
+    expect(row.search_url).toContain('Track+Taking+Shape');
+  });
+
+  test('blocked records a failure row with zero candidates', () => {
+    const { db, id, log } = fresh();
+    const outcome: LookupOutcome = { kind: 'blocked', searchUrl: 'https://untappd.com/search?q=Track&type=beer' };
+    applyLookupOutcome({ db, log }, id, outcome, '2026-06-11T00:00:00Z', input);
+    expect(failRow(db, id)).toMatchObject({ outcome: 'blocked', candidates_count: 0 });
+  });
+
+  test('matched clears any prior failure row', () => {
+    const { db, id, log } = fresh();
+    applyLookupOutcome({ db, log }, id,
+      { kind: 'not_found', searchUrls: ['u'], candidates: [] }, '2026-06-11T00:00:00Z', input);
+    expect(failRow(db, id)).toBeDefined();
+    applyLookupOutcome({ db, log }, id,
+      { kind: 'matched', result: cand({ bid: 999 }) }, '2026-06-11T01:00:00Z', input);
+    expect(failRow(db, id)).toBeUndefined();
+    expect(getBeer(db, id)?.untappd_id).toBe(999);
+  });
+
+  test('transient does not record a failure', () => {
+    const { db, id, log } = fresh();
+    applyLookupOutcome({ db, log }, id,
+      { kind: 'transient', error: new Error('x') }, '2026-06-11T00:00:00Z', input);
+    expect(failRow(db, id)).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx jest src/domain/lookup-outcome.test.ts`
+Expected: FAIL — `applyLookupOutcome` takes 4 args (no `input`) and does not touch `enrich_failures`.
+
+- [ ] **Step 3: Implement the logging + summary helper**
+
+In `src/domain/lookup-outcome.ts`, update imports (add the failure store + `SearchResult`):
+
+```typescript
+import {
+  mergeIntoCanonical,
+  recordLookupNotFound,
+  recordLookupSuccess,
+  recordLookupTransient,
+} from '../storage/beers';
+import { recordEnrichFailure, clearEnrichFailure } from '../storage/enrich_failures';
+import type { LookupOutcome } from './untappd-lookup';
+import type { SearchResult } from '../sources/untappd/search';
+```
+
+Add the summary helper above `applyLookupOutcome`:
+
+```typescript
+// Compact, human-readable summary of what the Untappd search returned — top 3
+// "<brewery> — <name>". Empty string when the search returned nothing (a noisy query).
+function summarizeCandidates(candidates: SearchResult[]): string {
+  return candidates.slice(0, 3).map((r) => `${r.brewery_name} — ${r.beer_name}`).join('; ');
+}
+```
+
+Change the signature to accept the raw input and rewrite the body so `not_found`/`blocked` upsert a failure row and `matched` clears it:
+
+```typescript
+export function applyLookupOutcome(
+  deps: { db: DB; log: pino.Logger },
+  beerId: number,
+  outcome: LookupOutcome,
+  nowIso: string,
+  input: { brewery: string; name: string },
+): EnrichOutcomeKind {
+  switch (outcome.kind) {
+    case 'matched':
+      try {
+        recordLookupSuccess(deps.db, beerId, outcome.result);
+        clearEnrichFailure(deps.db, beerId);
+        return 'matched';
+      } catch (e: unknown) {
+        if ((e as { code?: string }).code !== 'SQLITE_CONSTRAINT_UNIQUE') throw e;
+        const canonical = deps.db
+          .prepare('SELECT id FROM beers WHERE untappd_id = ?')
+          .get(outcome.result.bid) as { id: number } | undefined;
+        if (canonical) {
+          // mergeIntoCanonical deletes the orphan row → its enrich_failures row
+          // is CASCADE-removed; this is a success, not a failure.
+          mergeIntoCanonical(deps.db, beerId, canonical.id);
+          deps.log.warn(
+            { beerId, canonicalId: canonical.id, bid: outcome.result.bid },
+            'enrich: merged duplicate orphan into canonical',
+          );
+        }
+        return 'not_found';
+      }
+    case 'not_found':
+      recordEnrichFailure(deps.db, {
+        beer_id: beerId,
+        brewery: input.brewery,
+        name: input.name,
+        search_url: outcome.searchUrls[0] ?? '',
+        outcome: 'not_found',
+        candidates_count: outcome.candidates.length,
+        candidates_summary: summarizeCandidates(outcome.candidates),
+        at: nowIso,
+      });
+      recordLookupNotFound(deps.db, beerId, nowIso);
+      return 'not_found';
+    case 'transient':
+      deps.log.warn({ err: outcome.error, beerId }, 'untappd-lookup transient failure');
+      recordLookupTransient(deps.db, beerId, nowIso);
+      return 'transient';
+    case 'blocked':
+      recordEnrichFailure(deps.db, {
+        beer_id: beerId,
+        brewery: input.brewery,
+        name: input.name,
+        search_url: outcome.searchUrl,
+        outcome: 'blocked',
+        candidates_count: 0,
+        candidates_summary: '',
+        at: nowIso,
+      });
+      return 'blocked';
+  }
+}
+```
+
+- [ ] **Step 4: Update the two callers**
+
+In `src/api/routes/enrich.ts`, change the `applyLookupOutcome` call (~line 76) to pass the request input:
+
+```typescript
+    const kind = applyLookupOutcome({ db: deps.db, log: deps.log }, row.id, outcome, nowIso, { brewery, name });
+```
+
+In `src/jobs/untappd-enrich.ts`, change the final call (~line 39):
+
+```typescript
+  return applyLookupOutcome(deps, beerId, outcome, nowIso, { brewery: beer.brewery, name: beer.name });
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npx jest src/domain/lookup-outcome.test.ts src/api/routes/enrich.test.ts src/jobs`
+Expected: PASS (new logging tests + existing enrich/cron tests still green).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/domain/lookup-outcome.ts src/domain/lookup-outcome.test.ts src/api/routes/enrich.ts src/jobs/untappd-enrich.ts
+git commit -m "feat(enrich): log not_found/blocked to enrich_failures, clear on match (both channels)"
+```
+
+---
+
+## Task 5: Spec sync + full suite
+
+**Files:**
+- Modify: `spec.md`
+
+- [ ] **Step 1: Update `spec.md`**
+
+- §3: add a `3.x enrich_failures` table subsection (columns per the design doc: `beer_id` PK→beers CASCADE, `brewery`, `name`, `search_url`, `outcome` CHECK in (`not_found`,`blocked`), `candidates_count`, `candidates_summary`, `fail_count`, `last_at`); add a v10 row to the §3.15 migration-history table: `| 10 | enrich_failures (orphan enrich-failure logging) |`.
+- §4 (`/enrich/*` + background jobs): note that `not_found`/`blocked` outcomes upsert an `enrich_failures` row (one per beer, both channels via `applyLookupOutcome`), carrying input + `search_url` + candidate summary, self-cleared on `matched`. Untappd search is cookieless-reproducible, so the `search_url` suffices to debug.
+- §5.2: clarify the "block never mutates backoff" invariant still holds — logging a `blocked` failure row does not touch `untappd_lookup_*`.
+
+- [ ] **Step 2: Run the full suite + typecheck**
+
+Run: `npx jest && npm run typecheck`
+Expected: PASS, no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add spec.md
+git commit -m "docs(spec): document enrich_failures table (v10) + orphan-failure logging"
+```
+
+---
+
+## Done criteria
+- All Jest suites green; typecheck clean.
+- `not_found`/`blocked` from either channel produce/refresh an `enrich_failures` row; `matched` clears it; `transient` does not log.
+- Migration v10 idempotent; `enrich_failures` CASCADE-deletes with its beer.
+
+## Out of scope / follow-ups
+- `/orphans` bot command over the table (trivial add later).
+- Logging `matched`/`transient`; storing HTML.

--- a/docs/superpowers/specs/2026-06-11-orphan-enrich-failure-logging-design.md
+++ b/docs/superpowers/specs/2026-06-11-orphan-enrich-failure-logging-design.md
@@ -1,0 +1,110 @@
+# Orphan enrich-failure logging — design
+
+> **Стандарт:** OpenSpec (spec-driven). **Статус:** `DESIGN`.
+> **Дата:** 2026-06-11. **Мотивація:** дебаг матчингу (#117, #124) вимагав ручного
+> відтворення кейсів — зберегти вхід + сторінку пошуку Untappd і причепити до ішьюзу.
+> **Звіряти з:** `spec.md` §3 (схема), §4 (`/enrich/*`, фонові джоби), §5.2 (інваріанти).
+
+## 1. Problem
+
+Коли пиво не енричиться (лишається orphan), зараз немає сліду **чому**. Щоб
+дебажити, доводилося просити користувача відтворити пошук, зберегти HTML і причепити
+до GitHub-ішьюзу (#117, #124) — повільно й не масштабується.
+
+**Ключове спостереження (перевірено з прод-хоста, 2026-06-11):** пошук Untappd
+(`untappd.com/search?q=…&type=beer`) **доступний без кукі/логіна** — HTTP 200, реальні
+результати в `.results-container .beer-item`, які `parseSearchPage` парсить. Серверне
+«блокування» (через яке зроблено client-relay) — інтермітентне/rate-based (тригерить
+circuit breaker під автоматичним батчем), не абсолютне. Тож **HTML зберігати не треба**:
+достатньо залогувати `searchUrl`, і його можна відкрити в браузері або перетягнути
+`curl`-ом для відтворення.
+
+## 2. Goals / Non-goals
+
+**Goals.** Запитувана таблиця провалів енричу: для кожного orphan'а, що дав `not_found`
+або `blocked`, зберегти вхід (`brewery`/`name`), `searchUrl`, результат і **короткий
+summary кандидатів** (скільки повернув пошук і топ-3 `brewery — name`), щоб «чому» було
+видно одразу або однокліково відтворювалося. Обидва канали енричу. Self-cleaning.
+
+**Non-goals.** Не логуємо `matched` (успіх) і `transient` (тимчасова мережа, не сигнал
+матчингу). Не зберігаємо HTML. Не будуємо `/orphans`-команду бота (тривіальна добавка
+згодом — YAGNI). Не чіпаємо `/match`-оверлей (read-only, інший шлях).
+
+## 3. Design
+
+### 3.1 Дані (міграція v10)
+
+Нова таблиця `enrich_failures` — **один рядок на пиво**, upsert на кожному провалі,
+видаляється коли пиво нарешті матчиться. Розмір обмежений поточним набором orphan'ів.
+
+| Поле | Тип | Опис |
+|------|-----|------|
+| `beer_id` | INTEGER | PK → `beers(id)` **ON DELETE CASCADE** |
+| `brewery` | TEXT NOT NULL | сирий вхід (як прийшов) |
+| `name` | TEXT NOT NULL | сирий вхід |
+| `search_url` | TEXT NOT NULL | побудований запит (перша brewery-частина) — відкрити для відтворення |
+| `outcome` | TEXT NOT NULL CHECK IN (`not_found`,`blocked`) | результат |
+| `candidates_count` | INTEGER NOT NULL | скільки кандидатів повернув пошук (0 = зашумлений запит) |
+| `candidates_summary` | TEXT NOT NULL | топ-3 `"<brewery> — <name>"`, `;`-joined (порожньо для blocked) |
+| `fail_count` | INTEGER NOT NULL DEFAULT 1 | скільки разів провалився (++ на upsert) |
+| `last_at` | TEXT NOT NULL | час останнього провалу (ISO) |
+
+Запит дебагу: `SELECT brewery, name, outcome, candidates_count, candidates_summary,
+search_url, fail_count, last_at FROM enrich_failures ORDER BY last_at DESC;`
+«0 кандидатів» → запит зашумлений (як #124 Track); «N, але not_found» → brewery-gate
+або name-fuzzy відсікли (видно по їхніх brewery/name, як #117).
+
+### 3.2 Прокидання діагностики з `lookupBeer`
+
+Розширити `LookupOutcome` (`domain/untappd-lookup.ts`) — діагностика вже є всередині
+(URL'и будуються, результати парсяться), просто повертаємо її:
+```ts
+| { kind: 'not_found'; searchUrls: string[]; candidates: SearchResult[] }
+| { kind: 'blocked'; searchUrl: string }
+```
+- `not_found`: `searchUrls` — усі спробувані brewery-частини; `candidates` — об'єднання
+  розпарсених результатів (може бути порожнім).
+- `blocked`: `searchUrl` — той, що дав блок.
+- `matched`/`transient` — без змін.
+
+### 3.3 Логування в спільному хуку
+
+`applyLookupOutcome` (`domain/lookup-outcome.ts`) — спільний для серверного крона
+(`enrichOneOrphan`) і client-relay (`/enrich/result`), тож обидва канали логуються
+однаково. Сигнатура отримує вхід `input: { brewery: string; name: string }`:
+- `outcome.kind === 'not_found'` → `recordEnrichFailure(...)` (`outcome: 'not_found'`,
+  `search_url = searchUrls[0]`, summary з `candidates`), потім наявний `recordLookupNotFound`.
+- `outcome.kind === 'blocked'` → `recordEnrichFailure(...)` (`outcome: 'blocked'`,
+  `candidates_count: 0`), нічого більше (блок не мутує backoff — інваріант §5.2).
+- `outcome.kind === 'matched'` → `clearEnrichFailure(db, beerId)` ПІСЛЯ `recordLookupSuccess`
+  (пиво більше не провал). Merge-гілка (UNIQUE-клеш → повертає `'not_found'`) — це
+  **успіх**, тож теж чистить, НЕ логує провал (гейтимо по `outcome.kind`, не по return).
+
+### 3.4 Storage-модуль
+
+`storage/enrich_failures.ts` (один модуль на таблицю): `recordEnrichFailure(db, row)`
+(upsert по `beer_id`, `fail_count = fail_count + 1` на конфлікті), `clearEnrichFailure(db,
+beerId)` (`DELETE`). Summary будує хелпер: топ-3 `r.brewery_name — r.beer_name`, `; `-joined.
+
+## 4. Testing
+
+- **schema.test.ts:** міграція до v10 створює `enrich_failures`; ідемпотентна.
+- **enrich_failures.test.ts:** upsert створює/оновлює (++`fail_count`, новий `last_at`);
+  `clearEnrichFailure` видаляє; CASCADE при видаленні beer'а.
+- **lookup-outcome.test.ts:** `not_found` пише рядок (`outcome`, `search_url`, count,
+  summary); `blocked` пише (count 0); `matched` чистить; merge-гілка (`matched`+UNIQUE)
+  чистить і НЕ лишає провалу.
+- **untappd-lookup.test.ts:** `not_found` повертає `searchUrls`+`candidates`; `blocked`
+  повертає `searchUrl`. Summary: «0 кандидатів» (зашумлений запит) і «N кандидатів, але
+  not_found» (gate/fuzzy відсік) — на синтетичних фікстурах.
+
+## 5. Spec impact (`spec.md`)
+
+- §3: нова таблиця `enrich_failures` (v10) + рядок у §3.15 (історія міграцій).
+- §4 (`/enrich/*` + фонові джоби): нотатка, що `not_found`/`blocked` логуються в
+  `enrich_failures` (обидва канали), self-cleaning на `matched`.
+- §5.2: «блок не мутує backoff» лишається — логування провалу backoff не змінює.
+
+## 6. Rollout
+Без впливу на користувача. Міграція v10 — ідемпотентний `CREATE TABLE`. Таблиця
+наповнюється з наступного енричу (крон або client-relay).

--- a/spec.md
+++ b/spec.md
@@ -328,10 +328,30 @@ src/
 `file_id`/`attached_by` — бот, коли адмін надсилає zip і його sha256 збігається з
 останнім рядком. «Остання» версія — за semver (числове порівняння, не лексичне).
 
-### 3.13 `schema_version` — версія міграцій
+### 3.13 `enrich_failures` — лог провалів енричу (v10)
+| Поле | Тип | Обмеження | Опис |
+|------|-----|-----------|------|
+| `beer_id` | INTEGER | PK → `beers(id)` **ON DELETE CASCADE** | один рядок на пиво |
+| `brewery` | TEXT | NOT NULL | сирий вхід (як прийшов) |
+| `name` | TEXT | NOT NULL | сирий вхід |
+| `search_url` | TEXT | NOT NULL | побудований запит (перша brewery-частина) — відкрити для відтворення |
+| `outcome` | TEXT | NOT NULL CHECK IN (`not_found`,`blocked`) | результат провалу |
+| `candidates_count` | INTEGER | NOT NULL | скільки кандидатів повернув пошук (0 = зашумлений запит) |
+| `candidates_summary` | TEXT | NOT NULL | топ-3 `"<brewery> — <name>"`, `;`-joined (порожньо для blocked) |
+| `fail_count` | INTEGER | NOT NULL DEFAULT 1 | скільки разів провалився (++ на upsert) |
+| `last_at` | TEXT | NOT NULL | час останнього провалу (ISO) |
+
+**Хто що пише:** `applyLookupOutcome` (спільний для серверного крона і client-relay)
+upsert'ить рядок на `not_found`/`blocked` і **видаляє** його на `matched`. Один рядок на
+пиво (upsert по `beer_id`), розмір обмежений поточним набором orphan'ів. Untappd-пошук
+відтворюваний без кукі, тож `search_url` достатньо для дебагу. Запит:
+`SELECT … FROM enrich_failures ORDER BY last_at DESC` — «0 кандидатів» = зашумлений запит;
+«N, але not_found» = brewery-gate / name-fuzzy відсік (видно по `candidates_summary`).
+
+### 3.14 `schema_version` — версія міграцій
 Єдине поле `version INTEGER PRIMARY KEY`; по рядку на застосовану міграцію.
 
-### 3.14 Зв'язки (ER, текстом)
+### 3.15 Зв'язки (ER, текстом)
 ```
 user_profiles 1───* checkins        (telegram_id)
 user_profiles 1───1 user_filters    (telegram_id, CASCADE)
@@ -340,12 +360,13 @@ user_profiles 1───* api_tokens      (telegram_id, CASCADE; ротація 
 beers         1───* checkins         (beer_id)
 beers         1───* untappd_had      (beer_id, CASCADE)
 beers         1───* match_links      (untappd_beer_id = LOCAL beers.id)
+beers         1───1 enrich_failures   (beer_id, CASCADE; один рядок на пиво, що провалило енрич)
 pubs          1───* tap_snapshots    (pub_id)
 tap_snapshots 1───* taps             (snapshot_id, CASCADE)
 pubs          *───* pubs             via pub_distances (a<b)
 ```
 
-### 3.15 Історія міграцій
+### 3.16 Історія міграцій
 | v | Зміст |
 |---|-------|
 | 1 | базова схема: beers, pubs, tap_snapshots, taps, checkins, match_links, user_profiles, user_filters |
@@ -357,6 +378,7 @@ pubs          *───* pubs             via pub_distances (a<b)
 | 7 | reset lookup-backoff для orphan'ів (`untappd_id IS NULL`) — переенрич |
 | 8 | `api_tokens` (токен-авторизація браузерного розширення) |
 | 9 | `extension_releases` (дистрибуція бета-версій розширення) |
+| 10 | `enrich_failures` (лог провалів енричу для дебагу матчингу) |
 
 ---
 
@@ -535,9 +557,15 @@ eligible,searchUrl}]}`, де `eligible` = backoff-due (`isEligible`) і пиво
 `/enrich/result` приймає `{brewery,name,html}` (обрізана клієнтом сторінка Untappd-пошуку),
 проганяє наявний `lookupBeer` з `fetch=()=>html` і застосовує спільний `applyLookupOutcome`:
 matched → `recordLookupSuccess` (bid+рейтинг; UNIQUE-клеш → merge у канонічний рядок),
-not_found → `recordLookupNotFound` (backoff++), blocked → НІЧОГО не пише (блок ніколи не
-мутує backoff). Той самий orphan-пул і backoff, що й у серверного enrich-крона — клієнт
-лише дозбирює видиме й due.
+not_found → `recordLookupNotFound` (backoff++), blocked → НІЧОГО не пише в backoff (блок
+ніколи не мутує backoff). Той самий orphan-пул і backoff, що й у серверного enrich-крона —
+клієнт лише дозбирює видиме й due.
+
+**Лог провалів (дебаг).** Обидва канали (крон + client-relay) через `applyLookupOutcome`
+upsert'ять рядок у `enrich_failures` (§3.13) на `not_found`/`blocked` — вхід + `search_url`
++ summary кандидатів, self-cleared на `matched`. Це робить орфани дебажними без ручного
+відтворення/прикладання HTML до ішьюзу (бо Untappd-пошук відтворюється без кукі — досить
+`search_url`). Backoff це НЕ зачіпає: `blocked` пише лише debug-рядок, не `untappd_lookup_*`.
 
 ### Фонові джоби (node-cron, у процесі)
 | Джоба | Розклад | Призначення |

--- a/src/api/routes/enrich.ts
+++ b/src/api/routes/enrich.ts
@@ -73,7 +73,7 @@ export function enrichRoute(app: Hono<ApiEnv>, deps: ApiDeps): void {
     // injected fetch just returns the relayed HTML regardless of URL.
     const outcome = await lookupBeer({ brewery, name, abv: row.abv, fetch: async () => html });
     const nowIso = new Date().toISOString();
-    const kind = applyLookupOutcome({ db: deps.db, log: deps.log }, row.id, outcome, nowIso);
+    const kind = applyLookupOutcome({ db: deps.db, log: deps.log }, row.id, outcome, nowIso, { brewery, name });
     if (kind === 'matched' && outcome.kind === 'matched') {
       return c.json({ status: 'matched', untappd_id: outcome.result.bid, rating_global: outcome.result.global_rating });
     }

--- a/src/domain/lookup-outcome.test.ts
+++ b/src/domain/lookup-outcome.test.ts
@@ -1,0 +1,65 @@
+import pino from 'pino';
+import { openDb } from '../storage/db';
+import { migrate } from '../storage/schema';
+import { upsertBeer, getBeer } from '../storage/beers';
+import { normalizeName, normalizeBrewery } from './normalize';
+import { applyLookupOutcome } from './lookup-outcome';
+import type { LookupOutcome } from './untappd-lookup';
+import type { SearchResult } from '../sources/untappd/search';
+
+function fresh() {
+  const db = openDb(':memory:');
+  migrate(db);
+  const id = upsertBeer(db, {
+    untappd_id: null, name: 'Taking Shape', brewery: 'Track', style: null, abv: null, rating_global: null,
+    normalized_name: normalizeName('Taking Shape'), normalized_brewery: normalizeBrewery('Track'),
+  });
+  return { db, id, log: pino({ level: 'silent' }) };
+}
+const input = { brewery: 'Track', name: 'Taking Shape' };
+const cand = (over: Partial<SearchResult>): SearchResult => ({
+  bid: 1, beer_name: 'Some Beer', brewery_name: 'Some Brewery', style: null, abv: null, global_rating: null, ...over,
+});
+const failRow = (db: any, id: number) =>
+  db.prepare('SELECT * FROM enrich_failures WHERE beer_id = ?').get(id);
+
+describe('applyLookupOutcome failure logging', () => {
+  test('not_found records a failure row with candidate summary', () => {
+    const { db, id, log } = fresh();
+    const outcome: LookupOutcome = {
+      kind: 'not_found',
+      searchUrls: ['https://untappd.com/search?q=Track+Taking+Shape&type=beer'],
+      candidates: [cand({ brewery_name: 'Track Brewing', beer_name: 'Taking Shape XPA' })],
+    };
+    applyLookupOutcome({ db, log }, id, outcome, '2026-06-11T00:00:00Z', input);
+    const row = failRow(db, id);
+    expect(row).toMatchObject({ outcome: 'not_found', candidates_count: 1, fail_count: 1 });
+    expect(row.candidates_summary).toContain('Track Brewing — Taking Shape XPA');
+    expect(row.search_url).toContain('Track+Taking+Shape');
+  });
+
+  test('blocked records a failure row with zero candidates', () => {
+    const { db, id, log } = fresh();
+    const outcome: LookupOutcome = { kind: 'blocked', searchUrl: 'https://untappd.com/search?q=Track&type=beer' };
+    applyLookupOutcome({ db, log }, id, outcome, '2026-06-11T00:00:00Z', input);
+    expect(failRow(db, id)).toMatchObject({ outcome: 'blocked', candidates_count: 0 });
+  });
+
+  test('matched clears any prior failure row', () => {
+    const { db, id, log } = fresh();
+    applyLookupOutcome({ db, log }, id,
+      { kind: 'not_found', searchUrls: ['u'], candidates: [] }, '2026-06-11T00:00:00Z', input);
+    expect(failRow(db, id)).toBeDefined();
+    applyLookupOutcome({ db, log }, id,
+      { kind: 'matched', result: cand({ bid: 999 }) }, '2026-06-11T01:00:00Z', input);
+    expect(failRow(db, id)).toBeUndefined();
+    expect(getBeer(db, id)?.untappd_id).toBe(999);
+  });
+
+  test('transient does not record a failure', () => {
+    const { db, id, log } = fresh();
+    applyLookupOutcome({ db, log }, id,
+      { kind: 'transient', error: new Error('x') }, '2026-06-11T00:00:00Z', input);
+    expect(failRow(db, id)).toBeUndefined();
+  });
+});

--- a/src/domain/lookup-outcome.ts
+++ b/src/domain/lookup-outcome.ts
@@ -6,9 +6,17 @@ import {
   recordLookupSuccess,
   recordLookupTransient,
 } from '../storage/beers';
+import { recordEnrichFailure, clearEnrichFailure } from '../storage/enrich_failures';
 import type { LookupOutcome } from './untappd-lookup';
+import type { SearchResult } from '../sources/untappd/search';
 
 export type EnrichOutcomeKind = 'matched' | 'not_found' | 'transient' | 'skipped' | 'blocked';
+
+// Compact, human-readable summary of what the Untappd search returned — top 3
+// "<brewery> — <name>". Empty string when the search returned nothing (a noisy query).
+function summarizeCandidates(candidates: SearchResult[]): string {
+  return candidates.slice(0, 3).map((r) => `${r.brewery_name} — ${r.beer_name}`).join('; ');
+}
 
 // Applies a lookupBeer outcome to a beer row's enrichment/backoff state. Shared by the
 // server enrich cron (enrichOneOrphan) and the client-relay /enrich/result endpoint so
@@ -19,11 +27,13 @@ export function applyLookupOutcome(
   beerId: number,
   outcome: LookupOutcome,
   nowIso: string,
+  input: { brewery: string; name: string },
 ): EnrichOutcomeKind {
   switch (outcome.kind) {
     case 'matched':
       try {
         recordLookupSuccess(deps.db, beerId, outcome.result);
+        clearEnrichFailure(deps.db, beerId);
         return 'matched';
       } catch (e: unknown) {
         if ((e as { code?: string }).code !== 'SQLITE_CONSTRAINT_UNIQUE') throw e;
@@ -31,6 +41,8 @@ export function applyLookupOutcome(
           .prepare('SELECT id FROM beers WHERE untappd_id = ?')
           .get(outcome.result.bid) as { id: number } | undefined;
         if (canonical) {
+          // mergeIntoCanonical deletes the orphan row → its enrich_failures row is
+          // CASCADE-removed; this is a success, not a failure.
           mergeIntoCanonical(deps.db, beerId, canonical.id);
           deps.log.warn(
             { beerId, canonicalId: canonical.id, bid: outcome.result.bid },
@@ -40,6 +52,16 @@ export function applyLookupOutcome(
         return 'not_found';
       }
     case 'not_found':
+      recordEnrichFailure(deps.db, {
+        beer_id: beerId,
+        brewery: input.brewery,
+        name: input.name,
+        search_url: outcome.searchUrls[0] ?? '',
+        outcome: 'not_found',
+        candidates_count: outcome.candidates.length,
+        candidates_summary: summarizeCandidates(outcome.candidates),
+        at: nowIso,
+      });
       recordLookupNotFound(deps.db, beerId, nowIso);
       return 'not_found';
     case 'transient':
@@ -47,6 +69,16 @@ export function applyLookupOutcome(
       recordLookupTransient(deps.db, beerId, nowIso);
       return 'transient';
     case 'blocked':
+      recordEnrichFailure(deps.db, {
+        beer_id: beerId,
+        brewery: input.brewery,
+        name: input.name,
+        search_url: outcome.searchUrl,
+        outcome: 'blocked',
+        candidates_count: 0,
+        candidates_summary: '',
+        at: nowIso,
+      });
       return 'blocked';
   }
 }

--- a/src/domain/untappd-lookup.test.ts
+++ b/src/domain/untappd-lookup.test.ts
@@ -223,6 +223,36 @@ describe('lookupBeer', () => {
     expect(out.kind).toBe('blocked');
   });
 
+  describe('diagnostics (orphan logging)', () => {
+    test('not_found returns the tried search URL(s) and parsed candidates', async () => {
+      const fetch = jest.fn(async () =>
+        htmlFor([{ bid: 1, name: 'Atak Chmielu', brewery: 'Magic Road' }]),
+      );
+      const out = await lookupBeer({ brewery: 'Magic Road', name: 'Totally Different Beer', fetch });
+      expect(out.kind).toBe('not_found');
+      if (out.kind !== 'not_found') return;
+      expect(out.searchUrls[0]).toContain('Magic%20Road');
+      expect(out.candidates.map((c) => c.beer_name)).toContain('Atak Chmielu');
+    });
+
+    test('not_found with zero results returns empty candidates', async () => {
+      const fetch = jest.fn(async () => '<html><body></body></html>');
+      const out = await lookupBeer({ brewery: 'Magic Road', name: 'Whatever', fetch });
+      expect(out.kind).toBe('not_found');
+      if (out.kind !== 'not_found') return;
+      expect(out.candidates).toEqual([]);
+      expect(out.searchUrls.length).toBeGreaterThan(0);
+    });
+
+    test('blocked returns the search URL that tripped the block', async () => {
+      const fetch = jest.fn(async () => '<title>Just a moment...</title>');
+      const out = await lookupBeer({ brewery: 'Magic Road', name: 'X', fetch });
+      expect(out.kind).toBe('blocked');
+      if (out.kind !== 'blocked') return;
+      expect(out.searchUrl).toContain('Magic%20Road');
+    });
+  });
+
   describe('name-keys stage (#117)', () => {
     test('matched: reordered name (below fuzzy 0.85) via key intersection', async () => {
       const fetch = jest.fn(async () =>

--- a/src/domain/untappd-lookup.ts
+++ b/src/domain/untappd-lookup.ts
@@ -13,9 +13,9 @@ const NAME_FUZZY_THRESHOLD = 0.85;
 
 export type LookupOutcome =
   | { kind: 'matched'; result: SearchResult }
-  | { kind: 'not_found' }
+  | { kind: 'not_found'; searchUrls: string[]; candidates: SearchResult[] }
   | { kind: 'transient'; error: unknown }
-  | { kind: 'blocked' };
+  | { kind: 'blocked'; searchUrl: string };
 
 export interface LookupArgs {
   brewery: string;
@@ -40,21 +40,27 @@ export async function lookupBeer(args: LookupArgs): Promise<LookupOutcome> {
   const inputBreweryAliases = breweryAliases(brewery);
   const targetName = normalizeName(name);
   const parts = brewerySearchParts(brewery);
+  const triedUrls: string[] = [];
+  const seenCandidates: SearchResult[] = [];
 
   for (const part of parts) {
+    const url = buildSearchUrl(`${stripBreweryNoise(part)} ${name}`.trim());
+    triedUrls.push(url);
+
     let html: string;
     try {
-      html = await fetch(buildSearchUrl(`${stripBreweryNoise(part)} ${name}`.trim()));
+      html = await fetch(url);
     } catch (error) {
       if (error instanceof HttpError && isBlockStatus(error.status)) {
-        return { kind: 'blocked' };
+        return { kind: 'blocked', searchUrl: url };
       }
       return { kind: 'transient', error };
     }
 
-    if (isBlockPage(html)) return { kind: 'blocked' };
+    if (isBlockPage(html)) return { kind: 'blocked', searchUrl: url };
 
     const results = parseSearchPage(html);
+    seenCandidates.push(...results);
     if (results.length === 0) continue;
 
     // Stage 1: brewery hard-gate — token-boundary prefix overlap.
@@ -105,5 +111,5 @@ export async function lookupBeer(args: LookupArgs): Promise<LookupOutcome> {
     return { kind: 'matched', result: matches[0].item };
   }
 
-  return { kind: 'not_found' };
+  return { kind: 'not_found', searchUrls: triedUrls, candidates: seenCandidates };
 }

--- a/src/jobs/untappd-enrich.ts
+++ b/src/jobs/untappd-enrich.ts
@@ -36,5 +36,5 @@ export async function enrichOneOrphan(
   });
 
   const nowIso = now.toISOString();
-  return applyLookupOutcome(deps, beerId, outcome, nowIso);
+  return applyLookupOutcome(deps, beerId, outcome, nowIso, { brewery: beer.brewery, name: beer.name });
 }

--- a/src/storage/enrich_failures.test.ts
+++ b/src/storage/enrich_failures.test.ts
@@ -1,0 +1,53 @@
+import { openDb } from './db';
+import { migrate } from './schema';
+import { upsertBeer } from './beers';
+import { normalizeName, normalizeBrewery } from '../domain/normalize';
+import { recordEnrichFailure, clearEnrichFailure, type EnrichFailureRow } from './enrich_failures';
+
+function freshDbWithBeer() {
+  const db = openDb(':memory:');
+  migrate(db);
+  const id = upsertBeer(db, {
+    untappd_id: null, name: 'Taking Shape', brewery: 'Track', style: null, abv: null, rating_global: null,
+    normalized_name: normalizeName('Taking Shape'), normalized_brewery: normalizeBrewery('Track'),
+  });
+  return { db, id };
+}
+
+const row = (over: Partial<EnrichFailureRow> & { beer_id: number }): EnrichFailureRow => ({
+  brewery: 'Track', name: 'Taking Shape', search_url: 'https://untappd.com/search?q=Track+Taking+Shape&type=beer',
+  outcome: 'not_found', candidates_count: 0, candidates_summary: '', at: '2026-06-11T00:00:00Z', ...over,
+});
+
+describe('enrich_failures', () => {
+  test('record inserts a row', () => {
+    const { db, id } = freshDbWithBeer();
+    recordEnrichFailure(db, row({ beer_id: id }));
+    const got = db.prepare('SELECT * FROM enrich_failures WHERE beer_id = ?').get(id) as any;
+    expect(got).toMatchObject({ beer_id: id, outcome: 'not_found', candidates_count: 0, fail_count: 1 });
+  });
+
+  test('record upserts: bumps fail_count and refreshes fields', () => {
+    const { db, id } = freshDbWithBeer();
+    recordEnrichFailure(db, row({ beer_id: id, at: '2026-06-11T00:00:00Z' }));
+    recordEnrichFailure(db, row({ beer_id: id, outcome: 'blocked', candidates_count: 0, at: '2026-06-11T01:00:00Z' }));
+    const got = db.prepare('SELECT * FROM enrich_failures WHERE beer_id = ?').get(id) as any;
+    expect(got.fail_count).toBe(2);
+    expect(got.outcome).toBe('blocked');
+    expect(got.last_at).toBe('2026-06-11T01:00:00Z');
+  });
+
+  test('clear deletes the row', () => {
+    const { db, id } = freshDbWithBeer();
+    recordEnrichFailure(db, row({ beer_id: id }));
+    clearEnrichFailure(db, id);
+    expect(db.prepare('SELECT * FROM enrich_failures WHERE beer_id = ?').get(id)).toBeUndefined();
+  });
+
+  test('deleting the beer cascades to enrich_failures', () => {
+    const { db, id } = freshDbWithBeer();
+    recordEnrichFailure(db, row({ beer_id: id }));
+    db.prepare('DELETE FROM beers WHERE id = ?').run(id);
+    expect(db.prepare('SELECT * FROM enrich_failures WHERE beer_id = ?').get(id)).toBeUndefined();
+  });
+});

--- a/src/storage/enrich_failures.ts
+++ b/src/storage/enrich_failures.ts
@@ -1,0 +1,39 @@
+import type { DB } from './db';
+
+export interface EnrichFailureRow {
+  beer_id: number;
+  brewery: string;
+  name: string;
+  search_url: string;
+  outcome: 'not_found' | 'blocked';
+  candidates_count: number;
+  candidates_summary: string;
+  at: string; // ISO timestamp of this failure
+}
+
+// One row per failing beer. Upsert on beer_id: a repeat failure refreshes the
+// diagnostic fields and bumps fail_count. The row is cleared (clearEnrichFailure)
+// when the beer eventually matches, and CASCADE-deleted if the beer row is removed.
+export function recordEnrichFailure(db: DB, r: EnrichFailureRow): void {
+  db.prepare(
+    `INSERT INTO enrich_failures
+       (beer_id, brewery, name, search_url, outcome, candidates_count, candidates_summary, fail_count, last_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?)
+     ON CONFLICT(beer_id) DO UPDATE SET
+       brewery            = excluded.brewery,
+       name               = excluded.name,
+       search_url         = excluded.search_url,
+       outcome            = excluded.outcome,
+       candidates_count   = excluded.candidates_count,
+       candidates_summary = excluded.candidates_summary,
+       fail_count         = enrich_failures.fail_count + 1,
+       last_at            = excluded.last_at`,
+  ).run(
+    r.beer_id, r.brewery, r.name, r.search_url, r.outcome,
+    r.candidates_count, r.candidates_summary, r.at,
+  );
+}
+
+export function clearEnrichFailure(db: DB, beerId: number): void {
+  db.prepare('DELETE FROM enrich_failures WHERE beer_id = ?').run(beerId);
+}

--- a/src/storage/schema.test.ts
+++ b/src/storage/schema.test.ts
@@ -179,4 +179,18 @@ describe('schema migrations', () => {
     expect(cols.find((c) => c.name === 'sha256')?.notnull).toBe(1);
     expect(cols.find((c) => c.name === 'file_id')?.notnull).toBe(0);
   });
+
+  test('migration v10 creates enrich_failures table with beer_id PK', () => {
+    const db = openDb(':memory:');
+    migrate(db);
+    const cols = db.prepare('PRAGMA table_info(enrich_failures)').all() as { name: string; pk: number }[];
+    const names = cols.map((c) => c.name);
+    expect(names).toEqual(
+      expect.arrayContaining([
+        'beer_id', 'brewery', 'name', 'search_url', 'outcome',
+        'candidates_count', 'candidates_summary', 'fail_count', 'last_at',
+      ]),
+    );
+    expect(cols.find((c) => c.name === 'beer_id')?.pk).toBe(1);
+  });
 });

--- a/src/storage/schema.ts
+++ b/src/storage/schema.ts
@@ -160,6 +160,23 @@ const MIGRATIONS: ReadonlyArray<{ version: number; sql: string }> = [
       );
     `,
   },
+  {
+    version: 10,
+    sql: `
+      CREATE TABLE enrich_failures (
+        beer_id            INTEGER NOT NULL PRIMARY KEY
+                           REFERENCES beers(id) ON DELETE CASCADE,
+        brewery            TEXT NOT NULL,
+        name               TEXT NOT NULL,
+        search_url         TEXT NOT NULL,
+        outcome            TEXT NOT NULL CHECK (outcome IN ('not_found','blocked')),
+        candidates_count   INTEGER NOT NULL,
+        candidates_summary TEXT NOT NULL,
+        fail_count         INTEGER NOT NULL DEFAULT 1,
+        last_at            TEXT NOT NULL
+      );
+    `,
+  },
 ];
 
 export function migrate(db: DB): void {


### PR DESCRIPTION
## Summary
Adds debuggability for matching/enrichment failures so we stop hand-reproducing cases and attaching Untappd HTML to issues (#117, #124).

- **Migration v10** — `enrich_failures` table (one row per failing beer, `beer_id` PK → `beers` CASCADE).
- **`lookupBeer`** now returns diagnostics: `searchUrls` + parsed `candidates` on `not_found`, `searchUrl` on `blocked`.
- **`applyLookupOutcome`** (shared by the server cron *and* client-relay `/enrich/result`) upserts a failure row on `not_found`/`blocked` — input + `search_url` + top-3 candidate summary — and clears it on `matched`. `transient` is not logged; backoff is untouched (`blocked` writes only a debug row).
- Debug query: `SELECT … FROM enrich_failures ORDER BY last_at DESC` — `0` candidates = noisy query (e.g. #124 Track); `N` but `not_found` = brewery-gate/name-fuzzy rejected (visible in the summary). Untappd search is cookieless-reproducible, so `search_url` suffices.

Spec + design + plan committed.

## Test Plan
- [x] migration v10 (table + PK), idempotent
- [x] `enrich_failures` upsert/clear + CASCADE
- [x] `lookupBeer` returns diagnostics (not_found/blocked/zero-results)
- [x] `applyLookupOutcome` records not_found/blocked, clears on matched, skips transient
- [x] Full suite green (606), typecheck clean

## Out of scope
`/orphans` bot command (trivial on top of the table); logging `matched`/`transient`; storing HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)