### PR TITLE
docs(runbook): purge DELETE needs PRAGMA foreign_keys=ON

### DIFF
--- a/docs/debug-orphan-matching.md
+++ b/docs/debug-orphan-matching.md
@@ -183,11 +183,15 @@ sudo -u warsaw-beer-bot /usr/bin/bash -lc '
       AND NOT EXISTS (SELECT 1 FROM checkins  c WHERE c.beer_id          = ef.beer_id);"'
 ```
 
-Після звірки — той самий WHERE у DELETE (каскадить enrich_failures):
+Після звірки — той самий WHERE у DELETE. **`PRAGMA foreign_keys=ON` обовʼязковий** — sqlite3 CLI
+тримає FK **вимкненими** за замовчуванням, тож без нього каскад на `enrich_failures` (FK
+`ON DELETE CASCADE`) НЕ спрацює і лишить осиротілі рядки. `busy_timeout` — бо бот тримає БД відкритою (WAL).
 
 ```bash
 sudo -u warsaw-beer-bot /usr/bin/bash -lc '
   sqlite3 /var/lib/warsaw-beer-bot/bot.db "
+    PRAGMA foreign_keys=ON;
+    PRAGMA busy_timeout=5000;
     DELETE FROM beers WHERE id IN (
       SELECT ef.beer_id FROM enrich_failures ef JOIN beers b ON b.id = ef.beer_id
       WHERE b.untappd_id IS NULL


### PR DESCRIPTION
## Summary

While running the #141 orphan purge I found the runbook's `DELETE FROM beers` command had a latent gap: the sqlite3 CLI defaults `foreign_keys` **OFF**, so the `enrich_failures` `ON DELETE CASCADE` would **not** fire — leaving orphaned `enrich_failures` rows pointing at deleted beers.

Added `PRAGMA foreign_keys=ON;` (and `PRAGMA busy_timeout=5000;`, since the bot holds the WAL DB open) to the DELETE block in `docs/debug-orphan-matching.md`.

The actual #141 purge was run **with** the pragma, so prod is clean (22 beers deleted, `enrich_failures` 117→95, 0 orphans verified).

## Test Plan
- [x] Verified empirically on prod: with the pragma, cascade removed all 22 `enrich_failures` rows; 0 orphaned rows remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)