### PR TITLE
feat(extension): cache-control popup — refresh page / clear all (0.6.0) (#3)

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-06-11
+
+- Added a toolbar popup to manage the cache: "Refresh this page" re-fetches badges for the beers on the current supported-shop tab (without waiting out the 8h TTL), and "Clear all cache" empties the whole cache.
 - Fixed BeerFreak parsing when product titles repeat a brewery suffix such as "Brewery", or when BeerFreak omits brand metadata for descriptor-led breweries like "Brouwerij ...".
 - Fixed BeerRepublic parsing so mixed beer packs, vertical sets, surprise boxes, and advent calendars are ignored instead of being matched as individual beers.
 

--- a/extension/manifest.config.ts
+++ b/extension/manifest.config.ts
@@ -10,9 +10,10 @@ export default defineManifest({
   // stored token survives a folder change / remove+re-add. Public key only; the
   // private key (~/warsaw-beer-extension-key.pem) is kept by the maintainer.
   key: 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqyZ4PALvAS9pOB6ImBCHA9T+5+8R94pTlH0NlALbbwTBbx4lIkilGB82gxXN1u/i/f7FSRhmxN4w/1b4jcl8MxqsxUrJOFg9u2dm84lwIqLN0ocjcGliZsnUFpwXBkn/23EWnPFhHtSV7OLfegPP2edMvZLCJ7yeXNZpfpDhNCdsBbQraLawY21zE+x0OpnRZ7CT2TLXyi+JtiDusaYvSN4eOnGTOAZTCBvXdrikll1zOpqkWrZ2fjryQ8A+8NGEz3eXsokG9O6jy9oK21AS+fKTmjkNCsddsbCoZm8D0m4xLnDBxxkv4LOMWGFG1MPv4gz0aXspaximsyFExL38KQIDAQAB',
-  permissions: ['storage'],
+  permissions: ['storage', 'activeTab', 'tabs'],
   host_permissions: ['https://beer-api.ysilvestrov-ai.uk/*'],
   optional_host_permissions: ['https://*/*'],
+  action: { default_popup: 'src/popup/popup.html' },
   options_page: 'src/options/options.html',
   background: { service_worker: 'src/background/index.ts', type: 'module' },
   content_scripts: [

--- a/extension/manifest.config.ts
+++ b/extension/manifest.config.ts
@@ -10,6 +10,10 @@ export default defineManifest({
   // stored token survives a folder change / remove+re-add. Public key only; the
   // private key (~/warsaw-beer-extension-key.pem) is kept by the maintainer.
   key: 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqyZ4PALvAS9pOB6ImBCHA9T+5+8R94pTlH0NlALbbwTBbx4lIkilGB82gxXN1u/i/f7FSRhmxN4w/1b4jcl8MxqsxUrJOFg9u2dm84lwIqLN0ocjcGliZsnUFpwXBkn/23EWnPFhHtSV7OLfegPP2edMvZLCJ7yeXNZpfpDhNCdsBbQraLawY21zE+x0OpnRZ7CT2TLXyi+JtiDusaYvSN4eOnGTOAZTCBvXdrikll1zOpqkWrZ2fjryQ8A+8NGEz3eXsokG9O6jy9oK21AS+fKTmjkNCsddsbCoZm8D0m4xLnDBxxkv4LOMWGFG1MPv4gz0aXspaximsyFExL38KQIDAQAB',
+  // storage: the match cache + token/settings. activeTab + tabs: the popup reads the
+  // active tab's URL (chrome.tabs.query) and messages its content script
+  // (chrome.tabs.sendMessage) for "Refresh this page". (tabs is a candidate to trim to
+  // activeTab-only once the popup is verified in Chrome — see PR #135 manual checklist.)
   permissions: ['storage', 'activeTab', 'tabs'],
   host_permissions: ['https://beer-api.ysilvestrov-ai.uk/*'],
   optional_host_permissions: ['https://*/*'],

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "warsaw-beer-extension",
   "private": true,
-  "version": "0.5.2",
+  "version": "0.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/extension/src/cache/store.test.ts
+++ b/extension/src/cache/store.test.ts
@@ -47,4 +47,12 @@ describe('cache/store', () => {
     expect(await getCached('a|x')).toBeNull();
     expect(await getCached('b|y')).toBeNull();
   });
+
+  it('clearAll leaves non-cache (non-mc2:) storage untouched', async () => {
+    await chrome.storage.local.set({ token: 'keep-me' });
+    await setCached('a|x', sample);
+    await clearAll();
+    expect(await getCached('a|x')).toBeNull();
+    expect((await chrome.storage.local.get('token')).token).toBe('keep-me');
+  });
 });

--- a/extension/src/cache/store.test.ts
+++ b/extension/src/cache/store.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getCached, setCached, CACHE_TTL_MS } from './store';
+import { getCached, setCached, CACHE_TTL_MS, clearKeys, clearAll } from './store';
 import type { MatchResult } from '../api/types';
 
 const sample: MatchResult = {
@@ -24,5 +24,27 @@ describe('cache/store', () => {
     const now = 1_000_000;
     await setCached('pinta|hazy morning', sample, now);
     expect(await getCached('pinta|hazy morning', now + CACHE_TTL_MS + 1)).toBeNull();
+  });
+
+  it('clearKeys removes only the given keys', async () => {
+    await setCached('a|x', sample);
+    await setCached('b|y', sample);
+    await clearKeys(['a|x']);
+    expect(await getCached('a|x')).toBeNull();
+    expect(await getCached('b|y')).toEqual(sample);
+  });
+
+  it('clearKeys is a no-op for an empty list', async () => {
+    await setCached('a|x', sample);
+    await clearKeys([]);
+    expect(await getCached('a|x')).toEqual(sample);
+  });
+
+  it('clearAll removes every cached entry', async () => {
+    await setCached('a|x', sample);
+    await setCached('b|y', sample);
+    await clearAll();
+    expect(await getCached('a|x')).toBeNull();
+    expect(await getCached('b|y')).toBeNull();
   });
 });

--- a/extension/src/cache/store.ts
+++ b/extension/src/cache/store.ts
@@ -24,3 +24,14 @@ export async function setCached(
   const entry: Entry = { result, expiresAt: now + CACHE_TTL_MS };
   await chrome.storage.local.set({ [PREFIX + key]: entry });
 }
+
+export async function clearKeys(keys: string[]): Promise<void> {
+  if (keys.length === 0) return;
+  await chrome.storage.local.remove(keys.map((k) => PREFIX + k));
+}
+
+export async function clearAll(): Promise<void> {
+  const all = await chrome.storage.local.get();
+  const ours = Object.keys(all).filter((k) => k.startsWith(PREFIX));
+  if (ours.length > 0) await chrome.storage.local.remove(ours);
+}

--- a/extension/src/content/badge.test.ts
+++ b/extension/src/content/badge.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { renderBadge, BADGE_MARKER, markSeen, isSeen, SEEN_MARKER } from './badge';
+import { renderBadge, BADGE_MARKER, markSeen, isSeen, SEEN_MARKER, resetCard } from './badge';
 import { setSearching, setEnriched, setOrphan } from './badge';
 import type { MatchResult } from '../api/types';
 
@@ -137,5 +137,19 @@ describe('seen marker', () => {
     markSeen(host);
     expect(host.hasAttribute(SEEN_MARKER)).toBe(true);
     expect(isSeen(host)).toBe(true);
+  });
+});
+
+describe('resetCard', () => {
+  it('resetCard removes the badge and the seen marker', () => {
+    const host = document.createElement('div');
+    renderBadge(host, { is_drunk: true, user_rating: 4, raw: { brewery: 'b', name: 'n' }, matched_beer: null });
+    markSeen(host);
+    expect(host.querySelector(`[${BADGE_MARKER}]`)).not.toBeNull();
+    expect(isSeen(host)).toBe(true);
+
+    resetCard(host);
+    expect(host.querySelector(`[${BADGE_MARKER}]`)).toBeNull();
+    expect(isSeen(host)).toBe(false);
   });
 });

--- a/extension/src/content/badge.ts
+++ b/extension/src/content/badge.ts
@@ -13,6 +13,12 @@ export function isSeen(el: HTMLElement): boolean {
   return el.hasAttribute(SEEN_MARKER);
 }
 
+/** Undo the overlay's marks on a card so the next run re-processes it from scratch. */
+export function resetCard(el: HTMLElement): void {
+  el.querySelector(`[${BADGE_MARKER}]`)?.remove();
+  el.removeAttribute(SEEN_MARKER);
+}
+
 function untappdUrl(untappdId: number): string {
   return `https://untappd.com/beer/${untappdId}`;
 }

--- a/extension/src/content/main.ts
+++ b/extension/src/content/main.ts
@@ -1,6 +1,8 @@
 import { pickAdapter } from '../sites/registry';
 import { runOverlay, type SendMatch, type EnrichOrphans } from './index';
 import { observeReRender, type ReRenderOptions } from './rerender';
+import { refreshCards } from './refresh';
+import { clearKeys } from '../cache/store';
 import { isSeen, setSearching, setEnriched, setOrphan } from './badge';
 import { runEnrichment, type OrphanBeer } from './enrich';
 import { trimSearchHtml } from './untappd-trim';
@@ -80,4 +82,18 @@ export function startOverlay(
 }
 
 const adapter = pickAdapter(new URL(window.location.href));
-if (adapter) startOverlay(document, adapter, sendMatch, undefined, enrichOrphans);
+if (adapter) {
+  startOverlay(document, adapter, sendMatch, undefined, enrichOrphans);
+  // Popup → "Refresh this page": drop the visible cards' cache entries and re-run
+  // the overlay so badges reflect fresh server state without waiting out the TTL.
+  chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+    if ((message as { type?: unknown }).type !== 'refresh-page') return undefined;
+    void (async () => {
+      const keys = refreshCards(document, adapter);
+      await clearKeys(keys);
+      await runOverlay(document, adapter, sendMatch, enrichOrphans);
+      sendResponse({ ok: true, cleared: keys.length });
+    })();
+    return true; // keep the message channel open for the async sendResponse
+  });
+}

--- a/extension/src/content/main.ts
+++ b/extension/src/content/main.ts
@@ -89,10 +89,15 @@ if (adapter) {
   chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     if ((message as { type?: unknown }).type !== 'refresh-page') return undefined;
     void (async () => {
-      const keys = refreshCards(document, adapter);
-      await clearKeys(keys);
-      await runOverlay(document, adapter, sendMatch, enrichOrphans);
-      sendResponse({ ok: true, cleared: keys.length });
+      try {
+        const keys = refreshCards(document, adapter);
+        await clearKeys(keys);
+        await runOverlay(document, adapter, sendMatch, enrichOrphans);
+        sendResponse({ ok: true, cleared: keys.length });
+      } catch {
+        // Always answer so the popup never hangs on "Refreshing…".
+        sendResponse({ ok: false, cleared: 0 });
+      }
     })();
     return true; // keep the message channel open for the async sendResponse
   });

--- a/extension/src/content/main.ts
+++ b/extension/src/content/main.ts
@@ -94,8 +94,9 @@ if (adapter) {
         await clearKeys(keys);
         await runOverlay(document, adapter, sendMatch, enrichOrphans);
         sendResponse({ ok: true, cleared: keys.length });
-      } catch {
+      } catch (err) {
         // Always answer so the popup never hangs on "Refreshing…".
+        console.warn('[beer-overlay] refresh-page failed', err);
         sendResponse({ ok: false, cleared: 0 });
       }
     })();

--- a/extension/src/content/refresh.test.ts
+++ b/extension/src/content/refresh.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { refreshCards } from './refresh';
+import { renderBadge, markSeen, isSeen, BADGE_MARKER } from './badge';
+import { normalizeKey } from '../shared/normalize';
+import type { SiteAdapter } from '../sites/types';
+
+function cardEl(): HTMLElement {
+  const el = document.createElement('div');
+  renderBadge(el, { is_drunk: true, user_rating: 4, raw: { brewery: 'x', name: 'y' }, matched_beer: null });
+  markSeen(el);
+  return el;
+}
+
+describe('refreshCards', () => {
+  it('resets every parsed card and returns its cache key', () => {
+    const a = cardEl();
+    const b = cardEl();
+    const adapter = {
+      id: 'fake',
+      hostMatch: () => true,
+      parseCards: () => [
+        { el: a, brewery: 'PINTA', name: 'Atak Chmielu' },
+        { el: b, brewery: 'Track', name: 'Sonoma' },
+      ],
+    } as unknown as SiteAdapter;
+
+    const keys = refreshCards(document, adapter);
+
+    expect(keys).toEqual([normalizeKey('PINTA', 'Atak Chmielu'), normalizeKey('Track', 'Sonoma')]);
+    expect(a.querySelector(`[${BADGE_MARKER}]`)).toBeNull();
+    expect(isSeen(a)).toBe(false);
+    expect(isSeen(b)).toBe(false);
+  });
+});

--- a/extension/src/content/refresh.test.ts
+++ b/extension/src/content/refresh.test.ts
@@ -30,5 +30,6 @@ describe('refreshCards', () => {
     expect(a.querySelector(`[${BADGE_MARKER}]`)).toBeNull();
     expect(isSeen(a)).toBe(false);
     expect(isSeen(b)).toBe(false);
+    expect(b.querySelector(`[${BADGE_MARKER}]`)).toBeNull();
   });
 });

--- a/extension/src/content/refresh.ts
+++ b/extension/src/content/refresh.ts
@@ -1,0 +1,16 @@
+import { normalizeKey } from '../shared/normalize';
+import { resetCard } from './badge';
+import type { SiteAdapter } from '../sites/types';
+
+// Resets every parsed card on the page (removes badge + seen marker) and returns
+// the cache keys for those cards, so the caller can drop them from the cache before
+// re-running the overlay to fetch fresh results. Site-independent keys mean this is
+// the "refresh the open page" primitive behind the popup's per-site button.
+export function refreshCards(doc: Document, adapter: SiteAdapter): string[] {
+  const keys: string[] = [];
+  for (const card of adapter.parseCards(doc)) {
+    keys.push(normalizeKey(card.brewery, card.name));
+    resetCard(card.el);
+  }
+  return keys;
+}

--- a/extension/src/manifest.test.ts
+++ b/extension/src/manifest.test.ts
@@ -9,6 +9,8 @@ const manifest = manifestExport as {
   version: string;
   key: string;
   content_scripts: Array<{ matches: string[] }>;
+  permissions: string[];
+  action?: { default_popup?: string };
 };
 
 describe('manifest', () => {
@@ -32,5 +34,14 @@ describe('manifest', () => {
     expect(contentScript.matches).toContain('https://*.bierloods22.nl/*');
     expect(contentScript.matches).toContain('https://winetime.com.ua/*');
     expect(contentScript.matches).toContain('https://*.winetime.com.ua/*');
+  });
+
+  it('exposes a popup action', () => {
+    expect(manifest.action?.default_popup).toBe('src/popup/popup.html');
+  });
+
+  it('requests activeTab + tabs permissions for the popup', () => {
+    expect(manifest.permissions).toContain('activeTab');
+    expect(manifest.permissions).toContain('tabs');
   });
 });

--- a/extension/src/popup/popup.css
+++ b/extension/src/popup/popup.css
@@ -1,0 +1,7 @@
+body { margin: 0; font: 14px/1.4 system-ui, sans-serif; }
+.card { min-width: 240px; padding: 12px; }
+h1 { font-size: 15px; margin: 0 0 8px; }
+.row { display: flex; flex-direction: column; gap: 8px; }
+button { padding: 8px; cursor: pointer; }
+button:disabled { cursor: default; opacity: 0.5; }
+.status { margin: 10px 0 0; color: #444; min-height: 1.2em; }

--- a/extension/src/popup/popup.html
+++ b/extension/src/popup/popup.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Warsaw Beer Overlay</title>
+    <link rel="stylesheet" href="./popup.css" />
+  </head>
+  <body>
+    <main class="card">
+      <h1>Warsaw Beer Overlay</h1>
+      <div class="row">
+        <button id="refresh" type="button">Refresh this page</button>
+        <button id="clearAll" type="button">Clear all cache</button>
+      </div>
+      <p id="status" class="status" aria-live="polite"></p>
+    </main>
+    <script type="module" src="./popup.ts"></script>
+  </body>
+</html>

--- a/extension/src/popup/popup.test.ts
+++ b/extension/src/popup/popup.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { canRefresh } from './popup';
+
+describe('canRefresh', () => {
+  it('true on a supported shop URL', () => {
+    expect(canRefresh('https://beerfreak.org/some/page')).toBe(true);
+    expect(canRefresh('https://winetime.com.ua/x')).toBe(true);
+  });
+  it('false on an unsupported URL', () => {
+    expect(canRefresh('https://example.com/')).toBe(false);
+  });
+  it('false on a malformed or empty URL', () => {
+    expect(canRefresh('not a url')).toBe(false);
+    expect(canRefresh('')).toBe(false);
+  });
+});

--- a/extension/src/popup/popup.ts
+++ b/extension/src/popup/popup.ts
@@ -1,0 +1,46 @@
+import { pickAdapter } from '../sites/registry';
+import { clearAll } from '../cache/store';
+
+// True when the URL belongs to a supported shop, so "Refresh this page" can act.
+export function canRefresh(url: string): boolean {
+  try {
+    return pickAdapter(new URL(url)) != null;
+  } catch {
+    return false;
+  }
+}
+
+function el<T extends HTMLElement>(id: string): T | null {
+  return document.getElementById(id) as T | null;
+}
+
+async function initPopup(): Promise<void> {
+  const refreshBtn = el<HTMLButtonElement>('refresh');
+  const clearBtn = el<HTMLButtonElement>('clearAll');
+  const status = el<HTMLElement>('status');
+  if (!refreshBtn || !clearBtn || !status) return;
+
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  const url = tab?.url ?? '';
+  refreshBtn.disabled = !canRefresh(url);
+  if (refreshBtn.disabled) status.textContent = 'Open a supported shop page to refresh it.';
+
+  refreshBtn.addEventListener('click', () => {
+    if (tab?.id == null) return;
+    status.textContent = 'Refreshing…';
+    chrome.tabs.sendMessage(tab.id, { type: 'refresh-page' }, (reply?: { cleared?: number }) => {
+      status.textContent = chrome.runtime.lastError
+        ? 'Could not reach the page — reload it and retry.'
+        : `Refreshed (${reply?.cleared ?? 0} cleared).`;
+    });
+  });
+
+  clearBtn.addEventListener('click', async () => {
+    await clearAll();
+    status.textContent = 'Cache cleared.';
+  });
+}
+
+if (typeof document !== 'undefined' && document.getElementById('refresh')) {
+  void initPopup();
+}

--- a/spec.md
+++ b/spec.md
@@ -797,6 +797,13 @@ test-БД, §3.2 «no `await` ⇒ no race», §3.3 визначення «extern
 - **Auth:** токен з команди `/extension` зберігається в `chrome.storage.local`;
   base URL редагований (дефолт `https://beer-api.ysilvestrov-ai.uk`, §5.9);
   options-сторінка має Test connection (`GET /health` + 1-beer `/match`).
+- **Popup керування кешем** (toolbar `action`, дозволи `activeTab`+`tabs`):
+  «Refresh this page» — для активної вкладки підтримуваного магазину скидає бейджі
+  видимих карток (видаляє їхні `mc2:`-записи кешу + ре-рендер живцем через
+  повідомлення `refresh-page` контент-скрипту → `refreshCards` + `clearKeys` +
+  `runOverlay`); «Clear all cache» — чистить усі `mc2:`-ключі (`clearAll`). Ключі
+  кешу site-незалежні (`normalizeKey(brewery,name)`), тож «per-site» реалізовано як
+  «оновити відкриту сторінку».
 - **Read-only гарантія:** лише додає власні бейдж-ноди; будь-яка помилка
   парсингу/рендеру проковтується й не ламає сторінку магазину.
 - **Тести:** контракт адаптера покрито **конформанс-тестом над реєстром**


### PR DESCRIPTION
## Summary
Third of the 3-PR orphan-debug batch (independent — extension-only, no server/migration). Adds a toolbar popup to manage the badge cache.

- **"Refresh this page"** — on a supported-shop tab, drops the visible cards' cached `/match` results and re-renders badges live, without waiting out the 8h TTL. Disabled on non-shop tabs.
- **"Clear all cache"** — empties every `mc2:` cache entry.
- Cache keys are site-independent (`normalizeKey(brewery,name)`), so "per-site" is implemented as "refresh the open page".

Mechanics:
- `clearKeys`/`clearAll` (PREFIX-scoped — never touches the stored token/options), `resetCard` (removes badge + seen marker so `renderBadge` re-renders), `refreshCards(doc, adapter)`.
- Content script handles a `refresh-page` message → `refreshCards` → `clearKeys` → `runOverlay` → `sendResponse`, in a try/catch so the popup never hangs.
- `src/popup/` (pure `canRefresh` + guarded `initPopup`, html, css); manifest `action.default_popup` + `activeTab`/`tabs`.
- Version → **0.6.0** (also cuts the accumulated unreleased BeerFreak/BeerRepublic fixes); `spec.md` §6 documents the popup.

## Test Plan
- [x] `npx vitest run` — 145 passing
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` — `dist/manifest.json` has `action.default_popup` + `["storage","activeTab","tabs"]`, `popup.html` emitted, version 0.6.0
- [ ] **Manual (Chrome, post-merge):** load `dist` unpacked → icon opens popup; "Refresh this page" re-renders badges on a shop tab + disabled on non-shop tabs; "Clear all cache" empties `mc2:` keys (DevTools → Application → Storage); host page never breaks. (Also a chance to confirm whether `tabs` perm can be trimmed to `activeTab` only.)

## Release (after merge)
`npm run release` (build → DB row → stage zip), then forward the zip to the bot to broadcast 📣. Note: the pending 0.5.2 broadcast is separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)