### PR TITLE
fix(extension): ignore BeerRepublic non-beer products

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fixed BeerFreak parsing when product titles repeat a brewery suffix such as "Brewery", or when BeerFreak omits brand metadata for descriptor-led breweries like "Brouwerij ...".
+- Fixed BeerRepublic parsing so mixed beer packs, vertical sets, surprise boxes, and advent calendars are ignored instead of being matched as individual beers.
 
 ## [0.5.2] - 2026-06-11
 

--- a/extension/src/sites/beerrepublic.test.ts
+++ b/extension/src/sites/beerrepublic.test.ts
@@ -13,6 +13,15 @@ function parseFixture() {
   return beerrepublic.parseCards(doc);
 }
 
+function product(title: string, vendor = 'Beer Republic'): string {
+  return `
+    <div class="product-item">
+      <span class="product-item__vendor">${vendor}</span>
+      <a class="product-item__title">${title}</a>
+    </div>
+  `;
+}
+
 let cards: ReturnType<typeof beerrepublic.parseCards>;
 beforeAll(() => { cards = parseFixture(); });
 
@@ -31,5 +40,19 @@ describe('beerrepublic adapter', () => {
 
   it('does not define waitForGrid (SSR)', () => {
     expect(beerrepublic.waitForGrid).toBeUndefined();
+  });
+
+  it('ignores non-beer pack and calendar products', () => {
+    const doc = new DOMParser().parseFromString(`
+      <section data-section-type="collection">
+        ${product('Limited Edition Anniversary Vertical Set', 'Firestone Walker')}
+        ${product("Firestone Walker Barrel Aged Brewer's Collective Brewery Pack", 'Firestone Walker')}
+        ${product('Surprise Box Barrel Aged Beers')}
+        ${product('Advent Calendar 2025 Green Edition')}
+        ${product('Mind Haze Galaxy Bender', 'Firestone Walker')}
+      </section>
+    `, 'text/html');
+
+    expect(beerrepublic.parseCards(doc).map((c) => c.name)).toEqual(['Mind Haze Galaxy Bender']);
   });
 });

--- a/extension/src/sites/beerrepublic.ts
+++ b/extension/src/sites/beerrepublic.ts
@@ -4,6 +4,10 @@ function text(el: Element | null): string {
   return el?.textContent?.trim() ?? '';
 }
 
+function isNonBeerProduct(name: string): boolean {
+  return /\b(vertical set|brewery pack|surprise box|advent calendar)\b/i.test(name);
+}
+
 export const beerrepublic: SiteAdapter = {
   id: 'beerrepublic',
   hostMatch: (url) => url.hostname === 'beerrepublic.eu' || url.hostname.endsWith('.beerrepublic.eu'),
@@ -14,6 +18,7 @@ export const beerrepublic: SiteAdapter = {
     for (const el of Array.from(root.querySelectorAll<HTMLElement>('.product-item'))) {
       const name = text(el.querySelector('.product-item__title'));
       if (!name) continue;
+      if (isNonBeerProduct(name)) continue;
       const brewery = text(el.querySelector('.product-item__vendor'));
       cards.push({ el, brewery, name });
     }


### PR DESCRIPTION
## Summary

BeerRepublic pack and calendar listings are no longer treated as individual beers, so the overlay will stop trying to match mixed product bundles such as vertical sets, brewery packs, surprise boxes, and advent calendars.

The filter is local to the BeerRepublic adapter and leaves normal product cards, including recommendation cards, eligible for matching.

## Test Plan

- `cd extension && npm test -- src/sites/beerrepublic.test.ts src/sites/conformance.test.ts`
- `cd extension && npm test`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
