### PR TITLE
fix(extension): parse BeerFreak brewery noise

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed BeerFreak parsing when product titles repeat a brewery suffix such as "Brewery", or when BeerFreak omits brand metadata for descriptor-led breweries like "Brouwerij ...".
+
 ## [0.5.2] - 2026-06-11
 
 - Fixed Bierloods22 product parsing for breweries whose name contains " - " (e.g. "Kykao - Handcrafted") — those beers now match instead of showing as unmatched.

--- a/extension/src/sites/beerfreak.test.ts
+++ b/extension/src/sites/beerfreak.test.ts
@@ -11,6 +11,29 @@ function withoutProductMetadata(source: string): string {
   return source.replace(PRODUCT_METADATA_RE, '');
 }
 
+function metadataCard(id: number, title: string): string {
+  return `
+    <div class="catalogCard j-catalog-card">
+      <div class="j-product-container" data-id="${id}"></div>
+      <a class="catalogCard-title">${title}</a>
+    </div>
+  `;
+}
+
+function docWithProducts(products: unknown[]): Document {
+  return new DOMParser().parseFromString(`
+    <div data-catalog-view-block="products">
+      ${metadataCard(1737, 'fallback title')}
+      ${metadataCard(10079, 'fallback title')}
+      ${metadataCard(10112, 'fallback title')}
+    </div>
+    <script>
+      products = ${JSON.stringify(products)},
+      ids = [];
+    </script>
+  `, 'text/html');
+}
+
 let cards: ReturnType<typeof beerfreak.parseCards>;
 beforeAll(() => {
   cards = beerfreak.parseCards(new DOMParser().parseFromString(html, 'text/html'));
@@ -34,6 +57,33 @@ describe('beerfreak adapter', () => {
       brewery: '',
       name: 'Popihn/Brasserie Cambier DIPA DDH - DOLCITA',
     });
+  });
+
+  it('removes brewery suffix noise that remains after brand prefix trimming', () => {
+    const parsed = beerfreak.parseCards(docWithProducts([
+      { id: 1737, brand_title: 'ДІДЬКО (Україна)', title: 'Дідько Brewery Double Trouble' },
+      { id: 10079, brand_title: 'TEN MEN (Україна)', title: 'Ten Men Brewery RUBIS' },
+    ]));
+
+    expect(parsed).toContainEqual(expect.objectContaining({
+      brewery: 'ДІДЬКО',
+      name: 'Double Trouble',
+    }));
+    expect(parsed).toContainEqual(expect.objectContaining({
+      brewery: 'TEN MEN',
+      name: 'RUBIS',
+    }));
+  });
+
+  it('extracts a brewery prefix from Beerfreak titles when metadata has no brand', () => {
+    const parsed = beerfreak.parseCards(docWithProducts([
+      { id: 10112, brand_title: null, title: 'Brouwerij De Dolle Brouwers Oerbier' },
+    ]));
+
+    expect(parsed).toContainEqual(expect.objectContaining({
+      brewery: 'Brouwerij De Dolle Brouwers',
+      name: 'Oerbier',
+    }));
   });
 
   it('falls back to card title text when embedded product metadata is absent', () => {

--- a/extension/src/sites/beerfreak.ts
+++ b/extension/src/sites/beerfreak.ts
@@ -9,6 +9,9 @@ interface ProductMeta {
   title: string;
 }
 
+const BREWERY_NOISE_PREFIX_RE = /^(?:brewery|brewing|browar|brouwerij|brasserie)\s+/i;
+const LEADING_BREWERY_DESCRIPTORS = new Set(['brouwerij', 'brasserie', 'browar', 'pivovar', 'birrificio', 'brauerei']);
+
 function text(el: Element | null): string {
   return el?.textContent?.replace(/\s+/g, ' ').trim() ?? '';
 }
@@ -27,7 +30,22 @@ function cleanName(rawTitle: string, brewery: string): string {
   const prefix = rawTitle.slice(0, b.length);
   if (prefix.toLowerCase() !== b.toLowerCase()) return rawTitle.trim();
 
-  return rawTitle.slice(b.length).trim() || rawTitle.trim();
+  return rawTitle.slice(b.length).trim().replace(BREWERY_NOISE_PREFIX_RE, '').trim() || rawTitle.trim();
+}
+
+function splitBrandlessTitle(rawTitle: string): { brewery: string; name: string } {
+  const title = rawTitle.replace(/\s+/g, ' ').trim();
+  const tokens = title.split(/\s+/).filter(Boolean);
+  const first = tokens[0]?.toLowerCase();
+
+  if (tokens.length >= 3 && first && LEADING_BREWERY_DESCRIPTORS.has(first)) {
+    return {
+      brewery: tokens.slice(0, -1).join(' '),
+      name: tokens[tokens.length - 1],
+    };
+  }
+
+  return { brewery: '', name: title };
 }
 
 function ownerDocument(root: ParentNode): Document | null {
@@ -67,8 +85,11 @@ export const beerfreak: SiteAdapter = {
       const rawTitle = product?.title ?? text(el.querySelector('.catalogCard-title a'));
       if (!rawTitle) continue;
 
-      const brewery = cleanBrewery(product?.brand_title ?? null);
-      const name = cleanName(rawTitle, brewery);
+      const parsed = product?.brand_title == null
+        ? splitBrandlessTitle(rawTitle)
+        : { brewery: cleanBrewery(product.brand_title), name: '' };
+      const brewery = parsed.brewery;
+      const name = parsed.name || cleanName(rawTitle, brewery);
       if (!name) continue;
       cards.push({ el, brewery, name });
     }


### PR DESCRIPTION
## Summary

BeerFreak products that already exist in Untappd no longer get stuck as orphan badges when BeerFreak repeats brewery descriptors in the title or omits brand metadata. The adapter now parses examples from `https://beerfreak.org/barleywine-strong-ale/` as clean brewery/name pairs: `ДІДЬКО / Double Trouble`, `TEN MEN / RUBIS`, and `Brouwerij De Dolle Brouwers / Oerbier`.

## Verification

- `npm test -- beerfreak`
- `npm test`
- `npm run typecheck`
- Live BeerFreak HTML parse for `/barleywine-strong-ale/` returned the three corrected brewery/name pairs above.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
