### PR TITLE
fix(extension): ignore Bierloods22 beer packages

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed BeerFreak parsing when product titles repeat a brewery suffix such as "Brewery", or when BeerFreak omits brand metadata for descriptor-led breweries like "Brouwerij ...".
 - Fixed BeerRepublic parsing so mixed beer packs, vertical sets, surprise boxes, and advent calendars are ignored instead of being matched as individual beers.
+- Fixed Bierloods22 parsing so beer-package products such as Beerbox, Surprise Box, and subscription boxes are ignored instead of being matched as beers.
 
 ## [0.5.2] - 2026-06-11
 

--- a/extension/src/sites/bierloods22.test.ts
+++ b/extension/src/sites/bierloods22.test.ts
@@ -44,4 +44,19 @@ describe('bierloods22 brewery extraction (#117)', () => {
     expect(c.brewery).toBe('');
     expect(c.name).toBe('Solo');
   });
+
+  it('ignores beer-package cards from the Bierloods22 package category', () => {
+    const cards = parse([
+      card('Bierloods22 Beerbox - Surprise Box IPA', 'Beerbox - Surprise Box IPA'),
+      card('Bierloods22 Beertasting box: all styles', 'Beertasting box: all styles'),
+      card('Bierloods22 Beer Package present Birthday', 'Beer Package present Birthday'),
+      card('Browar Stu Mostów ART+81', 'Browar Stu Mostów - ART+81'),
+    ].join(''));
+
+    expect(cards).toHaveLength(1);
+    expect(cards[0]).toMatchObject({
+      brewery: 'Browar Stu Mostów',
+      name: 'ART+81',
+    });
+  });
 });

--- a/extension/src/sites/bierloods22.ts
+++ b/extension/src/sites/bierloods22.ts
@@ -1,9 +1,14 @@
 import type { Card, SiteAdapter } from './types';
 
 const CARD_SELECTOR = '.product-block';
+const PACKAGE_TITLE_RE = /^(?:beerbox\s*(?:-|:|$)|beertasting box\b|beer package\b|beerpackage\b|subscription\b|abonnement\b)|\b(?:surprise box|signature box|craftbeer box|benefit package|support your locals)\b/i;
 
 function text(el: Element | null | undefined): string {
   return el?.textContent?.replace(/\s+/g, ' ').trim() ?? '';
+}
+
+function isPackageTitle(title: string): boolean {
+  return PACKAGE_TITLE_RE.test(title.replace(/\s+/g, ' ').trim());
 }
 
 // bierloods22 cards expose the visible title (a.title text) as "{brewery} - {beer}" and
@@ -41,7 +46,11 @@ export const bierloods22: SiteAdapter = {
     const cards: Card[] = [];
     for (const el of Array.from(root.querySelectorAll<HTMLElement>(CARD_SELECTOR))) {
       const a = el.querySelector('a.title');
-      const parsed = splitTitle(text(a), a?.getAttribute('title') ?? '');
+      const titleText = text(a);
+      const titleAttr = a?.getAttribute('title') ?? '';
+      if (isPackageTitle(titleText) || isPackageTitle(titleAttr)) continue;
+
+      const parsed = splitTitle(titleText, titleAttr);
       if (!parsed) continue;
       cards.push({ el, brewery: parsed.brewery, name: parsed.name });
     }


### PR DESCRIPTION
## Summary
Bierloods22 package products no longer get sent to the match API as if they were individual beers. Cards from the Beer package category with titles such as Beerbox, Surprise Box, Beertasting box, Beer Package, and subscription boxes are skipped before brewery/name parsing, while normal beer cards continue through the existing parser.

The regression test covers a mixed grid so future package keywords do not hide valid beer parsing.

## Verification
- `npm test -- src/sites/bierloods22.test.ts`
- `npm test`
- `npm run typecheck`
- `npm run build`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
