### PR TITLE
feat(enrich): record shop page URL for orphan failures (source_url)

### DIFF
--- a/docs/debug-orphan-matching.md
+++ b/docs/debug-orphan-matching.md
@@ -8,7 +8,7 @@
 
 ```bash
 sqlite3 -readonly /var/lib/warsaw-beer-bot/bot.db \
-  "SELECT brewery, name, outcome, candidates_count, candidates_summary, search_url, fail_count, last_at
+  "SELECT brewery, name, outcome, candidates_count, candidates_summary, search_url, source_url, fail_count, last_at
    FROM enrich_failures ORDER BY last_at DESC LIMIT 30;"
 ```
 
@@ -59,6 +59,27 @@ sqlite3 -readonly /var/lib/warsaw-beer-bot/bot.db \
   `nameKeys` (#117): order-insensitive + `COLLAB_SEP`-split + brewery-dedup, потім
   fuzzy ≥ 0.85. Якщо валідний кандидат усе одно відсічений — дивись `nameKeys`/
   `nameTokensDiverge` у `matcher.ts` та Stage 2a/2b у `untappd-lookup.ts`.
+
+### `source_url` — сторінка магазину (тільки client-relay)
+
+`source_url` заповнюється лише коли провал прийшов через `/enrich/result`
+(розширення ретранслює пошук Untappd із browser-session'у користувача).
+Серверний крон пише `''` — при його провалах URL сторінки магазину невідомий.
+
+Коли `source_url != ''`, можна **відкрити сторінку магазину** і перевірити,
+чи правильно адаптер розпарсив пивоварню та назву. Це вирішує ключову дихотомію:
+- **Parser-баг** — адаптер прочитав назву/пивоварню криво; діагностується тільки
+  з реальною сторінкою магазину. Лагодити в `extension/src/sites/<shop>.ts`.
+- **Matcher-баг** — парсинг правильний, але brewery-gate або name-fuzzy відсік
+  валідного кандидата; діагностується з `brewery`/`name`/`candidates_summary`
+  без потреби у `source_url`. Лагодити в `src/domain/matcher.ts` / `untappd-lookup.ts`.
+
+```sql
+SELECT beer_id, brewery, name, source_url, candidates_count
+FROM enrich_failures
+WHERE outcome = 'not_found' AND source_url != ''
+ORDER BY fail_count DESC;
+```
 
 ## Крок 3. Відтворити (пошук Untappd публічний, без кукі)
 

--- a/docs/superpowers/plans/2026-06-11-extension-cache-popup.md
+++ b/docs/superpowers/plans/2026-06-11-extension-cache-popup.md
@@ -1,0 +1,560 @@
+# Extension cache-control popup (#3) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a browser-action popup with two buttons — "Refresh this page" (re-fetch badges for the beers on the open supported-shop tab) and "Clear all cache".
+
+**Architecture:** Cache keys are site-independent (`normalizeKey(brewery, name)`), so "per-site" is implemented as "refresh the open page". The popup messages the active tab's content script with `{type:'refresh-page'}`; the content script resets the visible cards (removes badge + seen marker — required because `renderBadge` is idempotent), drops their cache keys, and re-runs the overlay so badges refresh live. "Clear all" removes every `mc2:` key directly from the popup.
+
+**Tech Stack:** TypeScript, Chrome MV3 (manifest via `@crxjs/vite-plugin`), Vitest + jsdom.
+
+**Order:** PR #3 of the batch. Server-independent — can be built in parallel with #1/#2, but kept last by agreement.
+
+**Worktree:** Create via `superpowers:using-git-worktrees` (branches from `origin/main`; cherry-pick the doc commits if needed — `reference_worktree_docs_cherrypick`). All commands below run from `extension/`.
+
+---
+
+### Task 1: `clearKeys` + `clearAll` in the cache store
+
+**Files:**
+- Modify: `extension/src/cache/store.ts`
+- Test: `extension/src/cache/store.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `extension/src/cache/store.test.ts` (extend the import on line 2 to include `clearKeys, clearAll`):
+
+```typescript
+it('clearKeys removes only the given keys', async () => {
+  await setCached('a|x', sample);
+  await setCached('b|y', sample);
+  await clearKeys(['a|x']);
+  expect(await getCached('a|x')).toBeNull();
+  expect(await getCached('b|y')).toEqual(sample);
+});
+
+it('clearKeys is a no-op for an empty list', async () => {
+  await setCached('a|x', sample);
+  await clearKeys([]);
+  expect(await getCached('a|x')).toEqual(sample);
+});
+
+it('clearAll removes every cached entry', async () => {
+  await setCached('a|x', sample);
+  await setCached('b|y', sample);
+  await clearAll();
+  expect(await getCached('a|x')).toBeNull();
+  expect(await getCached('b|y')).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/cache/store.test.ts`
+Expected: FAIL (`clearKeys` / `clearAll` not exported).
+
+- [ ] **Step 3: Implement**
+
+Append to `extension/src/cache/store.ts`:
+
+```typescript
+export async function clearKeys(keys: string[]): Promise<void> {
+  if (keys.length === 0) return;
+  await chrome.storage.local.remove(keys.map((k) => PREFIX + k));
+}
+
+export async function clearAll(): Promise<void> {
+  const all = await chrome.storage.local.get();
+  const ours = Object.keys(all).filter((k) => k.startsWith(PREFIX));
+  if (ours.length > 0) await chrome.storage.local.remove(ours);
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/cache/store.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add extension/src/cache/store.ts extension/src/cache/store.test.ts
+git commit -m "feat(extension): clearKeys + clearAll cache helpers (#3)"
+```
+
+---
+
+### Task 2: `resetCard` in badge.ts
+
+**Files:**
+- Modify: `extension/src/content/badge.ts`
+- Test: `extension/src/content/badge.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `extension/src/content/badge.test.ts` (import `resetCard`, `BADGE_MARKER`, `markSeen`, `isSeen`, `renderBadge` as needed):
+
+```typescript
+it('resetCard removes the badge and the seen marker', () => {
+  const host = document.createElement('div');
+  renderBadge(host, { is_drunk: true, user_rating: 4, raw: { brewery: 'b', name: 'n' }, matched_beer: null });
+  markSeen(host);
+  expect(host.querySelector(`[${BADGE_MARKER}]`)).not.toBeNull();
+  expect(isSeen(host)).toBe(true);
+
+  resetCard(host);
+  expect(host.querySelector(`[${BADGE_MARKER}]`)).toBeNull();
+  expect(isSeen(host)).toBe(false);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/content/badge.test.ts -t resetCard`
+Expected: FAIL (`resetCard` not exported).
+
+- [ ] **Step 3: Implement**
+
+Add to `extension/src/content/badge.ts` (after `isSeen`):
+
+```typescript
+/** Undo the overlay's marks on a card so the next run re-processes it from scratch. */
+export function resetCard(el: HTMLElement): void {
+  el.querySelector(`[${BADGE_MARKER}]`)?.remove();
+  el.removeAttribute(SEEN_MARKER);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/content/badge.test.ts -t resetCard`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add extension/src/content/badge.ts extension/src/content/badge.test.ts
+git commit -m "feat(extension): resetCard to clear badge + seen marker (#3)"
+```
+
+---
+
+### Task 3: `refreshCards` — reset visible cards, return their keys
+
+**Files:**
+- Create: `extension/src/content/refresh.ts`
+- Test: `extension/src/content/refresh.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `extension/src/content/refresh.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { refreshCards } from './refresh';
+import { renderBadge, markSeen, isSeen, BADGE_MARKER } from './badge';
+import { normalizeKey } from '../shared/normalize';
+import type { SiteAdapter } from '../sites/types';
+
+function cardEl(): HTMLElement {
+  const el = document.createElement('div');
+  renderBadge(el, { is_drunk: true, user_rating: 4, raw: { brewery: 'x', name: 'y' }, matched_beer: null });
+  markSeen(el);
+  return el;
+}
+
+describe('refreshCards', () => {
+  it('resets every parsed card and returns its cache key', () => {
+    const a = cardEl();
+    const b = cardEl();
+    const adapter = {
+      id: 'fake',
+      hostMatch: () => true,
+      parseCards: () => [
+        { el: a, brewery: 'PINTA', name: 'Atak Chmielu' },
+        { el: b, brewery: 'Track', name: 'Sonoma' },
+      ],
+    } as unknown as SiteAdapter;
+
+    const keys = refreshCards(document, adapter);
+
+    expect(keys).toEqual([normalizeKey('PINTA', 'Atak Chmielu'), normalizeKey('Track', 'Sonoma')]);
+    expect(a.querySelector(`[${BADGE_MARKER}]`)).toBeNull();
+    expect(isSeen(a)).toBe(false);
+    expect(isSeen(b)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/content/refresh.test.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement**
+
+Create `extension/src/content/refresh.ts`:
+
+```typescript
+import { normalizeKey } from '../shared/normalize';
+import { resetCard } from './badge';
+import type { SiteAdapter } from '../sites/types';
+
+// Resets every parsed card on the page (removes badge + seen marker) and returns
+// the cache keys for those cards, so the caller can drop them from the cache before
+// re-running the overlay to fetch fresh results. Site-independent keys mean this is
+// the "refresh the open page" primitive behind the popup's per-site button.
+export function refreshCards(doc: Document, adapter: SiteAdapter): string[] {
+  const keys: string[] = [];
+  for (const card of adapter.parseCards(doc)) {
+    keys.push(normalizeKey(card.brewery, card.name));
+    resetCard(card.el);
+  }
+  return keys;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/content/refresh.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add extension/src/content/refresh.ts extension/src/content/refresh.test.ts
+git commit -m "feat(extension): refreshCards resets visible cards + returns keys (#3)"
+```
+
+---
+
+### Task 4: Content-script `refresh-page` message handler
+
+**Files:**
+- Modify: `extension/src/content/main.ts`
+- Test: covered by Task 3 (`refreshCards`) — the listener itself is thin glue; verify manually in Task 8.
+
+- [ ] **Step 1: Add imports**
+
+In `extension/src/content/main.ts`, add to the imports:
+
+```typescript
+import { runOverlay, startOverlay } from './index'; // adjust the existing line: keep startOverlay, add runOverlay
+import { refreshCards } from './refresh';
+import { clearKeys } from '../cache/store';
+```
+
+Note: `startOverlay` is defined in `main.ts` itself, and `runOverlay` is already imported from `./index` (see the existing top imports). Only add the `refreshCards` and `clearKeys` imports; ensure `runOverlay` stays imported.
+
+- [ ] **Step 2: Register the listener at the bottom**
+
+Replace the final two lines of `extension/src/content/main.ts`:
+
+```typescript
+const adapter = pickAdapter(new URL(window.location.href));
+if (adapter) startOverlay(document, adapter, sendMatch, undefined, enrichOrphans);
+```
+
+with:
+
+```typescript
+const adapter = pickAdapter(new URL(window.location.href));
+if (adapter) {
+  startOverlay(document, adapter, sendMatch, undefined, enrichOrphans);
+  // Popup → "Refresh this page": drop the visible cards' cache entries and re-run
+  // the overlay so badges reflect fresh server state without waiting out the TTL.
+  chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+    if ((message as { type?: unknown }).type !== 'refresh-page') return undefined;
+    void (async () => {
+      const keys = refreshCards(document, adapter);
+      await clearKeys(keys);
+      await runOverlay(document, adapter, sendMatch, enrichOrphans);
+      sendResponse({ ok: true, cleared: keys.length });
+    })();
+    return true; // keep the message channel open for the async sendResponse
+  });
+}
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add extension/src/content/main.ts
+git commit -m "feat(extension): content script handles refresh-page message (#3)"
+```
+
+---
+
+### Task 5: Popup decision helper + UI
+
+**Files:**
+- Create: `extension/src/popup/popup.ts`
+- Create: `extension/src/popup/popup.html`
+- Create: `extension/src/popup/popup.css`
+- Test: `extension/src/popup/popup.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `extension/src/popup/popup.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { canRefresh } from './popup';
+
+describe('canRefresh', () => {
+  it('true on a supported shop URL', () => {
+    expect(canRefresh('https://beerfreak.org/some/page')).toBe(true);
+    expect(canRefresh('https://winetime.com.ua/x')).toBe(true);
+  });
+  it('false on an unsupported URL', () => {
+    expect(canRefresh('https://example.com/')).toBe(false);
+  });
+  it('false on a malformed or empty URL', () => {
+    expect(canRefresh('not a url')).toBe(false);
+    expect(canRefresh('')).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/popup/popup.test.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement `popup.ts`**
+
+Create `extension/src/popup/popup.ts`:
+
+```typescript
+import { pickAdapter } from '../sites/registry';
+import { clearAll } from '../cache/store';
+
+// True when the URL belongs to a supported shop, so "Refresh this page" can act.
+export function canRefresh(url: string): boolean {
+  try {
+    return pickAdapter(new URL(url)) != null;
+  } catch {
+    return false;
+  }
+}
+
+function el<T extends HTMLElement>(id: string): T | null {
+  return document.getElementById(id) as T | null;
+}
+
+async function initPopup(): Promise<void> {
+  const refreshBtn = el<HTMLButtonElement>('refresh');
+  const clearBtn = el<HTMLButtonElement>('clearAll');
+  const status = el<HTMLElement>('status');
+  if (!refreshBtn || !clearBtn || !status) return;
+
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  const url = tab?.url ?? '';
+  refreshBtn.disabled = !canRefresh(url);
+  if (refreshBtn.disabled) status.textContent = 'Open a supported shop page to refresh it.';
+
+  refreshBtn.addEventListener('click', () => {
+    if (tab?.id == null) return;
+    status.textContent = 'Refreshing…';
+    chrome.tabs.sendMessage(tab.id, { type: 'refresh-page' }, (reply?: { cleared?: number }) => {
+      status.textContent = chrome.runtime.lastError
+        ? 'Could not reach the page — reload it and retry.'
+        : `Refreshed (${reply?.cleared ?? 0} cleared).`;
+    });
+  });
+
+  clearBtn.addEventListener('click', async () => {
+    await clearAll();
+    status.textContent = 'Cache cleared.';
+  });
+}
+
+if (typeof document !== 'undefined' && document.getElementById('refresh')) {
+  void initPopup();
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/popup/popup.test.ts`
+Expected: PASS (the `initPopup` guard is false under jsdom — no `#refresh` element — so `chrome.tabs` is never touched).
+
+- [ ] **Step 5: Create the HTML + CSS**
+
+Create `extension/src/popup/popup.html`:
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Warsaw Beer Overlay</title>
+    <link rel="stylesheet" href="./popup.css" />
+  </head>
+  <body>
+    <main class="card">
+      <h1>Warsaw Beer Overlay</h1>
+      <div class="row">
+        <button id="refresh" type="button">Refresh this page</button>
+        <button id="clearAll" type="button">Clear all cache</button>
+      </div>
+      <p id="status" class="status" aria-live="polite"></p>
+    </main>
+    <script type="module" src="./popup.ts"></script>
+  </body>
+</html>
+```
+
+Create `extension/src/popup/popup.css`:
+
+```css
+body { margin: 0; font: 14px/1.4 system-ui, sans-serif; }
+.card { min-width: 240px; padding: 12px; }
+h1 { font-size: 15px; margin: 0 0 8px; }
+.row { display: flex; flex-direction: column; gap: 8px; }
+button { padding: 8px; cursor: pointer; }
+button:disabled { cursor: default; opacity: 0.5; }
+.status { margin: 10px 0 0; color: #444; min-height: 1.2em; }
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add extension/src/popup/
+git commit -m "feat(extension): cache-control popup (refresh page / clear all) (#3)"
+```
+
+---
+
+### Task 6: Wire the popup + permissions into the manifest
+
+**Files:**
+- Modify: `extension/manifest.config.ts`
+- Test: `extension/src/manifest.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+In `extension/src/manifest.test.ts`, extend the `manifest` cast to include `action` and `permissions`:
+
+```typescript
+const manifest = manifestExport as {
+  version: string;
+  key: string;
+  permissions: string[];
+  action?: { default_popup?: string };
+  content_scripts: Array<{ matches: string[] }>;
+};
+```
+
+Add tests:
+
+```typescript
+it('exposes a popup action', () => {
+  expect(manifest.action?.default_popup).toBe('src/popup/popup.html');
+});
+
+it('requests activeTab + tabs permissions for the popup', () => {
+  expect(manifest.permissions).toContain('activeTab');
+  expect(manifest.permissions).toContain('tabs');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/manifest.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+In `extension/manifest.config.ts`, change the `permissions` line and add an `action` key:
+
+```typescript
+  permissions: ['storage', 'activeTab', 'tabs'],
+  host_permissions: ['https://beer-api.ysilvestrov-ai.uk/*'],
+  optional_host_permissions: ['https://*/*'],
+  action: { default_popup: 'src/popup/popup.html' },
+  options_page: 'src/options/options.html',
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/manifest.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add extension/manifest.config.ts extension/src/manifest.test.ts
+git commit -m "feat(extension): register popup action + activeTab/tabs permissions (#3)"
+```
+
+---
+
+### Task 7: Build + full extension suite
+
+**Files:** none (verification).
+
+- [ ] **Step 1: Full test + typecheck + build**
+
+Run (from `extension/`):
+```bash
+npx vitest run && npx tsc --noEmit && npm run build
+```
+Expected: all tests green, no type errors, build succeeds and emits `dist/manifest.json` containing `"action": { "default_popup": ... }`, `"permissions": ["storage","activeTab","tabs"]`, and a popup asset.
+
+- [ ] **Step 2: Confirm the built manifest**
+
+Run: `node -e "const m=require('./dist/manifest.json'); console.log(m.action, m.permissions)"`
+Expected: shows the popup action and the three permissions.
+
+---
+
+### Task 8: Manual verification in Chrome
+
+**Files:** none.
+
+- [ ] **Step 1: Load + smoke test**
+
+Load `extension/dist` as an unpacked extension. On a supported shop page (e.g. beerfreak.org): the toolbar icon opens the popup; "Refresh this page" is enabled, clears the page's cached entries and re-renders badges; on a non-shop tab the button is disabled with the hint. "Clear all cache" empties the cache (verify in DevTools → Application → Storage that `mc2:` keys are gone). The host page never breaks.
+
+---
+
+### Task 9: Version bump + release + spec.md
+
+**Files:**
+- Modify: `extension/package.json` (version)
+- Modify: `extension/CHANGELOG.md`
+- Modify (if needed): `spec.md`
+
+- [ ] **Step 1: Bump version + changelog**
+
+Bump `extension/package.json` `version` to `0.6.0` (new user-facing feature). Add a `CHANGELOG.md` entry: "0.6.0 — popup to refresh the current page's badges or clear the whole cache."
+
+- [ ] **Step 2: spec.md review**
+
+If `spec.md` documents the extension's UI surfaces / permissions, add the popup + `activeTab`/`tabs`. Otherwise note no change in the commit body.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add extension/package.json extension/CHANGELOG.md spec.md
+git commit -m "chore(extension): release 0.6.0 — cache-control popup (#3)"
+```
+
+- [ ] **Step 4: Release + broadcast (after merge)**
+
+Per `reference_extension_release_ops_gotchas`: run `npm run release` (build → DB row → stage zip), then forward the produced zip to the bot so it hash-matches and broadcasts 📣. (Note: the pending 0.5.2 broadcast in `project_shipped_2026_06` is separate — do not conflate.)
+
+---
+
+## Self-Review Checklist (run before opening the PR)
+
+- [ ] `cd extension && npx vitest run` green; `npx tsc --noEmit` clean; `npm run build` succeeds.
+- [ ] Built `dist/manifest.json` has the popup action + `activeTab`/`tabs`.
+- [ ] Manual smoke test (Task 8) done: refresh re-renders, clear-all empties, disabled state on non-shop tabs, host page never breaks.
+- [ ] Follow the PR review loop (`feedback_pr_review_loop`): open PR → wait for AI review → assess each comment.

--- a/docs/superpowers/plans/2026-06-11-orphan-review-admin-api.md
+++ b/docs/superpowers/plans/2026-06-11-orphan-review-admin-api.md
@@ -1,0 +1,523 @@
+# Orphan review classification + admin API (#2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let an agent mark an orphan `enrich_failures` row as triaged (with a classification + note) through an admin-authenticated API, so repeated triage passes skip already-reviewed rows; a recurring failure clears the mark.
+
+**Architecture:** Three nullable review columns on `enrich_failures`. `recordEnrichFailure` resets them on conflict (a recurring failure re-surfaces in triage). A new admin-only route `POST /admin/enrich-failures/review` (guarded by `ADMIN_API_TOKEN`, separate from the per-user Telegram auth) updates them. Agents keep reading the DB read-only and POST review marks via `curl`.
+
+**Tech Stack:** Node.js, TypeScript, better-sqlite3, Hono, Zod, `node:crypto` (constant-time compare), Jest.
+
+**Order:** This is PR #2 of the batch. **Land PR #1 (`source_url`) first** — this plan assumes migration version 11 (`source_url`) already exists and that `EnrichFailureRow` / `recordEnrichFailure` already carry `source_url`. If #1 is not yet merged, rebase after it lands and renumber this migration accordingly.
+
+> **Path note (deviation from spec):** The spec wrote `POST /enrich/failures/review`, but `app.use('/enrich/*', authMiddleware)` already guards every `/enrich/*` path with per-user Telegram auth. To use admin auth instead, this plan puts the endpoint under `/admin/*` (`POST /admin/enrich-failures/review`) so it gets the admin middleware, not the per-user one. Update `spec.md` to match (Task 6).
+
+**Worktree:** Create via `superpowers:using-git-worktrees` (branches from `origin/main`; cherry-pick the doc commits if needed — `reference_worktree_docs_cherrypick`).
+
+---
+
+### Task 1: Migration — add review columns to `enrich_failures`
+
+**Files:**
+- Modify: `src/storage/schema.ts` (append migration version 12)
+- Test: `src/storage/schema.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/storage/schema.test.ts`:
+
+```typescript
+test('enrich_failures has nullable review columns', () => {
+  const db = openDb(':memory:');
+  migrate(db);
+  const cols = db.prepare(`PRAGMA table_info(enrich_failures)`).all() as Array<{
+    name: string;
+    notnull: number;
+  }>;
+  for (const name of ['review_class', 'review_note', 'reviewed_at']) {
+    const col = cols.find((c) => c.name === name);
+    expect(col).toBeDefined();
+    expect(col!.notnull).toBe(0); // nullable
+  }
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest src/storage/schema.test.ts -t "review columns"`
+Expected: FAIL (columns undefined).
+
+- [ ] **Step 3: Add the migration**
+
+Append to the `MIGRATIONS` array in `src/storage/schema.ts` (after the `version: 11` object from PR #1):
+
+```typescript
+  {
+    version: 12,
+    sql: `
+      ALTER TABLE enrich_failures ADD COLUMN review_class TEXT
+        CHECK (review_class IN ('parser_bug','matcher_bug','not_on_untappd','wontfix'));
+      ALTER TABLE enrich_failures ADD COLUMN review_note TEXT;
+      ALTER TABLE enrich_failures ADD COLUMN reviewed_at TEXT;
+    `,
+  },
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx jest src/storage/schema.test.ts -t "review columns"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/storage/schema.ts src/storage/schema.test.ts
+git commit -m "feat(enrich): add review columns to enrich_failures (#2)"
+```
+
+---
+
+### Task 2: `recordEnrichFailure` resets review fields on conflict; add `setEnrichFailureReview`
+
+**Files:**
+- Modify: `src/storage/enrich_failures.ts`
+- Test: `src/storage/enrich_failures.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `src/storage/enrich_failures.test.ts` (import `setEnrichFailureReview` from the module):
+
+```typescript
+test('setEnrichFailureReview updates review fields and reports change', () => {
+  const { db, id } = freshDbWithBeer();
+  recordEnrichFailure(db, row({ beer_id: id }));
+  const ok = setEnrichFailureReview(db, id, 'parser_bug', 'name split wrong', '2026-06-11T02:00:00Z');
+  expect(ok).toBe(true);
+  const got = db.prepare('SELECT * FROM enrich_failures WHERE beer_id = ?').get(id) as any;
+  expect(got).toMatchObject({ review_class: 'parser_bug', review_note: 'name split wrong', reviewed_at: '2026-06-11T02:00:00Z' });
+});
+
+test('setEnrichFailureReview reports no change for an unknown beer', () => {
+  const { db } = freshDbWithBeer();
+  expect(setEnrichFailureReview(db, 99999, 'wontfix', null, '2026-06-11T02:00:00Z')).toBe(false);
+});
+
+test('a recurring failure clears a prior review', () => {
+  const { db, id } = freshDbWithBeer();
+  recordEnrichFailure(db, row({ beer_id: id }));
+  setEnrichFailureReview(db, id, 'matcher_bug', null, '2026-06-11T02:00:00Z');
+  recordEnrichFailure(db, row({ beer_id: id, at: '2026-06-11T03:00:00Z' })); // fails again
+  const got = db.prepare('SELECT * FROM enrich_failures WHERE beer_id = ?').get(id) as any;
+  expect(got.review_class).toBeNull();
+  expect(got.review_note).toBeNull();
+  expect(got.reviewed_at).toBeNull();
+  expect(got.fail_count).toBe(2);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx jest src/storage/enrich_failures.test.ts`
+Expected: FAIL (`setEnrichFailureReview` not exported; review not reset on conflict).
+
+- [ ] **Step 3: Implement — reset on conflict**
+
+In `src/storage/enrich_failures.ts`, add three reset lines to the `ON CONFLICT(beer_id) DO UPDATE SET` clause of `recordEnrichFailure` (after `last_at = excluded.last_at`):
+
+```typescript
+       last_at            = excluded.last_at,
+       review_class       = NULL,
+       review_note        = NULL,
+       reviewed_at        = NULL`,
+```
+
+- [ ] **Step 4: Implement — `setEnrichFailureReview`**
+
+Append to `src/storage/enrich_failures.ts`:
+
+```typescript
+export type ReviewClass = 'parser_bug' | 'matcher_bug' | 'not_on_untappd' | 'wontfix';
+
+// Marks an orphan failure as triaged. Returns false if no row exists for beerId
+// (e.g. the failure already cleared because the beer matched). A later recurring
+// failure resets these fields via recordEnrichFailure's ON CONFLICT clause.
+export function setEnrichFailureReview(
+  db: DB,
+  beerId: number,
+  reviewClass: ReviewClass,
+  note: string | null,
+  atIso: string,
+): boolean {
+  const info = db
+    .prepare(
+      `UPDATE enrich_failures
+         SET review_class = ?, review_note = ?, reviewed_at = ?
+       WHERE beer_id = ?`,
+    )
+    .run(reviewClass, note, atIso, beerId);
+  return info.changes > 0;
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npx jest src/storage/enrich_failures.test.ts`
+Expected: PASS (new + existing).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/storage/enrich_failures.ts src/storage/enrich_failures.test.ts
+git commit -m "feat(enrich): setEnrichFailureReview + reset review on recurring failure (#2)"
+```
+
+---
+
+### Task 3: `ADMIN_API_TOKEN` env var
+
+**Files:**
+- Modify: `src/config/env.ts`
+- Test: `src/config/env.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`src/config/env.test.ts` defines a `baseEnv` const inside `describe('loadEnv', ...)`. Add these two tests inside that same `describe` block (so `baseEnv` is in scope):
+
+```typescript
+it('ADMIN_API_TOKEN passes through when set', () => {
+  const env = loadEnv({ ...baseEnv, ADMIN_API_TOKEN: 'secret-token' });
+  expect(env.ADMIN_API_TOKEN).toBe('secret-token');
+});
+
+it('ADMIN_API_TOKEN is undefined when absent', () => {
+  const env = loadEnv(baseEnv);
+  expect(env.ADMIN_API_TOKEN).toBeUndefined();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest src/config/env.test.ts -t ADMIN_API_TOKEN`
+Expected: FAIL (property missing).
+
+- [ ] **Step 3: Implement**
+
+In `src/config/env.ts`, add to the `Schema` object (next to `ADMIN_TELEGRAM_ID`):
+
+```typescript
+  ADMIN_API_TOKEN: z.string().optional(),
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx jest src/config/env.test.ts -t ADMIN_API_TOKEN`
+Expected: PASS.
+
+- [ ] **Step 5: Document and commit**
+
+Add `ADMIN_API_TOKEN` to `.env.example` (if present) with a comment: `# admin token for POST /admin/* maintenance endpoints; unset = those endpoints return 503`.
+
+```bash
+git add src/config/env.ts src/config/env.test.ts .env.example
+git commit -m "feat(config): add optional ADMIN_API_TOKEN (#2)"
+```
+
+---
+
+### Task 4: Admin auth middleware
+
+**Files:**
+- Create: `src/api/middleware/admin.ts`
+- Test: `src/api/middleware/admin.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/api/middleware/admin.test.ts`:
+
+```typescript
+import { Hono } from 'hono';
+import type { Env } from '../../config/env';
+import type { ApiEnv } from '../types';
+import { adminMiddleware } from './admin';
+
+function appWith(token: string | undefined) {
+  const app = new Hono<ApiEnv>();
+  app.use('/admin/*', adminMiddleware({ ADMIN_API_TOKEN: token } as Env));
+  app.get('/admin/ping', (c) => c.json({ ok: true }));
+  return app;
+}
+
+const auth = (t: string) => ({ headers: { Authorization: `Bearer ${t}` } });
+
+describe('adminMiddleware', () => {
+  it('503 when ADMIN_API_TOKEN is unset', async () => {
+    const res = await appWith(undefined).request('/admin/ping');
+    expect(res.status).toBe(503);
+  });
+  it('401 with no/!bearer header', async () => {
+    const res = await appWith('secret').request('/admin/ping');
+    expect(res.status).toBe(401);
+  });
+  it('401 with a wrong token', async () => {
+    const res = await appWith('secret').request('/admin/ping', auth('nope'));
+    expect(res.status).toBe(401);
+  });
+  it('passes through with the correct token', async () => {
+    const res = await appWith('secret').request('/admin/ping', auth('secret'));
+    expect(res.status).toBe(200);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest src/api/middleware/admin.test.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement**
+
+Create `src/api/middleware/admin.ts`:
+
+```typescript
+import type { MiddlewareHandler } from 'hono';
+import { timingSafeEqual } from 'node:crypto';
+import type { Env } from '../../config/env';
+import type { ApiEnv } from '../types';
+
+// Constant-time string compare; length mismatch short-circuits to false (the
+// lengths themselves are not secret).
+function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  return ab.length === bb.length && timingSafeEqual(ab, bb);
+}
+
+// Bearer-token auth for /admin/* maintenance endpoints, gated on ADMIN_API_TOKEN.
+// Separate from the per-user Telegram-token authMiddleware: 503 when the token is
+// not configured (endpoint disabled), 401 on a missing/bad token.
+export function adminMiddleware(env: Env): MiddlewareHandler<ApiEnv> {
+  return async (c, next) => {
+    const expected = env.ADMIN_API_TOKEN;
+    if (!expected) return c.json({ error: 'admin disabled' }, 503);
+    const m = c.req.header('Authorization')?.match(/^Bearer (.+)$/);
+    if (!m || !safeEqual(m[1], expected)) return c.json({ error: 'unauthorized' }, 401);
+    await next();
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx jest src/api/middleware/admin.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/api/middleware/admin.ts src/api/middleware/admin.test.ts
+git commit -m "feat(api): admin Bearer-token middleware gated on ADMIN_API_TOKEN (#2)"
+```
+
+---
+
+### Task 5: `POST /admin/enrich-failures/review` route + wiring
+
+**Files:**
+- Create: `src/api/routes/admin.ts`
+- Modify: `src/api/index.ts` (wire middleware + route)
+- Test: `src/api/routes/admin.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/api/routes/admin.test.ts`:
+
+```typescript
+import { Hono } from 'hono';
+import pino from 'pino';
+import { openDb } from '../../storage/db';
+import { migrate } from '../../storage/schema';
+import { upsertBeer } from '../../storage/beers';
+import { normalizeName, normalizeBrewery } from '../../domain/normalize';
+import { recordEnrichFailure } from '../../storage/enrich_failures';
+import { adminMiddleware } from '../middleware/admin';
+import { adminRoute } from './admin';
+import type { ApiEnv } from '../types';
+import type { Env } from '../../config/env';
+
+function setup() {
+  const db = openDb(':memory:');
+  migrate(db);
+  const log = pino({ level: 'silent' });
+  const env = { ADMIN_API_TOKEN: 'secret' } as Env;
+  const app = new Hono<ApiEnv>();
+  app.use('/admin/*', adminMiddleware(env));
+  adminRoute(app, { db, env, log });
+  const id = upsertBeer(db, {
+    untappd_id: null, name: 'Taking Shape', brewery: 'Track', style: null, abv: null, rating_global: null,
+    normalized_name: normalizeName('Taking Shape'), normalized_brewery: normalizeBrewery('Track'),
+  });
+  recordEnrichFailure(db, {
+    beer_id: id, brewery: 'Track', name: 'Taking Shape',
+    search_url: 'u', source_url: '', outcome: 'not_found',
+    candidates_count: 0, candidates_summary: '', at: '2026-06-11T00:00:00Z',
+  });
+  return { db, app, id };
+}
+
+function review(app: Hono<ApiEnv>, body: unknown, token = 'secret') {
+  return app.request('/admin/enrich-failures/review', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /admin/enrich-failures/review', () => {
+  it('marks an existing failure as reviewed', async () => {
+    const { db, app, id } = setup();
+    const res = await review(app, { beer_id: id, review_class: 'parser_bug', note: 'split wrong' });
+    expect(res.status).toBe(200);
+    const got = db.prepare('SELECT * FROM enrich_failures WHERE beer_id = ?').get(id) as any;
+    expect(got.review_class).toBe('parser_bug');
+    expect(got.review_note).toBe('split wrong');
+  });
+
+  it('404 when no failure exists for beer_id', async () => {
+    const { app } = setup();
+    const res = await review(app, { beer_id: 99999, review_class: 'wontfix' });
+    expect(res.status).toBe(404);
+  });
+
+  it('400 on an invalid review_class', async () => {
+    const { app, id } = setup();
+    const res = await review(app, { beer_id: id, review_class: 'nonsense' });
+    expect(res.status).toBe(400);
+  });
+
+  it('401 with a bad admin token', async () => {
+    const { app, id } = setup();
+    const res = await review(app, { beer_id: id, review_class: 'wontfix' }, 'wrong');
+    expect(res.status).toBe(401);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest src/api/routes/admin.test.ts`
+Expected: FAIL (route module not found).
+
+- [ ] **Step 3: Implement the route**
+
+Create `src/api/routes/admin.ts`:
+
+```typescript
+import type { Hono } from 'hono';
+import { zValidator } from '@hono/zod-validator';
+import { z } from 'zod';
+import type { ApiDeps, ApiEnv } from '../types';
+import { setEnrichFailureReview } from '../../storage/enrich_failures';
+
+const ReviewBody = z.object({
+  beer_id: z.number().int().positive(),
+  review_class: z.enum(['parser_bug', 'matcher_bug', 'not_on_untappd', 'wontfix']),
+  note: z.string().optional(),
+});
+
+// Admin maintenance routes. Assumes adminMiddleware has already authenticated.
+export function adminRoute(app: Hono<ApiEnv>, deps: ApiDeps): void {
+  app.post('/admin/enrich-failures/review', zValidator('json', ReviewBody), (c) => {
+    const { beer_id, review_class, note } = c.req.valid('json');
+    const updated = setEnrichFailureReview(
+      deps.db, beer_id, review_class, note ?? null, new Date().toISOString(),
+    );
+    if (!updated) return c.json({ error: 'no failure for beer_id' }, 404);
+    return c.json({ status: 'reviewed', beer_id, review_class });
+  });
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx jest src/api/routes/admin.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Wire into the app**
+
+In `src/api/index.ts`, add imports and register the admin middleware + route. The `/admin/*` middleware must be registered before the route (mirroring the `/enrich/*` pattern):
+
+```typescript
+import { adminMiddleware } from './middleware/admin';
+import { adminRoute } from './routes/admin';
+```
+
+After the `enrichRoute(app, deps);` line:
+
+```typescript
+  app.use('/admin/*', adminMiddleware(deps.env));
+  adminRoute(app, deps);
+```
+
+- [ ] **Step 6: Run the full API suite**
+
+Run: `npx jest src/api`
+Expected: PASS (nothing else broken; `/admin/*` does not overlap `/match` or `/enrich/*`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/api/routes/admin.ts src/api/index.ts src/api/routes/admin.test.ts
+git commit -m "feat(api): POST /admin/enrich-failures/review (admin-gated) (#2)"
+```
+
+---
+
+### Task 6: Update the runbook + spec.md
+
+**Files:**
+- Modify: the orphan-failure runbook in `docs/` (find with `grep -rl enrich_failures docs/`)
+- Modify: `spec.md`
+
+- [ ] **Step 1: Document the triage workflow**
+
+In the runbook, add:
+- The triage read query should now exclude reviewed rows:
+  ```sql
+  SELECT beer_id, brewery, name, source_url, candidates_count, fail_count
+  FROM enrich_failures
+  WHERE review_class IS NULL
+  ORDER BY fail_count DESC;
+  ```
+- How to mark a row reviewed (admin token required):
+  ```bash
+  curl -fsS -X POST "$API_BASE/admin/enrich-failures/review" \
+    -H "Authorization: Bearer $ADMIN_API_TOKEN" \
+    -H 'Content-Type: application/json' \
+    -d '{"beer_id":123,"review_class":"parser_bug","note":"beerfreak split brewery into name"}'
+  ```
+- Note: a recurring failure clears the mark, re-surfacing the row.
+
+- [ ] **Step 2: Update spec.md**
+
+Add the `/admin/enrich-failures/review` endpoint and the `enrich_failures` review columns to `spec.md` (OpenSpec source of truth, per CLAUDE.md). Note the path differs from the original design (`/admin/*`, not `/enrich/*`) and why.
+
+- [ ] **Step 3: Full suite + typecheck**
+
+Run: `npx jest && npx tsc --noEmit`
+Expected: all green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs spec.md
+git commit -m "docs(enrich): triage workflow + admin review endpoint (#2)"
+```
+
+---
+
+## Self-Review Checklist (run before opening the PR)
+
+- [ ] `npx jest` green; `npx tsc --noEmit` clean.
+- [ ] PR #1 (`source_url`) is merged into the base this branch targets; migration is v12.
+- [ ] Deploy note: set `ADMIN_API_TOKEN` in the prod `.env` before agents use the endpoint (otherwise 503). See `reference_prod_deploy_and_db_ops` memory.
+- [ ] Follow the PR review loop (`feedback_pr_review_loop`): open PR → wait for AI review → assess each comment.

--- a/docs/superpowers/plans/2026-06-11-orphan-source-url.md
+++ b/docs/superpowers/plans/2026-06-11-orphan-source-url.md
@@ -1,0 +1,469 @@
+# Orphan source URL (#1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Store the shop page URL on each orphan's `enrich_failures` row so an agent can open the exact page and decide parser-bug vs matcher-bug.
+
+**Architecture:** Add a `source_url` column to `enrich_failures`. The page URL flows from the extension content script → background → `POST /enrich/result` body → `applyLookupOutcome` → `recordEnrichFailure`. The server cron path has no URL and passes `''`; the upsert never overwrites a known URL with an empty one.
+
+**Tech Stack:** Node.js, TypeScript, better-sqlite3, Hono, Zod, Jest (server); Vitest (extension).
+
+**Order:** This is PR #1 of the orphan-debug batch. Land it before PR #2 (review/admin API) — both edit `enrich_failures.ts` and `lookup-outcome.ts`.
+
+**Worktree:** Create via `superpowers:using-git-worktrees`. Note: EnterWorktree branches from `origin/main`; cherry-pick the spec/plan doc commits into the branch if they aren't on `origin/main` yet (see `reference_worktree_docs_cherrypick` memory).
+
+---
+
+### Task 1: Migration — add `source_url` to `enrich_failures`
+
+**Files:**
+- Modify: `src/storage/schema.ts` (append migration version 11)
+- Test: `src/storage/schema.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/storage/schema.test.ts`:
+
+```typescript
+test('enrich_failures has a source_url column defaulting to empty string', () => {
+  const db = openDb(':memory:');
+  migrate(db);
+  const cols = db.prepare(`PRAGMA table_info(enrich_failures)`).all() as Array<{
+    name: string;
+    dflt_value: string | null;
+    notnull: number;
+  }>;
+  const col = cols.find((c) => c.name === 'source_url');
+  expect(col).toBeDefined();
+  expect(col!.notnull).toBe(1);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest src/storage/schema.test.ts -t source_url`
+Expected: FAIL (`col` is undefined).
+
+- [ ] **Step 3: Add the migration**
+
+In `src/storage/schema.ts`, append a new entry to the `MIGRATIONS` array (after the `version: 10` object, before the closing `]`):
+
+```typescript
+  {
+    version: 11,
+    sql: `
+      ALTER TABLE enrich_failures ADD COLUMN source_url TEXT NOT NULL DEFAULT '';
+    `,
+  },
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx jest src/storage/schema.test.ts -t source_url`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/storage/schema.ts src/storage/schema.test.ts
+git commit -m "feat(enrich): add source_url column to enrich_failures (#1)"
+```
+
+---
+
+### Task 2: `recordEnrichFailure` writes `source_url` (no empty overwrite)
+
+**Files:**
+- Modify: `src/storage/enrich_failures.ts`
+- Test: `src/storage/enrich_failures.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `src/storage/enrich_failures.test.ts`, update the `row` helper to include `source_url` and add two tests. Change the helper:
+
+```typescript
+const row = (over: Partial<EnrichFailureRow> & { beer_id: number }): EnrichFailureRow => ({
+  brewery: 'Track', name: 'Taking Shape', search_url: 'https://untappd.com/search?q=Track+Taking+Shape&type=beer',
+  source_url: '', outcome: 'not_found', candidates_count: 0, candidates_summary: '', at: '2026-06-11T00:00:00Z', ...over,
+});
+```
+
+Add inside the `describe('enrich_failures', ...)` block:
+
+```typescript
+test('record stores source_url', () => {
+  const { db, id } = freshDbWithBeer();
+  recordEnrichFailure(db, row({ beer_id: id, source_url: 'https://beerfreak.org/p/x' }));
+  const got = db.prepare('SELECT source_url FROM enrich_failures WHERE beer_id = ?').get(id) as any;
+  expect(got.source_url).toBe('https://beerfreak.org/p/x');
+});
+
+test('upsert does not overwrite a known source_url with an empty one', () => {
+  const { db, id } = freshDbWithBeer();
+  recordEnrichFailure(db, row({ beer_id: id, source_url: 'https://beerfreak.org/p/x' }));
+  recordEnrichFailure(db, row({ beer_id: id, source_url: '' })); // cron re-fail, no URL
+  const got = db.prepare('SELECT source_url FROM enrich_failures WHERE beer_id = ?').get(id) as any;
+  expect(got.source_url).toBe('https://beerfreak.org/p/x');
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx jest src/storage/enrich_failures.test.ts`
+Expected: FAIL (TypeScript: `source_url` missing on `EnrichFailureRow`; runtime: column not written).
+
+- [ ] **Step 3: Implement**
+
+In `src/storage/enrich_failures.ts`, add `source_url` to the interface and the SQL:
+
+```typescript
+export interface EnrichFailureRow {
+  beer_id: number;
+  brewery: string;
+  name: string;
+  search_url: string;
+  source_url: string;
+  outcome: 'not_found' | 'blocked';
+  candidates_count: number;
+  candidates_summary: string;
+  at: string; // ISO timestamp of this failure
+}
+```
+
+Replace the `recordEnrichFailure` body's SQL and bindings:
+
+```typescript
+export function recordEnrichFailure(db: DB, r: EnrichFailureRow): void {
+  db.prepare(
+    `INSERT INTO enrich_failures
+       (beer_id, brewery, name, search_url, source_url, outcome, candidates_count, candidates_summary, fail_count, last_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, ?)
+     ON CONFLICT(beer_id) DO UPDATE SET
+       brewery            = excluded.brewery,
+       name               = excluded.name,
+       search_url         = excluded.search_url,
+       source_url         = CASE WHEN excluded.source_url != '' THEN excluded.source_url
+                                 ELSE enrich_failures.source_url END,
+       outcome            = excluded.outcome,
+       candidates_count   = excluded.candidates_count,
+       candidates_summary = excluded.candidates_summary,
+       fail_count         = enrich_failures.fail_count + 1,
+       last_at            = excluded.last_at`,
+  ).run(
+    r.beer_id, r.brewery, r.name, r.search_url, r.source_url, r.outcome,
+    r.candidates_count, r.candidates_summary, r.at,
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest src/storage/enrich_failures.test.ts`
+Expected: PASS (all tests, including the existing upsert/cascade ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/storage/enrich_failures.ts src/storage/enrich_failures.test.ts
+git commit -m "feat(enrich): record source_url, never overwrite known URL with empty (#1)"
+```
+
+---
+
+### Task 3: `applyLookupOutcome` threads `sourceUrl`
+
+**Files:**
+- Modify: `src/domain/lookup-outcome.ts`
+- Test: `src/domain/lookup-outcome.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/domain/lookup-outcome.test.ts` inside the `describe` block:
+
+```typescript
+test('not_found persists the supplied sourceUrl', () => {
+  const { db, id, log } = fresh();
+  const outcome: LookupOutcome = { kind: 'not_found', searchUrls: ['u'], candidates: [] };
+  applyLookupOutcome({ db, log }, id, outcome, '2026-06-11T00:00:00Z',
+    { ...input, sourceUrl: 'https://beerfreak.org/p/x' });
+  expect(failRow(db, id).source_url).toBe('https://beerfreak.org/p/x');
+});
+
+test('omitting sourceUrl stores empty string', () => {
+  const { db, id, log } = fresh();
+  const outcome: LookupOutcome = { kind: 'blocked', searchUrl: 'u' };
+  applyLookupOutcome({ db, log }, id, outcome, '2026-06-11T00:00:00Z', input);
+  expect(failRow(db, id).source_url).toBe('');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest src/domain/lookup-outcome.test.ts -t sourceUrl`
+Expected: FAIL (TypeScript: `sourceUrl` not on input type; runtime: column empty).
+
+- [ ] **Step 3: Implement**
+
+In `src/domain/lookup-outcome.ts`, widen the `input` param and pass `source_url` in both failure branches.
+
+Change the signature's `input` type:
+
+```typescript
+  input: { brewery: string; name: string; sourceUrl?: string },
+```
+
+In the `not_found` case, add `source_url` to the `recordEnrichFailure` object:
+
+```typescript
+      recordEnrichFailure(deps.db, {
+        beer_id: beerId,
+        brewery: input.brewery,
+        name: input.name,
+        search_url: outcome.searchUrls[0] ?? '',
+        source_url: input.sourceUrl ?? '',
+        outcome: 'not_found',
+        candidates_count: outcome.candidates.length,
+        candidates_summary: summarizeCandidates(outcome.candidates),
+        at: nowIso,
+      });
+```
+
+In the `blocked` case, likewise:
+
+```typescript
+      recordEnrichFailure(deps.db, {
+        beer_id: beerId,
+        brewery: input.brewery,
+        name: input.name,
+        search_url: outcome.searchUrl,
+        source_url: input.sourceUrl ?? '',
+        outcome: 'blocked',
+        candidates_count: 0,
+        candidates_summary: '',
+        at: nowIso,
+      });
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest src/domain/lookup-outcome.test.ts`
+Expected: PASS (new + existing tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/domain/lookup-outcome.ts src/domain/lookup-outcome.test.ts
+git commit -m "feat(enrich): thread sourceUrl through applyLookupOutcome (#1)"
+```
+
+---
+
+### Task 4: `POST /enrich/result` accepts `pageUrl`
+
+**Files:**
+- Modify: `src/api/routes/enrich.ts`
+- Test: `src/api/routes/enrich.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/api/routes/enrich.test.ts` inside `describe('POST /enrich/result', ...)`:
+
+```typescript
+it('stores the supplied pageUrl as the failure source_url', async () => {
+  const { db, app } = setup();
+  const html = searchHtml([{ bid: 9000, name: 'Totally Different', brewery: 'Other Brewery' }]);
+  await post(app, '/enrich/result', {
+    brewery: 'Magic Road Brewery',
+    name: 'Fifty/Fifty Clementine & Passionfruit',
+    html,
+    pageUrl: 'https://beerfreak.org/p/abc',
+  });
+  const row = findBeerByNormalized(
+    db, normalizeBrewery('Magic Road Brewery'), normalizeName('Fifty/Fifty Clementine & Passionfruit'),
+  )!;
+  const fail = db.prepare('SELECT source_url FROM enrich_failures WHERE beer_id = ?').get(row.id) as any;
+  expect(fail.source_url).toBe('https://beerfreak.org/p/abc');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest src/api/routes/enrich.test.ts -t pageUrl`
+Expected: FAIL (`pageUrl` ignored; `source_url` is `''`).
+
+- [ ] **Step 3: Implement**
+
+In `src/api/routes/enrich.ts`, add `pageUrl` to the `ResultBody` schema:
+
+```typescript
+const ResultBody = z.object({
+  brewery: z.string(),
+  name: z.string(),
+  html: z.string(),
+  pageUrl: z.string().optional(),
+});
+```
+
+In the `/enrich/result` handler, destructure `pageUrl` and pass it into `applyLookupOutcome`'s input:
+
+```typescript
+  app.post('/enrich/result', zValidator('json', ResultBody), async (c) => {
+    const { brewery, name, html, pageUrl } = c.req.valid('json');
+    const row = ensureBeerRow(deps.db, brewery, name);
+    if (row.untappd_id != null) {
+      return c.json({ status: 'skipped' });
+    }
+    const outcome = await lookupBeer({ brewery, name, abv: row.abv, fetch: async () => html });
+    const nowIso = new Date().toISOString();
+    const kind = applyLookupOutcome({ db: deps.db, log: deps.log }, row.id, outcome, nowIso,
+      { brewery, name, sourceUrl: pageUrl });
+    if (kind === 'matched' && outcome.kind === 'matched') {
+      return c.json({ status: 'matched', untappd_id: outcome.result.bid, rating_global: outcome.result.global_rating });
+    }
+    return c.json({ status: kind });
+  });
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest src/api/routes/enrich.test.ts`
+Expected: PASS (new + existing tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/api/routes/enrich.ts src/api/routes/enrich.test.ts
+git commit -m "feat(api): /enrich/result accepts pageUrl for orphan source tracking (#1)"
+```
+
+---
+
+### Task 5: Extension sends `window.location.href` as `pageUrl`
+
+**Files:**
+- Modify: `extension/src/api/client.ts` (`postEnrichResult` payload type)
+- Modify: `extension/src/background/index.ts` (`EnrichResultMessage` + `handleEnrichResult`)
+- Modify: `extension/src/content/main.ts` (submitResult closure)
+- Test: `extension/src/background/handle-enrich.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`handle-enrich.test.ts` stubs the global `fetch` (via `vi.stubGlobal`) rather than mocking `postEnrichResult`, so assert on the request body the handler sends. Add inside `describe('handleEnrichResult', ...)`:
+
+```typescript
+it('forwards pageUrl in the request body', async () => {
+  vi.stubGlobal('chrome', { storage: { local: { get: async () => ({ enrichEnabled: true, token: 't', baseUrl: 'https://api' }) } } });
+  const fetchMock = vi.fn(async () => new Response(JSON.stringify({ status: 'not_found' }), { status: 200 }));
+  vi.stubGlobal('fetch', fetchMock);
+  await handleEnrichResult({
+    type: 'enrich:result', brewery: 'B', name: 'N', html: '<x>', pageUrl: 'https://beerfreak.org/p/x',
+  });
+  const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+  expect(body.pageUrl).toBe('https://beerfreak.org/p/x');
+});
+```
+
+(`handleEnrichResult` is already imported at the top of the file.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd extension && npx vitest run src/background/handle-enrich.test.ts -t pageUrl`
+Expected: FAIL (TypeScript: `pageUrl` not on `EnrichResultMessage`; at runtime `body.pageUrl` is `undefined`).
+
+- [ ] **Step 3: Implement — client payload type**
+
+In `extension/src/api/client.ts`, widen the `postEnrichResult` payload type:
+
+```typescript
+export async function postEnrichResult(
+  baseUrl: string,
+  token: string,
+  payload: { brewery: string; name: string; html: string; pageUrl?: string },
+  timeoutMs: number = DEFAULT_TIMEOUT_MS,
+): Promise<EnrichResult> {
+```
+
+(The body already does `JSON.stringify(payload)`, so `pageUrl` is sent automatically.)
+
+- [ ] **Step 4: Implement — background message + handler**
+
+In `extension/src/background/index.ts`, add `pageUrl` to the message interface:
+
+```typescript
+export interface EnrichResultMessage { type: 'enrich:result'; brewery: string; name: string; html: string; pageUrl?: string }
+```
+
+And forward it in `handleEnrichResult`:
+
+```typescript
+    const result = await postEnrichResult(baseUrl, token, {
+      brewery: msg.brewery, name: msg.name, html: msg.html, pageUrl: msg.pageUrl,
+    });
+```
+
+- [ ] **Step 5: Implement — content script supplies the URL**
+
+In `extension/src/content/main.ts`, update the `submitResult` closure inside `enrichOrphans` to include the page URL in the background message:
+
+```typescript
+      submitResult: async (brewery, name, html) =>
+        (await sendBg<{ result: EnrichResult | null }>({
+          type: 'enrich:result', brewery, name, html, pageUrl: window.location.href,
+        }))?.result ?? { status: 'transient' },
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd extension && npx vitest run src/background/handle-enrich.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add extension/src/api/client.ts extension/src/background/index.ts extension/src/content/main.ts extension/src/background/handle-enrich.test.ts
+git commit -m "feat(extension): send page URL with enrich result for orphan source tracking (#1)"
+```
+
+---
+
+### Task 6: Update the orphan-failure runbook + spec.md review
+
+**Files:**
+- Modify: the orphan-failure runbook in `docs/` (the doc referenced by the `reference_orphan_failure_log` memory — find it with `grep -rl enrich_failures docs/`)
+- Modify (if needed): `spec.md`
+
+- [ ] **Step 1: Document `source_url`**
+
+In the runbook, add `source_url` to the documented `enrich_failures` columns and note: "populated only for client-relay (`/enrich/result`) failures; cron-only orphans have `''`. Use it to open the shop page and decide parser-bug vs matcher-bug." Add an example query, e.g.:
+
+```sql
+SELECT beer_id, brewery, name, source_url, candidates_count
+FROM enrich_failures
+WHERE outcome = 'not_found' AND source_url != ''
+ORDER BY fail_count DESC;
+```
+
+- [ ] **Step 2: Review spec.md**
+
+Open `spec.md`. If it documents the `enrich_failures` shape or the `/enrich/result` contract, add `source_url` / `pageUrl`. If it does not cover these, no change is needed — note that in the commit body.
+
+- [ ] **Step 3: Run the full server + extension suites**
+
+Run: `npx jest && cd extension && npx vitest run`
+Expected: all green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs spec.md
+git commit -m "docs(enrich): document source_url in orphan runbook (#1)"
+```
+
+---
+
+## Self-Review Checklist (run before opening the PR)
+
+- [ ] `npx jest` green; `cd extension && npx vitest run` green.
+- [ ] `npx tsc --noEmit` (root) and `cd extension && npx tsc --noEmit` clean.
+- [ ] Migration is additive only; no backfill needed.
+- [ ] Follow the PR review loop (`feedback_pr_review_loop` memory): open PR → wait for AI review → assess each comment.

--- a/docs/superpowers/specs/2026-06-11-orphan-debug-tooling-design.md
+++ b/docs/superpowers/specs/2026-06-11-orphan-debug-tooling-design.md
@@ -1,0 +1,140 @@
+# Orphan-debug tooling + extension cache control — design
+
+**Date:** 2026-06-11
+**Status:** Approved (brainstorming) — pending implementation plan
+
+## Problem
+
+Three maintenance gaps around the orphan-matching debug workflow and the extension:
+
+1. **No source URL for orphans.** When a beer ends up an orphan it can be either a
+   *parser* bug (adapter mis-read the page) or a *matcher* bug. The matcher case is
+   diagnosable from the data already in `enrich_failures` (brewery/name/candidates);
+   the parser case is **not** — you need the page the beer was scraped from. The shop
+   page URL is currently stored nowhere.
+2. **No way to mark an orphan failure as triaged.** Agents re-process the same
+   `enrich_failures` rows on every pass. There is no record that a row was already
+   looked at, why it was left unmatched, or whether the decision still holds.
+3. **No cache control in the extension.** Match results are cached 8h in
+   `chrome.storage.local`. There is no way to refresh badges on a page sooner.
+
+All three are one coherent "debug & maintenance" theme → one spec, but **three
+independent worktree branches / PRs**.
+
+## Background (current state)
+
+- Orphan beer rows (`beers.untappd_id IS NULL`) are created in the enrichment flow via
+  `ensureBeerRow` (`src/api/routes/enrich.ts`), called from `/enrich/candidates` and
+  `/enrich/result`. `/match` only *reads* the catalog.
+- `enrich_failures` (keyed on `beer_id`) is written in `applyLookupOutcome`
+  (`src/domain/lookup-outcome.ts`), reached from **two** paths:
+  - client relay `POST /enrich/result` — the extension knows the shop page URL here;
+  - server cron `enrich-orphans` (`enrichOneOrphan`) — page URL is **unknown** (the
+    orphan was created earlier).
+  The row self-clears (`clearEnrichFailure`) once the beer matches, and is
+  CASCADE-deleted if the beer row is removed.
+- Extension cache (`extension/src/cache/store.ts`): `chrome.storage.local`, prefix
+  `mc2:`, key = `normalizeKey(brewery, name)` — **site-independent**, 8h TTL.
+- Extension UI surfaces: `options_page` only, **no popup/action**. Content script runs
+  on the 5 supported shop hosts.
+
+### Key consequence for #3 (site-independent keys)
+
+Because the cache key has no site dimension, a fixed adapter parsing a name correctly
+produces a *different* key → automatic cache miss → fresh fetch. So per-site clearing is
+**not** needed for the "I fixed the adapter" case — stale entries simply expire. The real
+remaining need is: a beer just got matched/enriched server-side and the user wants to
+**refresh the badges on the open page now**, without waiting out the 8h TTL or nuking the
+whole cache. "Per-site" is therefore implemented as **"refresh the open page"**, not as
+true per-site key isolation.
+
+## Data model (shared)
+
+One new migration in `src/storage/schema.ts` adds four columns to `enrich_failures`:
+
+| column         | type                                   | notes                                  |
+|----------------|----------------------------------------|----------------------------------------|
+| `source_url`   | `TEXT NOT NULL DEFAULT ''`             | shop page URL (#1)                     |
+| `review_class` | `TEXT` (nullable)                      | CHECK ∈ {parser_bug, matcher_bug, not_on_untappd, wontfix} OR NULL (#2) |
+| `review_note`  | `TEXT` (nullable)                      | free-text triage note (#2)             |
+| `reviewed_at`  | `TEXT` (nullable)                      | ISO timestamp of the review (#2)       |
+
+Bump the migration version; the migration is additive (new nullable / defaulted columns),
+no backfill.
+
+## #1 — Page URL for orphans
+
+- `EnrichFailureRow` (`src/storage/enrich_failures.ts`) gains `source_url: string`.
+- `recordEnrichFailure` writes `source_url` on INSERT and, on `ON CONFLICT(beer_id)`,
+  **does not overwrite a known URL with an empty one**:
+  `source_url = CASE WHEN excluded.source_url != '' THEN excluded.source_url
+                     ELSE enrich_failures.source_url END`.
+  (Protects the URL captured by `/enrich/result` from being wiped by a later cron
+  re-fail that has no URL.)
+- `applyLookupOutcome` `input` param gains `sourceUrl?: string` (default `''`); passed to
+  `recordEnrichFailure` for both `not_found` and `blocked` outcomes.
+- `POST /enrich/result` body gains `pageUrl: z.string().optional()`; threaded into the
+  `applyLookupOutcome` `input`.
+- Server cron (`enrichOneOrphan`) passes `''` (URL unknown).
+- **Limitation (accepted):** `source_url` is populated only when an opt-in user's
+  `/enrich/result` fails — which is exactly the adapter-relevant case. Cron-only orphans
+  keep `''`.
+- Extension: `submitResult(brewery, name, html, pageUrl)` →
+  `postEnrichResult(..., pageUrl)` sends `pageUrl`; `main.ts` supplies
+  `window.location.href`.
+
+## #2 — Orphan review classification + admin API
+
+- `recordEnrichFailure` `ON CONFLICT` also **resets** the review fields
+  (`review_class = NULL, review_note = NULL, reviewed_at = NULL`) so a recurring failure
+  re-surfaces in triage. Fresh INSERT leaves them NULL.
+- New storage fn `setEnrichFailureReview(db, beerId, reviewClass, note, atIso)` — updates
+  the three review columns for the row; returns whether a row was updated.
+- New route `POST /enrich/failures/review`, body
+  `{ beer_id: number, review_class: <enum>, note?: string }`:
+  - **404** if no `enrich_failures` row exists for `beer_id` (cannot review a
+    non-existent / already-cleared failure).
+  - **200** with the stored review on success.
+- **Admin auth:** new env var `ADMIN_API_TOKEN`. A dedicated admin middleware does a
+  constant-time compare of the request token (header) against it. If `ADMIN_API_TOKEN` is
+  unset the route returns **503** (disabled). This is separate from the existing per-user
+  Telegram-token auth.
+- Agents continue to read `enrich_failures` **read-only** (now with `source_url` + review
+  columns), filtering `WHERE review_class IS NULL` to skip triaged rows, and POST review
+  marks via `curl` with the admin token. Update the orphan-failure runbook in `docs/`.
+- **Why an API (not direct DB write / CLI):** dev host == prod host; the bot process owns
+  the open SQLite DB; `sudo -u warsaw-beer-bot` does not work and direct file writes risk
+  lock/permission problems. Routing the write through the bot's own process avoids all of
+  that.
+
+## #3 — Extension popup for cache control
+
+- `manifest`: add `"action": { "default_popup": "src/popup/popup.html" }` and permissions
+  `activeTab`, `tabs` (query + message the active tab; host permission for the 5 shop
+  hosts already exists).
+- `src/popup/popup.html` + `popup.ts`:
+  - **"Refresh this page"** — queries the active tab; if its URL matches a supported site
+    adapter, sends `{ type: 'refresh-page' }` to that tab's content script; otherwise the
+    button is disabled with a hint.
+  - **"Clear all cache"** — removes all `mc2:` keys directly from the popup.
+- `cache/store.ts`: add `clearAll()` and `clearKeys(keys: string[])`.
+- Content script (`main.ts`): register a `chrome.runtime.onMessage` listener for
+  `refresh-page` → re-parse the current cards, delete their cache keys (`clearKeys`), and
+  re-run `runOverlay` via the existing re-render path (`content/rerender.ts`) so badges
+  update live.
+
+## Testing
+
+- **Storage:** upsert preserves a known `source_url` against an empty one; conflict resets
+  review fields; `setEnrichFailureReview` updates / reports no-op.
+- **Route:** admin middleware (401 bad token, 503 when unset, pass-through on match);
+  review endpoint (404 unknown beer, 200 happy path); `/enrich/result` stores `pageUrl`.
+- **Extension:** `clearAll` / `clearKeys`; popup button enable/disable + messaging logic;
+  content-script `refresh-page` handler clears keys and re-renders.
+
+## Rollout
+
+- Three worktree branches / PRs (one per feature), shared design doc.
+- Extension version bump + release / broadcast per the release-ops process.
+- **spec.md:** review whether the OpenSpec `spec.md` needs the new endpoint and the
+  `enrich_failures` columns documented; if so, update it in the same PR (per CLAUDE.md).

--- a/extension/src/api/client.ts
+++ b/extension/src/api/client.ts
@@ -71,7 +71,7 @@ export async function postEnrichCandidates(
 export async function postEnrichResult(
   baseUrl: string,
   token: string,
-  payload: { brewery: string; name: string; html: string },
+  payload: { brewery: string; name: string; html: string; pageUrl?: string },
   timeoutMs: number = DEFAULT_TIMEOUT_MS,
 ): Promise<EnrichResult> {
   let res: Response;

--- a/extension/src/background/handle-enrich.test.ts
+++ b/extension/src/background/handle-enrich.test.ts
@@ -75,4 +75,15 @@ describe('handleEnrichResult', () => {
     const out = await handleEnrichResult({ type: 'enrich:result', brewery: 'B', name: 'N', html: '<x>' });
     expect(out.result).toMatchObject({ status: 'matched', untappd_id: 5001 });
   });
+
+  it('forwards pageUrl in the request body', async () => {
+    vi.stubGlobal('chrome', { storage: { local: { get: async () => ({ enrichEnabled: true, token: 't', baseUrl: 'https://api' }) } } });
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ status: 'not_found' }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    await handleEnrichResult({
+      type: 'enrich:result', brewery: 'B', name: 'N', html: '<x>', pageUrl: 'https://beerfreak.org/p/x',
+    });
+    const body = JSON.parse(((fetchMock.mock.calls[0] as unknown[])[1] as RequestInit).body as string);
+    expect(body.pageUrl).toBe('https://beerfreak.org/p/x');
+  });
 });

--- a/extension/src/background/handle-enrich.test.ts
+++ b/extension/src/background/handle-enrich.test.ts
@@ -78,12 +78,14 @@ describe('handleEnrichResult', () => {
 
   it('forwards pageUrl in the request body', async () => {
     vi.stubGlobal('chrome', { storage: { local: { get: async () => ({ enrichEnabled: true, token: 't', baseUrl: 'https://api' }) } } });
-    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ status: 'not_found' }), { status: 200 }));
+    const fetchMock = vi.fn(
+      async (_url: string, _init?: RequestInit) => new Response(JSON.stringify({ status: 'not_found' }), { status: 200 }),
+    );
     vi.stubGlobal('fetch', fetchMock);
     await handleEnrichResult({
       type: 'enrich:result', brewery: 'B', name: 'N', html: '<x>', pageUrl: 'https://beerfreak.org/p/x',
     });
-    const body = JSON.parse(((fetchMock.mock.calls[0] as unknown[])[1] as RequestInit).body as string);
+    const body = JSON.parse(fetchMock.mock.calls[0][1]!.body as string);
     expect(body.pageUrl).toBe('https://beerfreak.org/p/x');
   });
 });

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -36,7 +36,7 @@ export async function handleMatch(msg: MatchMessage): Promise<MatchReply> {
 
 export interface EnrichFetchMessage { type: 'enrich:fetch'; url: string }
 export interface EnrichCandidatesMessage { type: 'enrich:candidates'; beers: { brewery: string; name: string }[] }
-export interface EnrichResultMessage { type: 'enrich:result'; brewery: string; name: string; html: string }
+export interface EnrichResultMessage { type: 'enrich:result'; brewery: string; name: string; html: string; pageUrl?: string }
 
 const UNTAPPD_ORIGIN = 'https://untappd.com/*';
 
@@ -77,7 +77,7 @@ export async function handleEnrichResult(
   const { token, baseUrl, enrichEnabled } = await getSettings();
   if (!enrichEnabled || !token) return { type: 'enrich:result:ok', result: null };
   try {
-    const result = await postEnrichResult(baseUrl, token, { brewery: msg.brewery, name: msg.name, html: msg.html });
+    const result = await postEnrichResult(baseUrl, token, { brewery: msg.brewery, name: msg.name, html: msg.html, pageUrl: msg.pageUrl });
     return { type: 'enrich:result:ok', result };
   } catch {
     return { type: 'enrich:result:ok', result: null };

--- a/extension/src/content/main.ts
+++ b/extension/src/content/main.ts
@@ -41,7 +41,7 @@ const enrichOrphans: EnrichOrphans = (orphans) => {
         (await sendBg<{ html: string | null }>({ type: 'enrich:fetch', url }))?.html ?? null,
       trim: trimSearchHtml,
       submitResult: async (brewery, name, html) =>
-        (await sendBg<{ result: EnrichResult | null }>({ type: 'enrich:result', brewery, name, html }))?.result ??
+        (await sendBg<{ result: EnrichResult | null }>({ type: 'enrich:result', brewery, name, html, pageUrl: window.location.href }))?.result ??
         { status: 'transient' },
       setSearching: (key) => { const el = elByKey.get(key); if (el) setSearching(el); },
       setEnriched: (key, id, r) => { const el = elByKey.get(key); if (el) setEnriched(el, id, r); },

--- a/spec.md
+++ b/spec.md
@@ -340,11 +340,15 @@ src/
 | `candidates_summary` | TEXT | NOT NULL | топ-3 `"<brewery> — <name>"`, `;`-joined (порожньо для blocked) |
 | `fail_count` | INTEGER | NOT NULL DEFAULT 1 | скільки разів провалився (++ на upsert) |
 | `last_at` | TEXT | NOT NULL | час останнього провалу (ISO) |
+| `source_url` | TEXT | NOT NULL DEFAULT '' | URL сторінки магазину, з якої прийшла ця пара brewery/name; заповнюється лише client-relay (`/enrich/result` з `pageUrl`); серверний крон пише `''` (URL невідомий) |
 
 **Хто що пише:** `applyLookupOutcome` (спільний для серверного крона і client-relay)
 upsert'ить рядок на `not_found`/`blocked` і **видаляє** його на `matched`. Один рядок на
 пиво (upsert по `beer_id`), розмір обмежений поточним набором orphan'ів. Untappd-пошук
-відтворюваний без кукі, тож `search_url` достатньо для дебагу. Запит:
+відтворюваний без кукі, тож `search_url` достатньо для дебагу. `source_url` (URL
+сторінки магазину) дозволяє відкрити першоджерело і перевірити, чи parser-баг
+(адаптер прочитав назву/пивоварню криво) чи matcher-баг; заповнюється лише
+client-relay (`/enrich/result`), серверний крон пише `''`. Запит:
 `SELECT … FROM enrich_failures ORDER BY last_at DESC` — «0 кандидатів» = зашумлений запит;
 «N, але not_found» = brewery-gate / name-fuzzy відсік (видно по `candidates_summary`).
 Покроковий дебаг-ранбук: `docs/debug-orphan-matching.md`.
@@ -555,7 +559,7 @@ fuzzy-матч дає `matched_beer` (тобто глобальний рейти
 Auth like `/match`. `/enrich/candidates` приймає `{beers:[{brewery,name}]}`, апсертить
 кожне нове пиво як orphan (`untappd_id` NULL) і повертає `{candidates:[{brewery,name,
 eligible,searchUrl}]}`, де `eligible` = backoff-due (`isEligible`) і пиво ще orphan.
-`/enrich/result` приймає `{brewery,name,html}` (обрізана клієнтом сторінка Untappd-пошуку),
+`/enrich/result` приймає `{brewery,name,html,pageUrl?}` (обрізана клієнтом сторінка Untappd-пошуку; `pageUrl` — опційна URL сторінки магазину, зберігається як `source_url` в `enrich_failures`),
 проганяє наявний `lookupBeer` з `fetch=()=>html` і застосовує спільний `applyLookupOutcome`:
 matched → `recordLookupSuccess` (bid+рейтинг; UNIQUE-клеш → merge у канонічний рядок),
 not_found → `recordLookupNotFound` (backoff++), blocked → НІЧОГО не пише в backoff (блок

--- a/src/api/routes/enrich.test.ts
+++ b/src/api/routes/enrich.test.ts
@@ -156,6 +156,22 @@ describe('POST /enrich/result', () => {
     expect(getBeer(db, row.id)!.untappd_lookup_count).toBe(1);
   });
 
+  it('stores the supplied pageUrl as the failure source_url', async () => {
+    const { db, app } = setup();
+    const html = searchHtml([{ bid: 9000, name: 'Totally Different', brewery: 'Other Brewery' }]);
+    await post(app, '/enrich/result', {
+      brewery: 'Magic Road Brewery',
+      name: 'Fifty/Fifty Clementine & Passionfruit',
+      html,
+      pageUrl: 'https://beerfreak.org/p/abc',
+    });
+    const row = findBeerByNormalized(
+      db, normalizeBrewery('Magic Road Brewery'), normalizeName('Fifty/Fifty Clementine & Passionfruit'),
+    )!;
+    const fail = db.prepare('SELECT source_url FROM enrich_failures WHERE beer_id = ?').get(row.id) as any;
+    expect(fail.source_url).toBe('https://beerfreak.org/p/abc');
+  });
+
   it('reports blocked without mutating backoff when Untappd serves a block page', async () => {
     const { db, app } = setup();
     // Cloudflare "Just a moment..." interstitial — isBlockPage flags this.

--- a/src/api/routes/enrich.ts
+++ b/src/api/routes/enrich.ts
@@ -74,6 +74,7 @@ export function enrichRoute(app: Hono<ApiEnv>, deps: ApiDeps): void {
     // injected fetch just returns the relayed HTML regardless of URL.
     const outcome = await lookupBeer({ brewery, name, abv: row.abv, fetch: async () => html });
     const nowIso = new Date().toISOString();
+    // pageUrl (the shop page the beer was scraped from) becomes the failure row's sourceUrl.
     const kind = applyLookupOutcome({ db: deps.db, log: deps.log }, row.id, outcome, nowIso, { brewery, name, sourceUrl: pageUrl });
     if (kind === 'matched' && outcome.kind === 'matched') {
       return c.json({ status: 'matched', untappd_id: outcome.result.bid, rating_global: outcome.result.global_rating });

--- a/src/api/routes/enrich.ts
+++ b/src/api/routes/enrich.ts
@@ -24,6 +24,7 @@ const ResultBody = z.object({
   brewery: z.string(),
   name: z.string(),
   html: z.string(),
+  pageUrl: z.string().optional(),
 });
 
 // Ensures a beer row exists for (brewery, name) and returns it.
@@ -62,7 +63,7 @@ export function enrichRoute(app: Hono<ApiEnv>, deps: ApiDeps): void {
   });
 
   app.post('/enrich/result', zValidator('json', ResultBody), async (c) => {
-    const { brewery, name, html } = c.req.valid('json');
+    const { brewery, name, html, pageUrl } = c.req.valid('json');
     const row = ensureBeerRow(deps.db, brewery, name);
     // Only orphans are enrichable. Never overwrite / merge a canonical (already
     // matched) row from client-relayed input.
@@ -73,7 +74,7 @@ export function enrichRoute(app: Hono<ApiEnv>, deps: ApiDeps): void {
     // injected fetch just returns the relayed HTML regardless of URL.
     const outcome = await lookupBeer({ brewery, name, abv: row.abv, fetch: async () => html });
     const nowIso = new Date().toISOString();
-    const kind = applyLookupOutcome({ db: deps.db, log: deps.log }, row.id, outcome, nowIso, { brewery, name });
+    const kind = applyLookupOutcome({ db: deps.db, log: deps.log }, row.id, outcome, nowIso, { brewery, name, sourceUrl: pageUrl });
     if (kind === 'matched' && outcome.kind === 'matched') {
       return c.json({ status: 'matched', untappd_id: outcome.result.bid, rating_global: outcome.result.global_rating });
     }

--- a/src/domain/lookup-outcome.test.ts
+++ b/src/domain/lookup-outcome.test.ts
@@ -71,6 +71,14 @@ describe('applyLookupOutcome failure logging', () => {
     expect(failRow(db, id).source_url).toBe('https://beerfreak.org/p/x');
   });
 
+  test('blocked persists the supplied sourceUrl', () => {
+    const { db, id, log } = fresh();
+    const outcome: LookupOutcome = { kind: 'blocked', searchUrl: 'u' };
+    applyLookupOutcome({ db, log }, id, outcome, '2026-06-11T00:00:00Z',
+      { ...input, sourceUrl: 'https://beerfreak.org/p/x' });
+    expect(failRow(db, id).source_url).toBe('https://beerfreak.org/p/x');
+  });
+
   test('omitting sourceUrl stores empty string', () => {
     const { db, id, log } = fresh();
     const outcome: LookupOutcome = { kind: 'blocked', searchUrl: 'u' };

--- a/src/domain/lookup-outcome.test.ts
+++ b/src/domain/lookup-outcome.test.ts
@@ -62,4 +62,19 @@ describe('applyLookupOutcome failure logging', () => {
       { kind: 'transient', error: new Error('x') }, '2026-06-11T00:00:00Z', input);
     expect(failRow(db, id)).toBeUndefined();
   });
+
+  test('not_found persists the supplied sourceUrl', () => {
+    const { db, id, log } = fresh();
+    const outcome: LookupOutcome = { kind: 'not_found', searchUrls: ['u'], candidates: [] };
+    applyLookupOutcome({ db, log }, id, outcome, '2026-06-11T00:00:00Z',
+      { ...input, sourceUrl: 'https://beerfreak.org/p/x' });
+    expect(failRow(db, id).source_url).toBe('https://beerfreak.org/p/x');
+  });
+
+  test('omitting sourceUrl stores empty string', () => {
+    const { db, id, log } = fresh();
+    const outcome: LookupOutcome = { kind: 'blocked', searchUrl: 'u' };
+    applyLookupOutcome({ db, log }, id, outcome, '2026-06-11T00:00:00Z', input);
+    expect(failRow(db, id).source_url).toBe('');
+  });
 });

--- a/src/domain/lookup-outcome.ts
+++ b/src/domain/lookup-outcome.ts
@@ -27,7 +27,7 @@ export function applyLookupOutcome(
   beerId: number,
   outcome: LookupOutcome,
   nowIso: string,
-  input: { brewery: string; name: string },
+  input: { brewery: string; name: string; sourceUrl?: string },
 ): EnrichOutcomeKind {
   switch (outcome.kind) {
     case 'matched':
@@ -57,6 +57,7 @@ export function applyLookupOutcome(
         brewery: input.brewery,
         name: input.name,
         search_url: outcome.searchUrls[0] ?? '',
+        source_url: input.sourceUrl ?? '',
         outcome: 'not_found',
         candidates_count: outcome.candidates.length,
         candidates_summary: summarizeCandidates(outcome.candidates),
@@ -74,6 +75,7 @@ export function applyLookupOutcome(
         brewery: input.brewery,
         name: input.name,
         search_url: outcome.searchUrl,
+        source_url: input.sourceUrl ?? '',
         outcome: 'blocked',
         candidates_count: 0,
         candidates_summary: '',

--- a/src/storage/enrich_failures.test.ts
+++ b/src/storage/enrich_failures.test.ts
@@ -16,7 +16,7 @@ function freshDbWithBeer() {
 
 const row = (over: Partial<EnrichFailureRow> & { beer_id: number }): EnrichFailureRow => ({
   brewery: 'Track', name: 'Taking Shape', search_url: 'https://untappd.com/search?q=Track+Taking+Shape&type=beer',
-  outcome: 'not_found', candidates_count: 0, candidates_summary: '', at: '2026-06-11T00:00:00Z', ...over,
+  source_url: '', outcome: 'not_found', candidates_count: 0, candidates_summary: '', at: '2026-06-11T00:00:00Z', ...over,
 });
 
 describe('enrich_failures', () => {
@@ -49,5 +49,20 @@ describe('enrich_failures', () => {
     recordEnrichFailure(db, row({ beer_id: id }));
     db.prepare('DELETE FROM beers WHERE id = ?').run(id);
     expect(db.prepare('SELECT * FROM enrich_failures WHERE beer_id = ?').get(id)).toBeUndefined();
+  });
+
+  test('record stores source_url', () => {
+    const { db, id } = freshDbWithBeer();
+    recordEnrichFailure(db, row({ beer_id: id, source_url: 'https://beerfreak.org/p/x' }));
+    const got = db.prepare('SELECT source_url FROM enrich_failures WHERE beer_id = ?').get(id) as any;
+    expect(got.source_url).toBe('https://beerfreak.org/p/x');
+  });
+
+  test('upsert does not overwrite a known source_url with an empty one', () => {
+    const { db, id } = freshDbWithBeer();
+    recordEnrichFailure(db, row({ beer_id: id, source_url: 'https://beerfreak.org/p/x' }));
+    recordEnrichFailure(db, row({ beer_id: id, source_url: '' })); // cron re-fail, no URL
+    const got = db.prepare('SELECT source_url FROM enrich_failures WHERE beer_id = ?').get(id) as any;
+    expect(got.source_url).toBe('https://beerfreak.org/p/x');
   });
 });

--- a/src/storage/enrich_failures.test.ts
+++ b/src/storage/enrich_failures.test.ts
@@ -65,4 +65,12 @@ describe('enrich_failures', () => {
     const got = db.prepare('SELECT source_url FROM enrich_failures WHERE beer_id = ?').get(id) as any;
     expect(got.source_url).toBe('https://beerfreak.org/p/x');
   });
+
+  test('upsert overwrites with a newer non-empty source_url (most-recent page wins)', () => {
+    const { db, id } = freshDbWithBeer();
+    recordEnrichFailure(db, row({ beer_id: id, source_url: 'https://beerfreak.org/p/old' }));
+    recordEnrichFailure(db, row({ beer_id: id, source_url: 'https://beerfreak.org/p/new' }));
+    const got = db.prepare('SELECT source_url FROM enrich_failures WHERE beer_id = ?').get(id) as any;
+    expect(got.source_url).toBe('https://beerfreak.org/p/new');
+  });
 });

--- a/src/storage/enrich_failures.ts
+++ b/src/storage/enrich_failures.ts
@@ -5,6 +5,7 @@ export interface EnrichFailureRow {
   brewery: string;
   name: string;
   search_url: string;
+  source_url: string;
   outcome: 'not_found' | 'blocked';
   candidates_count: number;
   candidates_summary: string;
@@ -17,19 +18,21 @@ export interface EnrichFailureRow {
 export function recordEnrichFailure(db: DB, r: EnrichFailureRow): void {
   db.prepare(
     `INSERT INTO enrich_failures
-       (beer_id, brewery, name, search_url, outcome, candidates_count, candidates_summary, fail_count, last_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?)
+       (beer_id, brewery, name, search_url, source_url, outcome, candidates_count, candidates_summary, fail_count, last_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, ?)
      ON CONFLICT(beer_id) DO UPDATE SET
        brewery            = excluded.brewery,
        name               = excluded.name,
        search_url         = excluded.search_url,
+       source_url         = CASE WHEN excluded.source_url != '' THEN excluded.source_url
+                                 ELSE enrich_failures.source_url END,
        outcome            = excluded.outcome,
        candidates_count   = excluded.candidates_count,
        candidates_summary = excluded.candidates_summary,
        fail_count         = enrich_failures.fail_count + 1,
        last_at            = excluded.last_at`,
   ).run(
-    r.beer_id, r.brewery, r.name, r.search_url, r.outcome,
+    r.beer_id, r.brewery, r.name, r.search_url, r.source_url, r.outcome,
     r.candidates_count, r.candidates_summary, r.at,
   );
 }

--- a/src/storage/schema.test.ts
+++ b/src/storage/schema.test.ts
@@ -205,5 +205,6 @@ describe('schema migrations', () => {
     const col = cols.find((c) => c.name === 'source_url');
     expect(col).toBeDefined();
     expect(col!.notnull).toBe(1);
+    expect(col!.dflt_value).toBe("''"); // backfills existing rows on the additive migration
   });
 });

--- a/src/storage/schema.test.ts
+++ b/src/storage/schema.test.ts
@@ -193,4 +193,17 @@ describe('schema migrations', () => {
     );
     expect(cols.find((c) => c.name === 'beer_id')?.pk).toBe(1);
   });
+
+  test('enrich_failures has a source_url column defaulting to empty string', () => {
+    const db = openDb(':memory:');
+    migrate(db);
+    const cols = db.prepare(`PRAGMA table_info(enrich_failures)`).all() as Array<{
+      name: string;
+      dflt_value: string | null;
+      notnull: number;
+    }>;
+    const col = cols.find((c) => c.name === 'source_url');
+    expect(col).toBeDefined();
+    expect(col!.notnull).toBe(1);
+  });
 });

--- a/src/storage/schema.ts
+++ b/src/storage/schema.ts
@@ -177,6 +177,12 @@ const MIGRATIONS: ReadonlyArray<{ version: number; sql: string }> = [
       );
     `,
   },
+  {
+    version: 11,
+    sql: `
+      ALTER TABLE enrich_failures ADD COLUMN source_url TEXT NOT NULL DEFAULT '';
+    `,
+  },
 ];
 
 export function migrate(db: DB): void {


### PR DESCRIPTION
## Summary
First of a 3-PR batch (orphan-debug tooling + extension cache control; spec + plans included under `docs/superpowers/`).

Records the **shop page URL** on each `enrich_failures` row so a triager can open the exact page and tell a **parser bug** (adapter mis-read the page — only diagnosable from the page) apart from a **matcher bug** (diagnosable from existing brewery/name/candidates).

- New `enrich_failures.source_url` column (migration v11, `TEXT NOT NULL DEFAULT ''` — additive, backfills existing rows).
- Page URL flows: extension `window.location.href` → `enrich:result` message → `POST /enrich/result` body `pageUrl?` → `applyLookupOutcome(input.sourceUrl)` → `recordEnrichFailure` (both `not_found` and `blocked` arms).
- The server cron path has no URL and passes `''`; the upsert **never overwrites a known URL with an empty one** (cron re-fail keeps the extension-supplied URL); a newer non-empty URL wins.
- Backward compatible: `pageUrl` optional everywhere — old extension clients and the cron path store `''`.
- Docs: `docs/debug-orphan-matching.md` runbook + `spec.md` §3.13 / §4 updated.

## Test Plan
- [x] `npx jest` — 613 passing (server)
- [x] `cd extension && npx vitest run` — 134 passing
- [x] `npx tsc --noEmit` clean (root + extension)
- [x] Coverage: migration default, insert, no-overwrite-empty, overwrite-with-newer, not_found+URL, blocked+URL, omit→'', route stores pageUrl, extension forwards pageUrl in body

🤖 Generated with [Claude Code](https://claude.com/claude-code)