### PR TITLE
fix(extension): paginate check-in sync via more_feed XHR (0.7.1, #145)

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-06-16
+
+- Fixed check-in sync only ever loading the most recent page: it now paginates through your full history via Untappd's "Show More" endpoint (older pages were previously not fetched at all), so backfilling a large history and topping up festival gaps work as intended.
+
 ## [0.7.0] - 2026-06-15
 
 - Added a "Sync my check-ins" toolbar-popup button that loads your Untappd check-in history straight from your logged-in Untappd session and sends it to the bot — no Untappd Supporter required (unlike `/import`). Requires linking your account first (`/link <username>`). It walks your feed newest-to-oldest and shows live progress; for large histories it syncs in chunks, so tap it again ("Synced X of Y — tap Sync again to continue") until it reports "Fully synced". Useful both to backfill your whole history and to quickly top up recent check-ins (e.g. after a festival) that the server's background sync misses.

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "warsaw-beer-extension",
   "private": true,
-  "version": "0.7.0",
+  "version": "0.7.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/extension/src/background/index.test.ts
+++ b/extension/src/background/index.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { feedUrl } from './index';
+
+describe('feedUrl', () => {
+  it('page 1 (null cursor) is the full profile page', () => {
+    expect(feedUrl('ysilvestrov', null)).toBe('https://untappd.com/user/ysilvestrov');
+  });
+
+  it('older pages use the more_feed XHR endpoint, not a ?max_id= query', () => {
+    expect(feedUrl('ysilvestrov', '1577238079')).toBe(
+      'https://untappd.com/profile/more_feed/ysilvestrov/1577238079?v2=true',
+    );
+  });
+
+  it('encodes the username', () => {
+    expect(feedUrl('a b/c', null)).toBe('https://untappd.com/user/a%20b%2Fc');
+  });
+});

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -121,9 +121,15 @@ function enqueueSyncStatus(s: StoredSyncStatus): Promise<void> {
 
 let syncRunning = false;
 
-function feedUrl(username: string, maxId: string | null): string {
-  const base = `https://untappd.com/user/${encodeURIComponent(username)}`;
-  return maxId === null ? base : `${base}?max_id=${encodeURIComponent(maxId)}`;
+// Page 1 (maxId === null) is the full profile page. Every older page is served by
+// Untappd's "Show More" XHR endpoint /profile/more_feed/<user>/<offset>?v2=true (a raw
+// item fragment). A `?max_id=` query on the profile page is IGNORED (always returns the
+// newest page), so it must NOT be used for pagination.
+export function feedUrl(username: string, maxId: string | null): string {
+  const u = encodeURIComponent(username);
+  return maxId === null
+    ? `https://untappd.com/user/${u}`
+    : `https://untappd.com/profile/more_feed/${u}/${encodeURIComponent(maxId)}?v2=true`;
 }
 
 export async function handleCheckinSyncStart(): Promise<{ type: 'checkin-sync:started'; alreadyRunning: boolean }> {
@@ -155,8 +161,18 @@ export async function handleCheckinSyncStart(): Promise<{ type: 'checkin-sync:st
       const outcome = await runCheckinSync({
         getState: () => getCheckinSyncState(baseUrl, token),
         fetchFeed: async (username, maxId) => {
-          const res = await fetch(feedUrl(username, maxId), { credentials: 'include' });
-          if (!res.ok) throw new ApiError(res.status === 403 || res.status === 429 ? 'blocked' : 'server');
+          // more_feed is XHR-only: without X-Requested-With Untappd 307-redirects it to
+          // /home. A redirect on that endpoint means the request wasn't honoured (e.g.
+          // logged-out session) — treat it as an error rather than parsing /home (which
+          // has no check-ins and would look like a clean "feed bottom").
+          const isMoreFeed = maxId !== null;
+          const res = await fetch(feedUrl(username, maxId), {
+            credentials: 'include',
+            headers: isMoreFeed ? { 'X-Requested-With': 'XMLHttpRequest' } : undefined,
+          });
+          if ((isMoreFeed && res.redirected) || !res.ok) {
+            throw new ApiError(res.status === 403 || res.status === 429 ? 'blocked' : 'server');
+          }
           return res.text();
         },
         submitPage: (html, maxId) => postCheckinSyncPage(baseUrl, token, html, maxId),

--- a/spec.md
+++ b/spec.md
@@ -660,11 +660,17 @@ Auth like `/match` (per-user Bearer-токен → `telegram_id`). Другий 
 (§3.14; `complete` при відсутності `nextMaxId`). Повертає `{ merged, alreadyKnown, pageSize,
 nextMaxId, profileTotal, serverCount, complete }`.
 
-**Stop-логіка (клієнт).** Стрічка гортається newest→older курсором `max_id` (тільки в один бік).
-Зупинка: повністю відома сторінка (`alreadyKnown === pageSize`), дно стрічки (`nextMaxId === null`),
-або жорсткий cap (~200 сторінок/прогін). Two-phase: Phase 1 (top-up) з «зараз», Phase 2 (deep extend)
-з збереженого `deepest_max_id` — повторні «Sync» поглиблюють покриття. Деталі — §6 і
-`docs/extension-install-uk.md`.
+**Пагінація (клієнт).** Сторінка 1 — повна сторінка профілю `untappd.com/user/<name>`; кожна
+наступна (старіша) сторінка — XHR-фрагмент `GET /profile/more_feed/<name>/<offset>?v2=true`
+(`offset` = найстаріший `checkin_id` попередньої сторінки), з заголовком `X-Requested-With:
+XMLHttpRequest` (без нього Untappd 307-редіректить на `/home`). ⚠️ `?max_id=` на сторінці профілю
+**ігнорується** (завжди віддає найновішу сторінку) — НЕ використовувати. `nextMaxId` = найстаріший
+`checkin_id` сторінки (фрагмент не має кнопки Show More), тож дно = сторінка з 0 чекінів.
+
+**Stop-логіка (клієнт).** Зупинка: повністю відома сторінка (`alreadyKnown === pageSize`), дно
+стрічки (`nextMaxId === null` / 0 чекінів), або жорсткий cap (~200 сторінок/прогін). Two-phase:
+Phase 1 (top-up) з «зараз», Phase 2 (deep extend) з збереженого `deepest_max_id` — повторні «Sync»
+поглиблюють покриття. Деталі — §6 і `docs/extension-install-uk.md`.
 
 #### `POST /admin/enrich-failures/review` — тріажна розмітка провалу
 

--- a/src/api/routes/checkins.test.ts
+++ b/src/api/routes/checkins.test.ts
@@ -28,17 +28,9 @@ const PAGE_ONE = `
 </body></html>`;
 
 // Same single check-in, NO Show More → feed bottom.
-const PAGE_BOTTOM = `
-<html><body>
-  <div class="item" data-checkin-id="555">
-    <a href="/b/some-ipa/42" class="label"><img></a>
-    <p class="text">
-      <a href="/user/bob" class="user">Bob</a> is drinking an <a href="/b/some-ipa/42">Some IPA</a>
-      by <a href="/SomeBrewery">Some Brewery</a>
-    </p>
-    <a href="/user/bob/checkin/555" class="time timezoner">Mon, 15 Jun 2026 18:00:00 +0000</a>
-  </div>
-</body></html>`;
+// Feed bottom = a page (more_feed fragment) with zero check-in items. The walk stops
+// here (nextMaxId null → complete), not on the absence of a Show More button.
+const PAGE_BOTTOM = `<html><body></body></html>`;
 
 const RAW_TOKEN = 'test-checkins-token-abc';
 const RAW_TOKEN_NO_USER = 'test-checkins-token-no-user';
@@ -150,12 +142,12 @@ describe('POST /checkins/sync', () => {
     expect(countCheckins(db, TELEGRAM_ID)).toBe(1);
   });
 
-  it('marks sync complete when no Show More is present', async () => {
+  it('marks sync complete on an empty (exhausted) page', async () => {
     const { db, app } = setup();
     const res = await post(app, '/checkins/sync', { html: PAGE_BOTTOM, maxId: null }, RAW_TOKEN);
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body).toMatchObject({ nextMaxId: null, complete: true });
+    expect(body).toMatchObject({ pageSize: 0, nextMaxId: null, complete: true });
     expect(getSyncState(db, TELEGRAM_ID).complete).toBe(true);
   });
 

--- a/src/sources/untappd/checkin-feed.test.ts
+++ b/src/sources/untappd/checkin-feed.test.ts
@@ -43,9 +43,38 @@ describe('parseCheckinFeedPage', () => {
     expect(out.profileTotal).toBe(12407);
   });
 
-  it('nextMaxId is the last (oldest) check-in id, since Show More is present', () => {
+  it('nextMaxId is the last (oldest) check-in id on the page', () => {
     expect(out.nextMaxId).toBe(out.checkins[out.checkins.length - 1].checkin_id);
     expect(out.nextMaxId).toMatch(/^\d+$/);
+  });
+
+  it('paginates a more_feed fragment (no .stats / no .more_checkins button)', () => {
+    // After page 1, pages come from /profile/more_feed/<user>/<offset> as raw item
+    // fragments with no stats block and no Show More button. nextMaxId must still be
+    // the oldest id so the walk can continue; profileTotal is unknown in a fragment.
+    const fragment = `
+      <div class="item " data-checkin-id="1577233492">
+        <p class="text">
+          <a class="user" href="/user/ysilvestrov">Y</a> is drinking
+          <a href="/b/oatkeeper/6438923">Oatkeeper</a> by
+          <a href="/PiwnePodziemie">Piwne Podziemie</a> at
+          <a href="/v/offside/1">Offside</a>
+        </p>
+        <div class="caps " data-rating="3.5"></div>
+        <a class="time">Fri, 12 Jun 2026 17:47:48 +0000</a>
+      </div>
+      <div class="item " data-checkin-id="1574693054">
+        <p class="text">
+          <a class="user" href="/user/ysilvestrov">Y</a> is drinking
+          <a href="/b/renety-2024/6391450">Renety 2024</a> by
+          <a href="/SlowFlow">Slow Flow Group</a>
+        </p>
+        <a class="time">Sun, 31 May 2026 18:03:24 +0000</a>
+      </div>`;
+    const frag = parseCheckinFeedPage(fragment);
+    expect(frag.checkins).toHaveLength(2);
+    expect(frag.profileTotal).toBeNull();
+    expect(frag.nextMaxId).toBe('1574693054'); // oldest (last) id, despite no button
   });
 
   it('returns empty + null cursor for a page with no check-ins', () => {

--- a/src/sources/untappd/checkin-feed.ts
+++ b/src/sources/untappd/checkin-feed.ts
@@ -105,11 +105,13 @@ export function parseCheckinFeedPage(html: string): CheckinFeedPage {
 
   const profileTotal = parseProfileTotal($);
 
-  // Untappd renders an .more_checkins button only when older pages exist.
-  let nextMaxId: string | null = null;
-  if (checkins.length > 0 && $('.more_checkins').length > 0) {
-    nextMaxId = checkins[checkins.length - 1].checkin_id;
-  }
+  // Cursor for the next (older) page = the oldest check-in id on this page. Pages
+  // are newest→oldest, so the last item is the oldest. We deliberately do NOT gate
+  // on the `.more_checkins` button: the full profile page has it, but the
+  // `/profile/more_feed/<user>/<offset>` fragments (which serve every page after the
+  // first) do not — yet they still have older check-ins. The walk instead stops when
+  // a page yields zero check-ins (handled by the caller treating null as feed bottom).
+  const nextMaxId = checkins.length > 0 ? checkins[checkins.length - 1].checkin_id : null;
 
   return { checkins, nextMaxId, profileTotal };
 }

--- a/tmp/Yuriy Silvestrov on Untappd.html
+++ b/tmp/Yuriy Silvestrov on Untappd.html
@@ -1,0 +1,2822 @@
+<!DOCTYPE html>
+
+<html lang="en">
+
+<head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# untappd: http://ogp.me/ns/fb/untappd#">
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+
+			<title>Yuriy Silvestrov on Untappd</title>
+		
+	<meta property="og:site_name" content="Untappd" />
+
+	<!-- meta block -->
+			<meta name="description" content="Yuriy Silvestrov Check-in Activity on Untappd with beer ratings, venues and more." />
+		<meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width" />
+	  		<meta property="fb:app_id" content="153339744679495" />
+  		<meta property="og:url"    content="https://untappd.com/user/ysilvestrov" />
+		<meta property="og:title"  content="Yuriy Silvestrov" />
+					<meta property="og:image" content="https://next.untappd.com/og/user/ysilvestrov.png" />
+						<meta property="og:image:width"  content="1200" />
+			<meta property="og:image:height" content="630" />
+					<meta property="og:description" content="Yuriy Silvestrov Check-in Activity on Untappd with beer ratings, venues and more." />
+
+		<meta property="og:type"   content="profile" />
+				<meta name="twitter:card" content="summary_large_image">
+		<meta name="twitter:site" content="@untappd">
+		<meta name="twitter:title" content="Yuriy Silvestrov on Untappd">
+		<meta name="twitter:description" content="Yuriy Silvestrov Check-in Activity on Untappd with beer ratings, venues and more.">
+		<meta name="twitter:image" content="https://next.untappd.com/og/user/ysilvestrov.png">
+		<meta name="twitter:domain" content="untappd.com">
+		<meta name="twitter:app:name:iphone" content="Untappd">
+        <meta name="twitter:app:name:android" content="Untappd">
+        <meta name="twitter:app:id:iphone" content="id449141888">
+        <meta name="twitter:app:id:googleplay" content="com.untappdllc.app">
+		<meta name="robots" content="noindex, nofollow"><meta name="referrer" content="origin-when-crossorigin">
+	<meta name="author" content="The Untappd Team" />
+	<meta name="Copyright" content="Copyright Untappd 2026. All Rights Reserved." />
+	<meta name="DC.title" content="Untappd" />
+			<meta name="DC.subject" content="Yuriy Silvestrov Check-in Activity on Untappd with beer ratings, venues and more." />
+			<meta name="DC.creator" content="The Untappd Team" />
+
+	<meta name="google-site-verification" content="EnR7QavTgiLCzZCCOv_OARCHsHhFwkwnJdG0Sti9Amg" />
+	<meta name="bitly-verification" content="b3080898518a"/>
+
+	<!-- favicon -->
+	<link rel="apple-touch-icon" sizes="144x144" href="https://untappd.com/assets/apple-touch-icon.png">
+	<link rel="icon" type="image/png" href="https://untappd.com/assets/favicon-32x32-v2.png" sizes="32x32">
+	<link rel="icon" type="image/png" href="https://untappd.com/assets/favicon-16x16-v2.png" sizes="16x16">
+	<link rel="manifest" href="https://untappd.com/assets/manifest.json">
+	<link rel="mask-icon" href="https://untappd.com/assets/safari-pinned-tab.svg" color="#5bbad5">
+
+	<link rel="stylesheet"
+    	href="https://untappd.com/assets/css/tailwind.css?v=2.8.37">
+	</link>
+
+			<link rel="stylesheet" href="https://untappd.com/assets/css/master.min.css?v=4.5.42" />
+		<link rel="stylesheet" href="https://untappd.com/assets/v3/css/style.css?v=4.5.42" />
+		<link rel="stylesheet" href="https://untappd.com/assets/design-system/css/styles.css?v=4.5.42" />
+		<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+		<link href="https://fonts.googleapis.com/css?family=Material+Icons|Material+Icons+Outlined|Material+Icons+Two+Tone|Material+Icons+Round|Material+Icons+Sharp" rel="stylesheet">
+			<script src="https://untappd.com/assets/v3/js/common/min/site_common_min.js?v=2.8.37"></script>
+				<link rel="stylesheet" href="https://untappd.com/assets/css/facybox.min.css?v=4.5.42" />
+			
+		<link rel="stylesheet" href="https://untappd.com/assets/css/jquery.notifyBar.min.css?v=4.5.42" />
+		<link rel="stylesheet" href="https://untappd.com/assets/css/tipsy.min.css?v=4.5.42" type="text/css" media="screen" title="no title" charset="utf-8">
+		
+		<script type="text/javascript" language="Javascript">
+			$(document).ready(function(){
+				$(".tip").tipsy({fade: true});
+				$('.badge_hint').tipsy({gravity: 's', fade: true});
+				$('.disabled').tipsy({gravity: 'n', fade: true});
+
+				refreshTime(".timezoner", "D MMM YY", true);
+
+				$(".tab").click(function(){
+					$(".tab-area li").removeClass('active');
+					$(this).parent().addClass('active');
+					$(".list").hide();
+					$($(this).attr("href")).show();
+					return false;
+				});
+			});
+
+			</script>
+			<!-- For IE -->
+	<script type="text/javascript" language="Javascript">
+	onChangeInterval = "";
+	if(!(window.console && console.log)) {
+	  console = {
+	    log: function(){},
+	    debug: function(){},
+	    info: function(){},
+	    warn: function(){},
+	    error: function(){}
+	  };
+	}
+	</script>
+	
+	<!-- algoliasearch -->
+	<script type="text/javascript" src="https://untappd.com/assets/libs/js/algoliasearch.min.js?v2.8.37"></script>
+	<script type="text/javascript" src="https://untappd.com/assets/libs/js/autocomplete.min.js?v2.8.37"></script>
+	<script type="text/javascript" src="https://untappd.com/assets/libs/js/lodash.min.js?v2.8.37"></script>
+	<script type="text/javascript" src="https://untappd.com/assets/js/global/autosearch_tracking.min.js?v2.8.37"></script>
+
+	<script>
+        !function(e,a,t,n,s,i,c){e.AlgoliaAnalyticsObject=s,e.aa=e.aa||function(){(e.aa.queue=e.aa.queue||[]).push(arguments)},i=a.createElement(t),c=a.getElementsByTagName(t)[0],i.async=1,i.src="https://cdn.jsdelivr.net/npm/search-insights@0.0.14",c.parentNode.insertBefore(i,c)}(window,document,"script",0,"aa");
+
+        // Initialize library
+        aa('init', {
+        applicationID: '9WBO4RQ3HO',
+        apiKey: '1d347324d67ec472bb7132c66aead485',
+        })
+    </script>
+
+
+			<!-- Google Tag Manager -->
+		<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+		new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+		j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+		'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+		})(window,document,'script','dataLayer','GTM-N4DVXTR');</script>
+		<!-- End Google Tag Manager -->
+	
+	<script src="https://untappd.com/assets/v3/js/venue-impression-tracker.js"></script>
+
+	<script type="text/javascript">
+		var clevertap = {event:[], profile:[], account:[], onUserLogin:[], region: 'us1', notifications:[], privacy:[]};
+        clevertap.account.push({"id": "865-K5R-W96Z"});
+        clevertap.privacy.push({optOut: false}); //set the flag to true, if the user of the device opts out of sharing their data
+        clevertap.privacy.push({useIP: true}); //set the flag to true, if the user agrees to share their IP data
+        (function () {
+                var wzrk = document.createElement('script');
+                wzrk.type = 'text/javascript';
+                wzrk.async = true;
+                wzrk.src = ('https:' == document.location.protocol ? 'https://d2r1yp2w7bby2u.cloudfront.net' : 'http://static.clevertap.com') + '/js/clevertap.min.js';
+                var s = document.getElementsByTagName('script')[0];
+                s.parentNode.insertBefore(wzrk, s);
+        })();
+	</script>
+
+    
+<!-- Freestar Ads -->
+<!-- Below is a recommended list of pre-connections, which allow the network to establish each connection quicker, speeding up response times and improving ad performance. -->
+<link rel="preconnect" href="https://a.pub.network/" crossorigin />
+<link rel="preconnect" href="https://b.pub.network/" crossorigin />
+<link rel="preconnect" href="https://c.pub.network/" crossorigin />
+<link rel="preconnect" href="https://d.pub.network/" crossorigin />
+<link rel="preconnect" href="https://c.amazon-adsystem.com" crossorigin />
+<link rel="preconnect" href="https://s.amazon-adsystem.com" crossorigin />
+<link rel="preconnect" href="https://btloader.com/" crossorigin />
+<link rel="preconnect" href="https://api.btloader.com/" crossorigin />
+<link rel="preconnect" href="https://cdn.confiant-integrations.net" crossorigin />
+<!-- Below is a link to a CSS file that accounts for Cumulative Layout Shift, a new Core Web Vitals subset that Google uses to help rank your site in search -->
+<!-- The file is intended to eliminate the layout shifts that are seen when ads load into the page. If you don't want to use this, simply remove this file -->
+<!-- To find out more about CLS, visit https://web.dev/vitals/ -->
+<link rel="stylesheet" href="https://a.pub.network/untappd-com/cls.css">
+<script data-cfasync="false" type="text/javascript">
+    var isLoggedIn = true;
+    console.log("freestar_init", `isLoggedIn: ${isLoggedIn}`);
+
+    var env = 'PROD';
+
+    var freestar = freestar || {};
+    freestar.queue = freestar.queue || [];
+    freestar.queue.push(function () {
+        if (env !== 'PROD') {   
+            googletag.pubads().set('page_url', 'https://untappd.com/'); // Makes ads fill in non-prod environments
+        }
+    });
+    freestar.config = freestar.config || {};
+    if (isLoggedIn) {
+        // https://freestarhelp.zendesk.com/hc/en-us/articles/34516941197460-Disabling-Products
+        freestar.config.disabledProducts = {
+            stickyFooter: true,
+            video: true,
+            stickyRail: true,
+            pushdown: true,
+            dynamicAds: true,
+            sideWall: true,
+            pageGrabber: true,
+            googleInterstitial: true,
+            videoAdhesion: true,
+            iai: true,
+        };  
+    }
+    freestar.config.enabled_slots = [];
+    freestar.initCallback = function () { (freestar.config.enabled_slots.length === 0) ? freestar.initCallbackCalled = false : freestar.newAdSlots(freestar.config.enabled_slots) };
+</script>
+
+
+<script src="https://a.pub.network/untappd-com/pubfig.min.js" data-cfasync="false" async></script>
+<script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js?network-code=15184186" ></script>
+<!-- End Freestar Ads -->
+    <!-- Freestar Ad Sticky Styling: https://resources.freestar.com/docs/sticky-ads-1 -->
+    <style>
+    div.sticky {
+        position: -webkit-sticky; /* Safari */
+        position: sticky;
+        top: 84px; /* Navbar height */
+    }
+    </style>
+
+</head>
+<style type="text/css">
+	.hidden {display: none;}
+	.main {
+       margin-top: 0px !important;
+   }
+</style>
+<script src="https://untappd.com/assets/libs/js/feather-icons@4.29.2.min.js"></script>
+<body onunload="">
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-N4DVXTR" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+<script type="text/javascript">
+		clevertap.event.push("pageview_user");
+	</script>
+
+<script type="text/javascript">
+    $(document).ready(function() {
+        $('a[data-href=":logout"]').on('click', function(event) {
+            clevertap.event.push("logout");
+        });
+        $('a[data-href=":external/help"]').on('click', function(event) {
+            clevertap.event.push("pageview_help");
+        });
+        $('a[data-href=":store"]').on('click', function(event) {
+            clevertap.event.push("pageview_store");
+        });
+        $('a[href="/admin"]').on('click', function(event) {
+          clevertap.event.push("pageview_admin");
+        });
+
+            });
+</script>
+<div id="mobile_nav_user">
+
+         <div class="nav_user_header">
+        <img src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" >
+        <p>Yuriy Silvestrov</p>
+      </div>
+      <ul>
+
+      
+        <li><a class="track-click" data-track="mobile_menu" data-href=":home" href="/home">Recent Activity</a></li>
+        <li><a class="track-click" data-track="mobile_menu" data-href=":user/profile" href="/user/ysilvestrov">My Profile</a></li>
+
+        <li><a class="track-click" data-track="mobile_menu" data-href=":stats" href="/stats">Personal Stats</a></li>
+        
+        <li><a class="track-click" data-track="mobile_menu" data-href=":user/beerhistory" href="/user/ysilvestrov/beers">Beer History</a></li>
+        <li><a href="#">My Events</a></li>
+        <li><a class="track-click" data-track="mobile_menu" data-href=":user/friends" href="/user/ysilvestrov/friends">Friends</a></li>
+        <li><a class="track-click" data-track="mobile_menu" data-href=":user/lists" href="/user/ysilvestrov/lists/">Lists</a></li>
+        <li><a class="track-click" data-track="mobile_menu" data-href=":user/badges" href="/user/ysilvestrov/badges">Badges</a></li>
+        <li><a class="track-click" data-track="mobile_menu" data-href=":user/venues" href="/user/ysilvestrov/venues">Venues</a></li>
+        <li><a class="track-click" data-track="mobile_menu" data-href=":account/settings" href="/account/settings">Account Settings</a></li>
+        <li><a class="track-click" data-track="mobile_menu" data-href=":logout" href="/logout">Logout</a></li>
+
+          </ul>
+    </div>
+
+<div id="mobile_nav_site">
+  <form class="search_box" method="get" action="/search">
+    <input type="text" class="track-focus search-input-desktop" autocomplete="off" data-track="desktop_search" placeholder="Find a drink, brewery or bar..." name="q" aria-label="Find a drink, brewery or bar search" />
+    <input type="submit" value="Submit the form!" style="position: absolute; top: 0; left: 0; z-index: 0; width: 1px; height: 1px; visibility: hidden;" />
+    <div class="autocomplete">
+    </div>
+  </form>
+  <ul>
+    <li><a class="track-click" data-track="mobile_menu" data-href=":blog" href="/blog">Blog</a></li>
+    <li><a class="track-click" data-track="mobile_menu" data-href=":beer/top_rated" href="/beer/top_rated">Top Rated</a></li>
+    <li><a class="track-click" data-track="mobile_menu" data-href=":supporter" href="/supporter">Insiders</a></li>
+    <li><a class="track-click" data-track="mobile_menu" data-href=":external/help" target="_blank" href="http://help.untappd.com">Help</a></li>
+    <li><a class="track-click" data-track="mobile_menu" data-href=":shop" target="_blank" href="https://untappd.com/shop">Shop</a></li>
+          <li><a class="track-click" data-track="mobile_menu" data-href=":sidebar/logout" href="/logout">Logout</a></li>
+        </ul>
+</div>
+<header>
+
+  <div class="inner mt-2">
+
+		<a class="track-click logo" style="margin-top: 2px;" data-track="desktop_header" data-href=":root" href="/">
+			<img src="https://untappd.com/assets/design-system/ut-brand-dark.svg" class="" alt="Untappd"/>
+		</a>
+
+          <div class="user_nav_btn">
+        <div style="position: relative;" >
+          <img  src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="ysilvestrov avatar">
+          <div data-brewery-portal-badge style="position: absolute; top: 0; right: 0; width: 10px; height: 10px; border-radius: 50%; background-color: #ffc000; z-index: 1000; display: none;">
+          </div>
+        </div>
+
+        <div class="nav_user_desktop">
+
+          <ul>
+
+            
+              <li><a class="track-click" data-track="desktop_menu" data-href=":home" href="/home">Recent Activity</a></li>
+              <li><a class="track-click" data-track="desktop_menu" data-href=":user/profile" href="/user/ysilvestrov">My Profile</a></li>
+
+              <li><a class="track-click" data-track="desktop_menu" data-href=":stats" href="/stats">Personal Stats</a></li>
+              
+              <li><a class="track-click" data-track="desktop_menu" data-href=":user/beerhistory" href="/user/ysilvestrov/beers">Beer History</a></li>
+              <li><a class="track-click" data-track="desktop_menu" data-href=":user/friends" href="/user/ysilvestrov/friends">Friends</a></li>
+              <li><a class="track-click" data-track="desktop_menu" data-href=":user/lists" href="/user/ysilvestrov/lists/">Lists</a></li>
+              <li><a class="track-click" data-track="desktop_menu" data-href=":user/badges" href="/user/ysilvestrov/badges">Badges</a></li>
+              <li><a class="track-click" data-track="desktop_menu" data-href=":user/venues" href="/user/ysilvestrov/venues">Venues</a></li>
+              <li><a class="track-click" data-track="desktop_menu" data-href=":account/settings" href="/account/settings">Account Settings</a></li>
+              <li><a class="track-click" data-track="desktop_menu" data-href=":logout" href="/logout">Logout</a></li>
+
+            
+          </ul>
+        </div>
+
+      </div>
+    
+    <div class="mobile_menu_btn">Menu</div>
+
+    <div id="nav_site">
+      <ul>
+        <li><a class="track-click" data-track="desktop_menu" data-href=":blog" href="/blog">Blog</a></li>
+        <li><a class="track-click" data-track="desktop_menu" data-href=":beer/top_rated" href="/beer/top_rated">Top Rated</a></li>
+        <li><a class="track-click" data-track="desktop_menu" data-href=":supporter" href="/supporter">Insiders</a></li>
+        <li><a class="track-click" data-track="desktop_menu" data-href=":external/help" target="_blank" href="http://help.untappd.com">Help</a></li>
+        <li><a class="track-click" data-track="desktop_menu" data-href=":shop" target="_blank" href="https://untappd.com/shop">Shop</a></li>
+      </ul>
+      <form class="search_box" method="get" action="/search">
+        <input type="text" class="track-focus search-input-desktop" autocomplete="off" data-track="desktop_search" placeholder="Find a drink, brewery or bar..." name="q" aria-label="Find a drink, brewery or bar search" />
+        <input type="submit" value="Submit the form!" style="position: absolute; top: 0; left: 0; z-index: 0; width: 1px; height: 1px; visibility: hidden;" />
+        <div class="autocomplete">
+        </div>
+      </form>
+    </div>
+    </div>
+</header>
+<style type="text/css">
+    .ac-selected {
+        background-color: #f8f8f8;
+    }
+</style>
+
+<div class="nav_open_overlay"></div>
+<div id="slide">
+
+<script>
+$(document).ready(() => {
+	$(".hide-notice-banner").on("click", function(e) {
+		e.preventDefault();
+		$(this).parent().parent().slideUp();
+		$.post(`/account/hide_notice_wildcard`, {cookie: $(this).attr('data-cookie-name')}, (data) => {
+			console.log(data);
+		}).fail((err) => {
+			console.error(err);
+		})
+	})
+
+	$(".hide-notice-simple").on("click", function(e) {
+		e.preventDefault();
+		$(this).parent().parent().slideUp();
+	})
+
+	feather.replace()
+})
+</script>
+
+<div class="cont user_profile">
+
+	<div class="profile_header" style="background-image: url('https://assets.untappd.com/site/assets/v3/images/cover_default.jpg'); background-position: center -0px" data-offset="0" data-image-url="https://assets.untappd.com/site/assets/v3/images/cover_default.jpg">
+
+		<div class="profile_header_loader">
+				<div id="floatingCirclesG">
+				  <div class="f_circleG" id="frotateG_01"></div>
+				  <div class="f_circleG" id="frotateG_02"></div>
+				  <div class="f_circleG" id="frotateG_03"></div>
+				  <div class="f_circleG" id="frotateG_04"></div>
+				  <div class="f_circleG" id="frotateG_05"></div>
+				  <div class="f_circleG" id="frotateG_06"></div>
+				  <div class="f_circleG" id="frotateG_07"></div>
+				  <div class="f_circleG" id="frotateG_08"></div>
+				</div>
+			</div>
+			<form id="coverPostionForm" style="display: none;">
+				<input type="hidden" name="offset" id="offset_cover">
+			</form>
+
+			<img class="cover_move" id="cover_photo_move" style="display: none;" src="https://assets.untappd.com/site/assets/v3/images/cover_default.jpg"/>
+
+			<div class="save-btn" style="display: none;">
+    		<a href="#" class="cancel-cover button grey track-click" data-track="profile" data-href=":coverphoto/cancelFinal">Cancel</a>
+    		<a href="#" class="save-cover button yellow track-click" data-track="profile" data-href=":coverphoto/saveFinal">Save Changes</a>
+ 			</div>
+			
+		<div class="content">
+							<form id="myFileForm" enctype="multipart/form-data">
+					<input type="file" id="fileInput" name="file" />
+				</form>
+				<div class="edit-cover">
+					<div class="edit-cover-holder">
+						<a class="edit-cover-image   track-click" data-track="profile" data-href=":coverphoto/change" href="#">Change</a><a class="adjust-cover-image track-click" data-track="profile" data-href=":coverphoto/adjust" href="#">Adjust</a><a class="remove-cover-image track-click" data-track="profile" data-href=":coverphoto/remove" href="#">Remove</a>
+					</div>
+				</div>
+
+				
+
+			<div class="user-info">
+				<div class="user-avatar">
+											<a href="/insiders" class="track-click" data-track="profile" data-href=":info/supporter" aria-label="insider"><span class="supporter"></span></a>
+											<div class="avatar-holder">
+						<img src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=125&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="User avatar">
+					</div>
+				</div><div class="info">
+					<h1>
+						Yuriy Silvestrov					</h1>
+					<div class="user-details">
+					<p class="username">ysilvestrov</p>
+						<p class="location">Warsaw</p>						<div class="social">
+																<p>
+										<a class="sq track-click" target="_blank" data-track="profile" data-href=":foursquare" href="https://foursquare.com/user/580666072">Foursquare</a>
+									</p>
+															</div>
+					</div>
+
+					<div class="stats">
+													<a href="/user/ysilvestrov" class="track-click" data-track="profile" data-href=":stats/general">
+								<span class="stat">12,407</span>
+								<span class="title">Total</span>
+							</a><a href="/user/ysilvestrov/beers" class="track-click" data-track="profile" data-href=":stats/beerhistory">
+								<span class="stat">11,548</span>
+								<span class="title">Unique</span>
+							</a><a href="/user/ysilvestrov/badges" class="track-click" data-track="profile" data-href=":stats/badges">
+								<span class="stat">6,678</span>
+								<span class="title">Badges</span>
+							</a><a href="/user/ysilvestrov/friends" class="track-click" data-track="profile" data-href=":stats/friends">
+								<span class="stat">154</span>
+								<span class="title">Friends</span>
+							</a>
+							
+					</div>
+
+					<div class="friend-button">
+
+						
+											</div>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	
+		<div class="profile_left">
+
+								<div class="photo-boxes">
+						<p><a href="/user/ysilvestrov/checkin/1578245453"><img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_15/126c53d3bf17347be7836822c4de38b0_c_1578245453_raw.jpg" alt="Recent check-in photo 1" /></a></p><p><a href="/user/ysilvestrov/checkin/1578231855"><img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_15/fac2c1b1706634e5cb1d730db6830669_c_1578231855_raw.jpg" alt="Recent check-in photo 2" /></a></p><p><a href="/user/ysilvestrov/checkin/1578224019"><img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_15/f1823729bfb0fbfbbe843cb0612db085_c_1578224019_raw.jpg" alt="Recent check-in photo 3" /></a></p><p><a href="/user/ysilvestrov/checkin/1578218159"><img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_15/f171035bfd107ba8b0f33b1d257743cd_c_1578218159_raw.jpg" alt="Recent check-in photo 4" /></a></p><p><a href="/user/ysilvestrov/photos"><span class="all">See All</span><img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_13/344ab989416b81a376620d8880420bab_c_1577501144_raw.jpg" alt="See all photos"></a></p>					</div>
+					
+			<div class="activity box">
+
+				<div class="content">
+												<h3>Your Recent Activity</h3>
+												<div id="main-stream">
+						
+			<div class="item " id="checkin_1578245453" data-checkin-id="1578245453">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/pohjala-emberwood/6421621" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6421621_b50b1_sm.jpeg" alt="Emberwood by Põhjala">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-9448532-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking an <a href="/b/pohjala-emberwood/6421621">Emberwood</a> by <a  href="/Pohjala">Põhjala</a> at <a href="/v/os-gorczewska-200/9448532">Os. Górczewska 200</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1578245453">
+									Чоколяда, копчене, смачне									</p>
+
+									
+								<p class="purchased" data-track-venue-impression="venue_id-12250363-type-checkin_feed">Purchased at <a href="/v/onemorebeer/12250363">OneMoreBeer</a></p>									<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/bottle@3x.png" alt="Bottle">
+										          <span>Bottle</span>
+										        </p>
+												<div class="caps " data-rating="4.5">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-50"></div>
+	</div>								    </div>
+									
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/esodin">
+																	<img src="https://assets.untappd.com/profile/e05c5d9aa3ed082e8354ab144e716a96_100x100.jpg" alt="Eugene Sodin avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/AlexFavorov">
+																	<img src="https://assets.untappd.com/profile/db287f406553168adbdc3a5e961b24e5_100x100.jpg" alt="Alex Favorov avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/eastern_european_beergeek">
+																	<img src="https://assets.untappd.com/profile/1fdf28d5abe5fb2af5d7d227f7d611da_100x100.jpg" alt="Eastern European Beergeek  avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1578245453" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_15/126c53d3bf17347be7836822c4de38b0_c_1578245453_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1578245453">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1578245453" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1578245453" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Mon, 15 Jun 2026 19:25:26 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1578245453" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1578245453">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>2</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="Astro-nat" href="/user/Astro-nat" title="Natali Astrowska" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/90a720216262d00799c526b254f7f2bb_100x100.jpg" alt="Natali Astrowska avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="Helen_Holyf" href="/user/Helen_Holyf" title="Helen Holyf" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/7bcac31154c0e22bdb36b6bfc9c5489d_100x100.jpg" alt="Helen Holyf avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1578245453" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1578245453" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1578245453'),$('#commentForm_1578245453 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1578245453" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1578245453" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1578231855" data-checkin-id="1578231855">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/coopers-best-extra-stout/4933" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-4933_c8252_sm.jpeg" alt="Best Extra Stout by Coopers">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-9448532-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/coopers-best-extra-stout/4933">Best Extra Stout</a> by <a  href="/CoopersBrewery">Coopers</a> at <a href="/v/os-gorczewska-200/9448532">Os. Górczewska 200</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1578231855">
+									Чоколяда, гірке, пересмажений солод, кислинка. Дивне									</p>
+
+																					<p class="comment-text-orginial" id="translateorg_1578231855" style="display: none;"></p>
+												<div class="translate"><a href="#" class="translate-text" data-checkin-id="1578231855">Translate</a></div>
+												
+								<p class="purchased" data-track-venue-impression="venue_id-5770655-type-checkin_feed">Purchased at <a href="/v/auchan/5770655">Auchan</a></p>									<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/bottle@3x.png" alt="Bottle">
+										          <span>Bottle</span>
+										        </p>
+												<div class="caps " data-rating="3.5">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-50"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+																			<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/promo/4434d775ba_UTC-WorldPint-Badges-01_2.png" alt="World Pint 2026: Australia">
+											<span>Earned the World Pint 2026: Australia badge!</span>
+										</span>
+										
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/AlexFavorov">
+																	<img src="https://assets.untappd.com/profile/db287f406553168adbdc3a5e961b24e5_100x100.jpg" alt="Alex Favorov avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/JurgenChe">
+																	<img src="https://assets.untappd.com/profile/1b6fb9917d398a52b6078f2f2ca46ed1_100x100.png" alt="Yurii Chetverykov avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/annaklym">
+																	<img src="https://assets.untappd.com/profile/57ee93afe7e46d0211bcd0be2dba073f_100x100.jpg" alt="Анна Клименко avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/esodin">
+																	<img src="https://assets.untappd.com/profile/e05c5d9aa3ed082e8354ab144e716a96_100x100.jpg" alt="Eugene Sodin avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/eastern_european_beergeek">
+																	<img src="https://assets.untappd.com/profile/1fdf28d5abe5fb2af5d7d227f7d611da_100x100.jpg" alt="Eastern European Beergeek  avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1578231855" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_15/fac2c1b1706634e5cb1d730db6830669_c_1578231855_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1578231855">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1578231855" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1578231855" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Mon, 15 Jun 2026 18:19:33 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1578231855" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1578231855">Delete Check-In</a>						</div>
+
+						<div class="cheers" style="display: none;">								<span class="count"><span>0</span></span>
+								<span class="toast-list"></span>
+														</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1578231855" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1578231855" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1578231855'),$('#commentForm_1578231855 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1578231855" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1578231855" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1578224019" data-checkin-id="1578224019">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/saku-olletehas-karl-friedrich-kali-kirss/6214005" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6214005_b4baf_sm.jpeg" alt="Karl Friedrich Kali Kirss by Saku Õlletehas">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-9448532-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/saku-olletehas-karl-friedrich-kali-kirss/6214005">Karl Friedrich Kali Kirss</a> by <a  href="/w/saku-olletehas/1094">Saku Õlletehas</a> at <a href="/v/os-gorczewska-200/9448532">Os. Górczewska 200</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1578224019">
+									Химозна вишня, солодке, та й таке									</p>
+
+									
+								<p class="purchased" data-track-venue-impression="venue_id-5770655-type-checkin_feed">Purchased at <a href="/v/auchan/5770655">Auchan</a></p>									<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/can@3x.png" alt="Can">
+										          <span>Can</span>
+										        </p>
+												<div class="caps " data-rating="3.5">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-50"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+																			<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/badges/bdg_KvassRyeot_2020_sm.jpg" alt="Kvass RYEot (Level 14)">
+											<span>Earned the Kvass RYEot (Level 14) badge!</span>
+										</span>
+										
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/eastern_european_beergeek">
+																	<img src="https://assets.untappd.com/profile/1fdf28d5abe5fb2af5d7d227f7d611da_100x100.jpg" alt="Eastern European Beergeek  avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/esodin">
+																	<img src="https://assets.untappd.com/profile/e05c5d9aa3ed082e8354ab144e716a96_100x100.jpg" alt="Eugene Sodin avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/AlexFavorov">
+																	<img src="https://assets.untappd.com/profile/db287f406553168adbdc3a5e961b24e5_100x100.jpg" alt="Alex Favorov avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/JurgenChe">
+																	<img src="https://assets.untappd.com/profile/1b6fb9917d398a52b6078f2f2ca46ed1_100x100.png" alt="Yurii Chetverykov avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/annaklym">
+																	<img src="https://assets.untappd.com/profile/57ee93afe7e46d0211bcd0be2dba073f_100x100.jpg" alt="Анна Клименко avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1578224019" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_15/f1823729bfb0fbfbbe843cb0612db085_c_1578224019_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1578224019">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1578224019" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1578224019" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Mon, 15 Jun 2026 17:37:29 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1578224019" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1578224019">Delete Check-In</a>						</div>
+
+						<div class="cheers" style="display: none;">								<span class="count"><span>0</span></span>
+								<span class="toast-list"></span>
+														</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1578224019" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1578224019" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1578224019'),$('#commentForm_1578224019 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1578224019" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1578224019" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1578218159" data-checkin-id="1578218159">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/moon-lark-brewery-non-alcoholic-czech-pils-nealko-5-deg-extra-horka/6647823" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6647823_0b37a_sm.jpeg" alt="Non-Alcoholic Czech Pils / Nealko 5° Extra Hořká by Moon Lark Brewery">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-9448532-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/moon-lark-brewery-non-alcoholic-czech-pils-nealko-5-deg-extra-horka/6647823">Non-Alcoholic Czech Pils / Nealko 5° Extra Hořká</a> by <a  href="/MoonLarkBrewery">Moon Lark Brewery</a> at <a href="/v/os-gorczewska-200/9448532">Os. Górczewska 200</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1578218159">
+									Гарна безалко									</p>
+
+									
+								<p class="purchased" data-track-venue-impression="venue_id-12963055-type-checkin_feed">Purchased at <a href="/v/kaufland/12963055">Kaufland</a></p>									<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/bottle@3x.png" alt="Bottle">
+										          <span>Bottle</span>
+										        </p>
+												<div class="caps " data-rating="4">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+																			<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/badges/bdg_LagerJack_sm.jpg" alt="Lager Jack (Level 57)">
+											<span>Earned the Lager Jack (Level 57) badge!</span>
+										</span>
+										
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/esodin">
+																	<img src="https://assets.untappd.com/profile/e05c5d9aa3ed082e8354ab144e716a96_100x100.jpg" alt="Eugene Sodin avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/AlexFavorov">
+																	<img src="https://assets.untappd.com/profile/db287f406553168adbdc3a5e961b24e5_100x100.jpg" alt="Alex Favorov avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/JurgenChe">
+																	<img src="https://assets.untappd.com/profile/1b6fb9917d398a52b6078f2f2ca46ed1_100x100.png" alt="Yurii Chetverykov avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/eastern_european_beergeek">
+																	<img src="https://assets.untappd.com/profile/1fdf28d5abe5fb2af5d7d227f7d611da_100x100.jpg" alt="Eastern European Beergeek  avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1578218159" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_15/f171035bfd107ba8b0f33b1d257743cd_c_1578218159_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1578218159">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1578218159" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1578218159" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Mon, 15 Jun 2026 17:06:26 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1578218159" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1578218159">Delete Check-In</a>						</div>
+
+						<div class="cheers" style="display: none;">								<span class="count"><span>0</span></span>
+								<span class="toast-list"></span>
+														</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1578218159" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1578218159" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1578218159'),$('#commentForm_1578218159 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1578218159" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1578218159" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1577501144" data-checkin-id="1577501144">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/palatum-hazy-ipa-mbc/5423687" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/brewery_logos/brewery-270446_8b440.jpeg" alt="Hazy IPA (MBC) by Palatum">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-12359853-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/palatum-hazy-ipa-mbc/5423687">Hazy IPA (MBC)</a> by <a  href="/BrowarPalatum">Palatum</a> at <a href="/v/willa-ogrodnikow/12359853">Willa Ogrodników</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1577501144">
+									Охмілене, гірке, соковите, доволі смачно									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/draft@3x.png" alt="Draft">
+										          <span>Draft</span>
+										        </p>
+												<div class="caps " data-rating="4.2">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-20"></div>
+	</div>								    </div>
+									
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1577501144" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_13/344ab989416b81a376620d8880420bab_c_1577501144_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1577501144">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1577501144" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1577501144" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Sat, 13 Jun 2026 12:06:44 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1577501144" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1577501144">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>1</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1577501144" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1577501144" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1577501144'),$('#commentForm_1577501144 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1577501144" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1577501144" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1577350490" data-checkin-id="1577350490">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/seoul-brewery-disco-bong-bong-rye-fruit-sour/6599426" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6599426_55fd7_sm.jpeg" alt="DISCO BONG BONG RYE FRUIT SOUR by 서울브루어리ㅣSEOUL BREWERY">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-10592162-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/seoul-brewery-disco-bong-bong-rye-fruit-sour/6599426">DISCO BONG BONG RYE FRUIT SOUR</a> by <a  href="/SeoulBrewery">서울브루어리ㅣSEOUL BREWERY</a> at <a href="/v/pinta-warszawa-craft-beer-food/10592162">PINTA Warszawa Craft Beer & Food</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1577350490">
+									Норм кислячок									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/draft@3x.png" alt="Draft">
+										          <span>Draft</span>
+										        </p>
+												<div class="caps " data-rating="3.8">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-80"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+																			<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/promo/dacc277d2e_SOUTH-KOREA-UTC-WorldPint-Badges-07.png" alt="World Pint 2026: South Korea">
+											<span>Earned the World Pint 2026: South Korea badge!</span>
+										</span>
+										
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/Black_mzfk">
+																	<img src="https://assets.untappd.com/profile/c48718cf62242ead68e5309884791628_100x100.jpg" alt="Mykola Bortnychuk avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1577350490" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_12/3adb415e6c9466da3dfcee8c4900b04a_c_1577350490_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1577350490">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1577350490" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1577350490" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Fri, 12 Jun 2026 21:23:39 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1577350490" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1577350490">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>2</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="nyakove" href="/user/nyakove" title="Mykhailo Dykun" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/6d3ba80291124794db1a990f33237fb0_100x100.jpg" alt="Mykhailo Dykun avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1577350490" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1577350490" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1577350490'),$('#commentForm_1577350490 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1577350490" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1577350490" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1577349937" data-checkin-id="1577349937">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/nepo-brewing-top-tier/6748324" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/brewery_logos/brewery-192779_0e99d.jpeg" alt="Top-tier by Nepo Brewing">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-10592162-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/nepo-brewing-top-tier/6748324">Top-tier</a> by <a  href="/BrowarNepomucen">Nepo Brewing</a> at <a href="/v/pinta-warszawa-craft-beer-food/10592162">PINTA Warszawa Craft Beer & Food</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1577349937">
+									Норм іпашка									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/draft@3x.png" alt="Draft">
+										          <span>Draft</span>
+										        </p>
+												<div class="caps " data-rating="4.2">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-20"></div>
+	</div>								    </div>
+									
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/Black_mzfk">
+																	<img src="https://assets.untappd.com/profile/c48718cf62242ead68e5309884791628_100x100.jpg" alt="Mykola Bortnychuk avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1577349937" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_12/5550c4bc16249c8d37ffd851c479f752_c_1577349937_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1577349937">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1577349937" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1577349937" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Fri, 12 Jun 2026 21:22:25 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1577349937" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1577349937">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>2</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="Nesh05" href="/user/Nesh05" title="Oleksandr Bogachov" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/108d6fb78e50a061b264b0578e51caed_100x100.jpg" alt="Oleksandr Bogachov avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1577349937" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1577349937" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1577349937'),$('#commentForm_1577349937 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1577349937" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1577349937" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1577333058" data-checkin-id="1577333058">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/pinta-barrel-brewing-patience-5th-anniversary-2026/6655583" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6655583_88c2e_sm.jpeg" alt="Patience 5th Anniversary (2026) by PINTA Barrel Brewing">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-11769928-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/pinta-barrel-brewing-patience-5th-anniversary-2026/6655583">Patience 5th Anniversary (2026)</a> by <a  href="/PINTABarrelBrewing">PINTA Barrel Brewing</a> at <a href="/v/hopito-chmielna/11769928">Hopito Chmielna</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1577333058">
+									Вме ще топ									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/bottle@3x.png" alt="Bottle">
+										          <span>Bottle</span>
+										        </p>
+												<div class="caps " data-rating="4.9">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-90"></div>
+	</div>								    </div>
+									
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Connoisseur">
+																	<img src="https://assets.untappd.com/profile/4a2ca4a782c24e072988b781352672c4_100x100.jpeg" alt="Victor  avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/Black_mzfk">
+																	<img src="https://assets.untappd.com/profile/c48718cf62242ead68e5309884791628_100x100.jpg" alt="Mykola Bortnychuk avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1577333058" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_12/88ee0d631a83acccf5b0d7b989128dc7_c_1577333058_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1577333058">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1577333058" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1577333058" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Fri, 12 Jun 2026 20:46:34 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1577333058" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1577333058">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>3</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="Nesh05" href="/user/Nesh05" title="Oleksandr Bogachov" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/108d6fb78e50a061b264b0578e51caed_100x100.jpg" alt="Oleksandr Bogachov avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="svitlanalana" href="/user/svitlanalana" title="Lana" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/ba31a55574f315078a68d2e6077353c8_100x100.jpg" alt="Lana avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1577333058" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1577333058" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1577333058'),$('#commentForm_1577333058 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1577333058" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1577333058" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1577329184" data-checkin-id="1577329184">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/sadyba-dropsy/6533724" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6533724_6a208_sm.jpeg" alt="Dropsy by Sadyba">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-11769928-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/sadyba-dropsy/6533724">Dropsy</a> by <a  href="/w/sadyba/581444">Sadyba</a> at <a href="/v/hopito-chmielna/11769928">Hopito Chmielna</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1577329184">
+									Наче норм									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/draft@3x.png" alt="Draft">
+										          <span>Draft</span>
+										        </p>
+												<div class="caps " data-rating="3.9">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-90"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+									
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/Black_mzfk">
+																	<img src="https://assets.untappd.com/profile/c48718cf62242ead68e5309884791628_100x100.jpg" alt="Mykola Bortnychuk avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Connoisseur">
+																	<img src="https://assets.untappd.com/profile/4a2ca4a782c24e072988b781352672c4_100x100.jpeg" alt="Victor  avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1577329184" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_12/a99db013b2459429a1ae0c4a27504eb7_c_1577329184_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1577329184">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1577329184" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1577329184" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Fri, 12 Jun 2026 20:38:55 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1577329184" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1577329184">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>1</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1577329184" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1577329184" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1577329184'),$('#commentForm_1577329184 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1577329184" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1577329184" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1577315325" data-checkin-id="1577315325">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/carlsberg-ukraine-lvivske-porter-lvivske-porter/17427" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-17427_d4f82_sm.jpeg" alt="Lvivske Porter (Львівське Портер) by Carlsberg Ukraine">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-11769928-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/carlsberg-ukraine-lvivske-porter-lvivske-porter/17427">Lvivske Porter (Львівське Портер)</a> by <a  href="/w/carlsberg-ukraine/4697">Carlsberg Ukraine</a> at <a href="/v/hopito-chmielna/11769928">Hopito Chmielna</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1577315325">
+									Бочеовий варіант. Дуже смачно насправді									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/bottle@3x.png" alt="Bottle">
+										          <span>Bottle</span>
+										        </p>
+												<div class="caps " data-rating="4">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+																			<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/badges/bdg_SupportforUkraine_sm.jpg" alt="Support for Ukraine (Level 96)">
+											<span>Earned the Support for Ukraine (Level 96) badge!</span>
+										</span>
+										
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Connoisseur">
+																	<img src="https://assets.untappd.com/profile/4a2ca4a782c24e072988b781352672c4_100x100.jpeg" alt="Victor  avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/Black_mzfk">
+																	<img src="https://assets.untappd.com/profile/c48718cf62242ead68e5309884791628_100x100.jpg" alt="Mykola Bortnychuk avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1577315325" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_12/da71586c2d556302d3067372bfea1dc1_c_1577315325_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1577315325">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1577315325" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1577315325" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Fri, 12 Jun 2026 20:14:08 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1577315325" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1577315325">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>3</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="ozerova" href="/user/ozerova" title="Alona Ozerova" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/32b6ee38b32a094a267bb390cbfc86cb_100x100.jpg" alt="Alona Ozerova avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="nyakove" href="/user/nyakove" title="Mykhailo Dykun" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/6d3ba80291124794db1a990f33237fb0_100x100.jpg" alt="Mykhailo Dykun avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1577315325" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1577315325" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1577315325'),$('#commentForm_1577315325 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1577315325" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1577315325" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1577305648" data-checkin-id="1577305648">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/browar-stu-mostow-green-fury/6671151" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6671151_d09f2_sm.jpeg" alt="Green Fury by Browar Stu Mostów">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-11769928-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/browar-stu-mostow-green-fury/6671151">Green Fury</a> by <a  href="/BrowarStuMostow">Browar Stu Mostów</a> at <a href="/v/hopito-chmielna/11769928">Hopito Chmielna</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1577305648">
+									Йолка, тіло, смачно									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/draft@3x.png" alt="Draft">
+										          <span>Draft</span>
+										        </p>
+												<div class="caps " data-rating="4.1">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-10"></div>
+	</div>								    </div>
+									
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/Black_mzfk">
+																	<img src="https://assets.untappd.com/profile/c48718cf62242ead68e5309884791628_100x100.jpg" alt="Mykola Bortnychuk avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Connoisseur">
+																	<img src="https://assets.untappd.com/profile/4a2ca4a782c24e072988b781352672c4_100x100.jpeg" alt="Victor  avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1577305648" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_12/354fda89bb32e000ef77856793f8c8b1_c_1577305648_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1577305648">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1577305648" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1577305648" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Fri, 12 Jun 2026 19:57:17 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1577305648" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1577305648">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>1</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1577305648" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1577305648" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1577305648'),$('#commentForm_1577305648 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1577305648" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1577305648" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1577302563" data-checkin-id="1577302563">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/cydr-chyliczki-stary-sad-2023/5828405" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/brewery_logos/brewery-271740_52802.jpeg" alt="Stary Sad 2023 by Cydr Chyliczki">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-11769928-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/cydr-chyliczki-stary-sad-2023/5828405">Stary Sad 2023</a> by <a  href="/CydrChyliczki">Cydr Chyliczki</a> at <a href="/v/hopito-chmielna/11769928">Hopito Chmielna</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1577302563">
+									Наче норм									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/draft@3x.png" alt="Draft">
+										          <span>Draft</span>
+										        </p>
+												<div class="caps " data-rating="4">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+									
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/Black_mzfk">
+																	<img src="https://assets.untappd.com/profile/c48718cf62242ead68e5309884791628_100x100.jpg" alt="Mykola Bortnychuk avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Connoisseur">
+																	<img src="https://assets.untappd.com/profile/4a2ca4a782c24e072988b781352672c4_100x100.jpeg" alt="Victor  avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1577302563" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_12/374237dbbdc305f2d788985179b70b2f_c_1577302563_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1577302563">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1577302563" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1577302563" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Fri, 12 Jun 2026 19:51:45 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1577302563" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1577302563">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>1</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1577302563" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1577302563" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1577302563'),$('#commentForm_1577302563 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1577302563" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1577302563" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1577255517" data-checkin-id="1577255517">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/white-crow-brew-dept-la-tomatina-originale-vol-3/6584367" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6584367_30aa6_sm.jpeg" alt="La Tomatina Originale vol.3 by White Crow Brew Dept ">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-12617758-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/white-crow-brew-dept-la-tomatina-originale-vol-3/6584367">La Tomatina Originale vol.3</a> by <a  href="/WhiteCrowBrewDivision">White Crow Brew Dept </a> at <a href="/v/white-crow-craft-beer-and-kitchen/12617758">White Crow Craft Beer & Kitchen</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1577255517">
+									Гостре, смачне									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/taster@3x.png" alt="Taster">
+										          <span>Taster</span>
+										        </p>
+												<div class="caps " data-rating="4.6">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-60"></div>
+	</div>								    </div>
+									
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Connoisseur">
+																	<img src="https://assets.untappd.com/profile/4a2ca4a782c24e072988b781352672c4_100x100.jpeg" alt="Victor  avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1577255517" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_12/21df86329a0aae70df34f296406dec98_c_1577255517_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1577255517">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1577255517" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1577255517" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Fri, 12 Jun 2026 18:30:34 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1577255517" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1577255517">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>1</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1577255517" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1577255517" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1577255517'),$('#commentForm_1577255517 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1577255517" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1577255517" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1577247607" data-checkin-id="1577247607">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/funky-fluid-funky-on-tour-islay/6728427" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6728427_cdd3e_sm.jpeg" alt="Funky On Tour: Islay by Funky Fluid">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-12767316-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/funky-fluid-funky-on-tour-islay/6728427">Funky On Tour: Islay</a> by <a  href="/FunkyFluid">Funky Fluid</a> at <a href="/v/offside/12767316">Offside</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1577247607">
+									Дуже норм peated. 0.25 на бурбонову версію									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/can@3x.png" alt="Can">
+										          <span>Can</span>
+										        </p>
+												<div class="caps " data-rating="4.5">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-50"></div>
+	</div>								    </div>
+																			<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/badges/aae45250bb4d36b264f1165ab0a6d94c_sm.jpeg" alt="White Guard LvL2 (Level 32)">
+											<span>Earned the White Guard LvL2 (Level 32) badge!</span>
+										</span>
+										
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/Black_mzfk">
+																	<img src="https://assets.untappd.com/profile/c48718cf62242ead68e5309884791628_100x100.jpg" alt="Mykola Bortnychuk avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Connoisseur">
+																	<img src="https://assets.untappd.com/profile/4a2ca4a782c24e072988b781352672c4_100x100.jpeg" alt="Victor  avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1577247607" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_12/9c64c7326557f31a3089bbd221b6689f_c_1577247607_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1577247607">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1577247607" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1577247607" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Fri, 12 Jun 2026 18:15:33 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1577247607" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1577247607">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>1</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1577247607" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1577247607" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1577247607'),$('#commentForm_1577247607 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1577247607" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1577247607" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1577238079" data-checkin-id="1577238079">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/fuerst-wiacek-berlin-cool-jumper/6728184" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/brewery_logos/brewery-314016_5eba0.jpeg" alt="Cool Jumper by FUERST WIACEK Berlin">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-12617758-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/fuerst-wiacek-berlin-cool-jumper/6728184">Cool Jumper</a> by <a  href="/fuerstwiacekbrew">FUERST WIACEK Berlin</a> at <a href="/v/white-crow-craft-beer-and-kitchen/12617758">White Crow Craft Beer & Kitchen</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1577238079">
+									Кисленьке									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/taster@3x.png" alt="Taster">
+										          <span>Taster</span>
+										        </p>
+												<div class="caps " data-rating="3.7">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-70"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+																			<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/badges/bdg_DasBoot16_sm.jpg" alt="Das Boot (Level 72)">
+											<span>Earned the Das Boot (Level 72) badge!</span>
+										</span>
+										
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Connoisseur">
+																	<img src="https://assets.untappd.com/profile/4a2ca4a782c24e072988b781352672c4_100x100.jpeg" alt="Victor  avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/Black_mzfk">
+																	<img src="https://assets.untappd.com/profile/c48718cf62242ead68e5309884791628_100x100.jpg" alt="Mykola Bortnychuk avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1577238079" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_12/5205f868da62cc102719b2544f8a6025_c_1577238079_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1577238079">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1577238079" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1577238079" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Fri, 12 Jun 2026 17:57:01 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1577238079" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1577238079">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>2</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="ozerova" href="/user/ozerova" title="Alona Ozerova" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/32b6ee38b32a094a267bb390cbfc86cb_100x100.jpg" alt="Alona Ozerova avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1577238079" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1577238079" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1577238079'),$('#commentForm_1577238079 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1577238079" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1577238079" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+						<script type="text/javascript" src="https://untappd.com/assets/v3/js/common/min/feed_scripts_min.js?v=2.8.37"></script>
+			<style type="text/css">
+				.translate {
+					color: #000;
+				    font-weight: 600;
+				    font-size: 12px;
+				    text-transform: uppercase;
+				    margin-bottom: 0px;
+				    margin-top: 15px;
+				    margin-bottom: 10px;
+				}
+			</style>
+								<script type="text/javascript">
+						$(document).on("click", ".translate-text", function() {
+							const _this = this;
+
+							const checkinId = $(_this).attr("data-checkin-id");
+
+							if ($(_this).text() == "See Original") {
+								$(_this).html("Translate");
+								const orgText = $(`#translateorg_${checkinId}`).html();
+								$(`#translate_${checkinId}`).html(orgText);
+								$(`#translateorg_${checkinId}`).html('');
+							} else {
+								const orgText = $(`#translate_${checkinId}`).html();
+								$(`#translateorg_${checkinId}`).html(orgText);
+
+								$(_this).attr("disabled", "true");
+		   						$(_this).html("Loading....");
+
+		   						$.ajax({
+									url: `/apireqs/translate/${checkinId}`,
+									type: "GET",
+									dataType: "json",
+									headers: {
+									    'Accept': 'application/json',
+									    'Accept-Language': navigator.language
+									},
+								    error: function(html)
+									{
+										$(_this).attr("disabled", "false");
+						   				$(_this).html("Translate");
+
+										var tct = "Something went horribly wrong. Please refresh the page and try again.";
+
+										$.notifyBar({
+											html: tct,
+											delay: 2000,
+											animationSpeed: "normal"
+										  })
+									},
+									success: function(html)
+									{
+										if (!html.error) {
+											$(_this).attr("disabled", "false");
+						   					$(_this).html("See Original");
+											$(`#translate_${checkinId}`).html(html.data.translated_text);
+										} else {
+
+											$(_this).attr("disabled", "false");
+						   					$(_this).html("Translate");
+
+											$.notifyBar({
+												html: html.error,
+												delay: 2000,
+												animationSpeed: "normal"
+										  })
+										}
+									}
+								});
+							}
+
+							return false;
+						})
+					</script>
+					
+			<script id="delete-checkin-container" type="text/x-handlebars-template">
+				<div class="delete-confirm-checkin"></div>
+			</script>
+			<script id="delete-checkin-template" type="text/x-handlebars-template">
+				<div class="modal delete-confirm"><div class="inner"><div class="top"><a class="close" href="#"></a><h3 style="margin-bottom: 0px; padding-bottom: 0px; border-bottom: none;">Confirm Check-in Deletion</h3></div><div class="error" id="delete-checkin-error" style="display: none;"></div><div class="delete-confirm-message" style="padding: 24px; text-align: center; -moz-box-sizing: border-box; box-sizing: border-box;"><p><strong>Warning</strong> - Are you sure you want to delete this check-in? This cannot be undone. All badges that are associated with this check-in will be removed.</p><div class="inner-container" style="width: 80%; margin: 15px auto;"><a href="#" class="check-confirm-deletion" data-checkin-id="{{checkin_id}}" style="margin-top: 15px;">Confirm Deletion</a><p id="checkin-delete-loader" class="stream-loading"><span></span></p></div></div></div></div>
+			</script>
+			<script id="comment-template" type="text/x-handlebars-template">
+				{{#each items}}<div class="comment" id="comment_{{this.comment_id}}"><div class="avatar"><div class="avatar-holder">{{#if this.user.supporter}} <span class="supporter"></span>{{/if}}<a href="/user/{{this.user.user_name}}"><img src="{{this.user.user_avatar}}" alt="Your Avatar"></a></div></div><div class="text"><p><a href="/user/{{this.user.user_name}}">{{this.user.first_name}} {{this.user.last_name}}</a>: <abbr id="checkincomment_{{this.comment_id}}">{{{this.comment}}}</abbr></p><p class="meta"><span class="time timezoner">{{this.created_at}}</span>{{#if this.comment_editor}}<a href="#" class="comment-edit" data-comment-id="{{this.comment_id}}">Edit</a>{{/if}}{{#if this.comment_owner}}<a href="#" class="comment-delete" data-comment-id="{{this.comment_id}}">Delete</a>{{/if}}</p></div></div>{{#if this.comment_editor}}<div class="comment" id="commentedit_{{this.comment_id}}" style="display: none;"><div class="avatar"><div class="avatar-holder">{{#if this.user.supporter}} <span class="supporter"></span>{{/if}}<a href="/user/{{this.user.user_name}}"><img src="{{this.user.user_avatar}}" alt="Your Avatar"></a></div></div><div class="text"><form class="editing"><p class="editerror_{{this.comment_id}} post-error" style="display: none;">There was a problem posting your comment, please try again.</p><textarea name="comment" id="commentBox_{{this.comment_id}}" onkeydown="limitTextReverse($('#commentBox_{{this.comment_id}}'),$('#commentedit_{{this.comment_id}} .myCount'), 140);">{{{this.comment}}}</textarea><span class="comment-loading" style="display: none;"></span><span class="counter"><abbr class="myCount">0</abbr>/140</span><span class="actions"><a href="#" class="submit comment-update-save" data-comment-id="{{this.comment_id}}">Update</a><a href="#" data-comment-id="{{this.comment_id}}" class="cancel comment-update-cancel">Cancel</a></span></form></div></div>{{/if}}{{/each}}
+			</script>
+			<script type="text/javascript">
+				$(document).ready(function() {
+					createImpressionTracker();
+				});
+			</script>
+			
+					</div>
+
+
+				<a href="#" data-user-name="ysilvestrov" class="yellow button more_checkins more_checkins_logged track-click" data-track="profile" data-href=":feed/showmore">Show More</a>
+						<p class="stream-loading"><span></span></p>
+									</div>
+			</div>
+		</div>
+
+		<div class="sidebar">
+
+
+			       <div class="box">
+            <div class="content">
+                <h3>Lists</h3>
+                                    <div class="list-item list-none">
+                        <div class="labels">
+                            <a href="/user/ysilvestrov/lists/11839499" aria-label="List image">
+                                <img src="https://assets.untappd.com/site/beer_logos/beer-65758_58817_sm.jpeg" alt="Beer label"><img src="https://assets.untappd.com/site/beer_logos/beer-7884_f1d70_sm.jpeg" alt="Beer label"><img src="https://assets.untappd.com/site/beer_logos/beer-5129955_a9541_sm.jpeg" alt="Beer label"><img src="https://assets.untappd.com/site/beer_logos/beer-70951_9a907_sm.jpeg" alt="Beer label">                            </a>
+                        </div>
+                        <div class="details">
+                            <span class="name"><a href="/user/ysilvestrov/lists/11839499">Silver Spoon Nest</a></span>
+                            <span class="meta">17 Items &bull; Updated <abbr class="format-date" data-date="Mon, 15 Jun 2026 19:25:35 +0000"></abbr></span>
+                        </div>
+                    </div>
+
+                                        <div class="list-item list-none">
+                        <div class="labels">
+                            <a href="/user/ysilvestrov/lists/12193314" aria-label="List image">
+                                <img src="https://assets.untappd.com/site/assets/images/temp/badge-beer-default.png" alt="Beer label"><img src="https://assets.untappd.com/site/beer_logos/beer-6630153_b50f7_sm.jpeg" alt="Beer label">                            </a>
+                        </div>
+                        <div class="details">
+                            <span class="name"><a href="/user/ysilvestrov/lists/12193314">No&Low</a></span>
+                            <span class="meta">2 Items &bull; Updated <abbr class="format-date" data-date="Mon, 15 Jun 2026 17:37:40 +0000"></abbr></span>
+                        </div>
+                    </div>
+
+                                        <div class="list-item list-none">
+                        <div class="labels">
+                            <a href="/user/ysilvestrov/lists/12745229" aria-label="List image">
+                                <img src="https://assets.untappd.com/site/beer_logos/beer-5825687_1452f_sm.jpeg" alt="Beer label"><img src="https://assets.untappd.com/site/beer_logos/beer-6512265_40888_sm.jpeg" alt="Beer label"><img src="https://assets.untappd.com/site/beer_logos/beer-6482949_c1802_sm.jpeg" alt="Beer label"><img src="https://assets.untappd.com/site/beer_logos/beer-6524976_72e17_sm.jpeg" alt="Beer label">                            </a>
+                        </div>
+                        <div class="details">
+                            <span class="name"><a href="/user/ysilvestrov/lists/12745229">Silver Spon Nest Premium</a></span>
+                            <span class="meta">17 Items &bull; Updated <abbr class="format-date" data-date="Fri, 12 Jun 2026 15:05:39 +0000"></abbr></span>
+                        </div>
+                    </div>
+
+                                        <div class="list-item list-none">
+                        <div class="labels">
+                            <a href="/user/ysilvestrov/lists/11720173" aria-label="List image">
+                                <img src="https://assets.untappd.com/site/beer_logos/beer-6126390_13c88_sm.jpeg" alt="Beer label"><img src="https://assets.untappd.com/site/assets/images/temp/badge-beer-default.png" alt="Beer label"><img src="https://assets.untappd.com/site/assets/images/temp/badge-beer-default.png" alt="Beer label"><img src="https://assets.untappd.com/site/beer_logos/beer-6480418_6e8d0_sm.jpeg" alt="Beer label">                            </a>
+                        </div>
+                        <div class="details">
+                            <span class="name"><a href="/user/ysilvestrov/lists/11720173">Silver Spoon Sharing</a></span>
+                            <span class="meta">24 Items &bull; Updated <abbr class="format-date" data-date="Sun, 31 May 2026 18:26:54 +0000"></abbr></span>
+                        </div>
+                    </div>
+
+                                        <div class="list-item list-none">
+                        <div class="labels">
+                            <a href="/user/ysilvestrov/lists/11839504" aria-label="List image">
+                                <img src="https://assets.untappd.com/site/beer_logos/beer-5571254_df826_sm.jpeg" alt="Beer label"><img src="https://assets.untappd.com/site/beer_logos/beer-6240545_cd945_sm.jpeg" alt="Beer label"><img src="https://assets.untappd.com/site/beer_logos/beer-5885268_6f148_sm.jpeg" alt="Beer label"><img src="https://assets.untappd.com/site/beer_logos/beer-65555_8d5a7_sm.jpeg" alt="Beer label">                            </a>
+                        </div>
+                        <div class="details">
+                            <span class="name"><a href="/user/ysilvestrov/lists/11839504">Kossutha 2A Misc</a></span>
+                            <span class="meta">12 Items &bull; Updated <abbr class="format-date" data-date="Sat, 04 Apr 2026 20:53:23 +0000"></abbr></span>
+                        </div>
+                    </div>
+
+                                                        <p class="more"><a class="track-click" data-track="sidebar" data-href=":userlists/lists" href="/user/ysilvestrov/lists/"">See All Lists</a></p>
+                                </div>
+
+        </div>
+        <script type="text/javascript">
+        $(document).ready(function() {
+            $('.format-date').each(function() {
+                $(this).html(moment($(this).attr('data-date')).format('MMM Do, YYYY'))
+            });
+        })
+        </script>
+                    <div class="box sb-events">
+                <div class="content">
+
+                    <h3>
+                        Your Events                    </h3>
+                    <div class="sb-event-list">
+                        <div class="sb-event-none">
+                            <p>You have not marked any events as Interested or Going.<br><br>
+                            <a href="/nearby/events">Find great events near you!</a></p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+              <div class="box">
+    <div class="content">
+      <h3>Badges</h3>
+      <div class="drinkers">
+                  <a class="tip track-click" data-track="sidebar" data-href=":user/viewbadge" href="/user/ysilvestrov/badges/1399228900" title="World Pint 2026: Australia" ><span><img src="https://assets.untappd.com/promo/4434d775ba_UTC-WorldPint-Badges-01_2.png" alt="World Pint 2026: Australia badge logo"></span></a>
+                  <a class="tip track-click" data-track="sidebar" data-href=":user/viewbadge" href="/user/ysilvestrov/badges/1398198338" title="World Pint 2026: South Korea" ><span><img src="https://assets.untappd.com/promo/dacc277d2e_SOUTH-KOREA-UTC-WorldPint-Badges-07.png" alt="World Pint 2026: South Korea badge logo"></span></a>
+                  <a class="tip track-click" data-track="sidebar" data-href=":user/viewbadge" href="/user/ysilvestrov/badges/1398005557" title="World Pint 2026: Germany" ><span><img src="https://assets.untappd.com/promo/2f830ebd30_GERMANY-UTC-WorldPint-Badges-38.png" alt="World Pint 2026: Germany badge logo"></span></a>
+                  <a class="tip track-click" data-track="sidebar" data-href=":user/viewbadge" href="/user/ysilvestrov/badges/1395542435" title="Beer for Keeping" ><span><img src="https://assets.untappd.com/badges/bdg_BeerForKeeping_md.jpg" alt="Beer for Keeping badge logo"></span></a>
+                  <a class="tip track-click" data-track="sidebar" data-href=":user/viewbadge" href="/user/ysilvestrov/badges/1391731259" title="Flying Saucer - American Craft Beer Week" ><span><img src="https://assets.untappd.com/badges/acbw26badge.jpg" alt="Flying Saucer - American Craft Beer Week badge logo"></span></a>
+                  <a class="tip track-click" data-track="sidebar" data-href=":user/viewbadge" href="/user/ysilvestrov/badges/1391731257" title="American Craft Beer Week (2026)" ><span><img src="https://assets.untappd.com/promo/64f0cda29a_ACBW26-Untappd-Badge.png" alt="American Craft Beer Week (2026) badge logo"></span></a>
+                  <a class="tip track-click" data-track="sidebar" data-href=":user/viewbadge" href="/user/ysilvestrov/badges/1389335606" title="Beer Gear Summer Giveaway" ><span><img src="https://assets.untappd.com/badges/BeerGear-Summer-2026-Badge_1000x1000.jpg" alt="Beer Gear Summer Giveaway badge logo"></span></a>
+                  <a class="tip track-click" data-track="sidebar" data-href=":user/viewbadge" href="/user/ysilvestrov/badges/1386691093" title="Saison Day (2026)" ><span><img src="https://assets.untappd.com/promo/5085f7f5f5_saison_day_badge_2026.png" alt="Saison Day (2026) badge logo"></span></a>
+                  <a class="tip track-click" data-track="sidebar" data-href=":user/viewbadge" href="/user/ysilvestrov/badges/1385208631" title="Belgian Beer Badge" ><span><img src="https://assets.untappd.com/badges/TVL_UNTAPPD_ALGEMEEN_3.jpg" alt="Belgian Beer Badge badge logo"></span></a>
+                  <a class="tip track-click" data-track="sidebar" data-href=":user/viewbadge" href="/user/ysilvestrov/badges/1384858676" title="New York Craft Beer Day" ><span><img src="https://assets.untappd.com/badges/NYUntappd_Badge.jpg" alt="New York Craft Beer Day badge logo"></span></a>
+                  <a class="tip track-click" data-track="sidebar" data-href=":user/viewbadge" href="/user/ysilvestrov/badges/1389360144" title="Fourtitude (Level 3)" ><span><img src="https://assets.untappd.com/promo/d18e73a69f_UTC-QIPA-Style-Badge_1000x1000.png" alt="Fourtitude (Level 3) badge logo"></span></a>
+                  <a class="tip track-click" data-track="sidebar" data-href=":user/viewbadge" href="/user/ysilvestrov/badges/1385370283" title="Beer Geek Madness 2026 (Level 23)" ><span><img src="https://assets.untappd.com/badges/99818665cdc4459fd70e0c89241834b7_md.jpeg" alt="Beer Geek Madness 2026 (Level 23) badge logo"></span></a>
+                <p class="more"><a href="/user/ysilvestrov/badges" class="track-click" data-track="sidebar" data-href=":user/recentbadges">See All Badges</a></p>
+      </div>
+    </div>
+  </div>
+          <div class="box">
+            <div class="content">
+                <h3>Top Beers</h3>                    <div class="item">
+                        <a href="/b/funky-fluid-la-tomatina/5895601" class="track-click" data-track="sidebar" data-href=":beer/toplist">
+                            <p class="logo">
+                                    <img src="https://assets.untappd.com/site/beer_logos/beer-5895601_9952b_sm.jpeg" alt="La Tomatina label">
+                            </p><p class="text">
+                                <span class="name">La Tomatina</span>
+                                <span class="brewery">Funky Fluid</span>                            </p>
+                        </a>
+                    </div>
+                                        <div class="item">
+                        <a href="/b/lervig-coconuts/2553376" class="track-click" data-track="sidebar" data-href=":beer/toplist">
+                            <p class="logo">
+                                    <img src="https://assets.untappd.com/site/beer_logos/beer-2553376_d41bd_sm.jpeg" alt="Coconuts label">
+                            </p><p class="text">
+                                <span class="name">Coconuts</span>
+                                <span class="brewery">LERVIG</span>                            </p>
+                        </a>
+                    </div>
+                                        <div class="item">
+                        <a href="/b/omnipollo-anagram-blueberry-cheesecake-stout/1501093" class="track-click" data-track="sidebar" data-href=":beer/toplist">
+                            <p class="logo">
+                                    <img src="https://assets.untappd.com/site/beer_logos/beer-1501093_d8066_sm.jpeg" alt="Anagram Blueberry Cheesecake Stout label">
+                            </p><p class="text">
+                                <span class="name">Anagram Blueberry Cheesecake Stout</span>
+                                <span class="brewery">Omnipollo</span>                            </p>
+                        </a>
+                    </div>
+                                        <div class="item">
+                        <a href="/b/brewdog-cocoa-psycho/273455" class="track-click" data-track="sidebar" data-href=":beer/toplist">
+                            <p class="logo">
+                                    <img src="https://assets.untappd.com/site/beer_logos/beer-273455_ca7d6_sm.jpeg" alt="Cocoa Psycho label">
+                            </p><p class="text">
+                                <span class="name">Cocoa Psycho</span>
+                                <span class="brewery">BrewDog</span>                            </p>
+                        </a>
+                    </div>
+                                        <div class="item">
+                        <a href="/b/cydr-chyliczki-lodowy-2017/2937479" class="track-click" data-track="sidebar" data-href=":beer/toplist">
+                            <p class="logo">
+                                    <img src="https://assets.untappd.com/site/assets/images/temp/badge-beer-default.png" alt="Lodowy 2017 label">
+                            </p><p class="text">
+                                <span class="name">Lodowy 2017</span>
+                                <span class="brewery">Cydr Chyliczki</span>                            </p>
+                        </a>
+                    </div>
+                                                <p class="more"><a class="track-click" data-track="sidebar" data-href=":user/beerhistory" href="/user/ysilvestrov/beers">See All Beers</a></p>
+                                        </div>
+        </div>
+            	<div class="box">
+        	<div class="content">
+                <h3>Top Venues</h3>                    <div class="item" data-track-venue-impression="venue_id-11941787-type-top_venues">
+                        <a href="/v/silver-spoon-nest/11941787" class="track-click" data-track="sidebar" data-href=":venue/toplist">
+                            <p class="logo">
+                                                                <img src="https://ss3.4sqi.net/img/categories_v2/nightlife/pub_bg_512.png" alt="Silver Spoon Nest logo">
+                            </p><p class="text">
+                                <span class="name">Silver Spoon Nest</span>
+
+                                <span class="location">Warszawa, Województwo mazowieckie                                        </span>                            </p>
+                        </a>
+                    </div>
+
+        			                    <div class="item" data-track-venue-impression="venue_id-5378424-type-top_venues">
+                        <a href="/v/black-door-pub/5378424" class="track-click" data-track="sidebar" data-href=":venue/toplist">
+                            <p class="logo">
+                                                                <img src="https://ss3.4sqi.net/img/categories_v2/nightlife/pub_bg_512.png" alt="Black Door Pub logo">
+                            </p><p class="text">
+                                <span class="name">Black Door Pub</span>
+
+                                <span class="location">Харків, Харківська обл.                                        </span>                            </p>
+                        </a>
+                    </div>
+
+        			                    <div class="item" data-track-venue-impression="venue_id-11142155-type-top_venues">
+                        <a href="/v/warsaw-beer-festival-warszawski-festiwal-piwa/11142155" class="track-click" data-track="sidebar" data-href=":venue/toplist">
+                            <p class="logo">
+                                <span>Verified</span>                                <img src="https://images.untp.beer/resize?width=176&height=176&background=255,255,255&extend=white&stripmeta=true&url=https://utfb-images.untappd.com/aqlndes4fiuk9knpzif4blmpifhv?auto=compress" alt="Warszawski Festiwal Piwa logo">
+                            </p><p class="text">
+                                <span class="name">Warszawski Festiwal Piwa</span>
+
+                                <span class="location">Warsaw, Województwo mazowieckie                                        </span>                            </p>
+                        </a>
+                    </div>
+
+        			                    <div class="item" data-track-venue-impression="venue_id-10791463-type-top_venues">
+                        <a href="/v/lviv-craft-beer-university-of-st-christopher/10791463" class="track-click" data-track="sidebar" data-href=":venue/toplist">
+                            <p class="logo">
+                                <span>Verified</span>                                <img src="https://images.untp.beer/resize?width=176&height=176&background=255,255,255&extend=white&stripmeta=true&url=https://utfb-images.untappd.com/27pv83z3nxvdznhhd42b2gmft1sl?auto=compress" alt="Lviv Craft Beer University of St. Christopher logo">
+                            </p><p class="text">
+                                <span class="name">Lviv Craft Beer University of St. Christopher</span>
+
+                                <span class="location">Львів, Львівська обл.                                        </span>                            </p>
+                        </a>
+                    </div>
+
+        			                    <div class="item" data-track-venue-impression="venue_id-12617758-type-top_venues">
+                        <a href="/v/white-crow-craft-beer-and-kitchen/12617758" class="track-click" data-track="sidebar" data-href=":venue/toplist">
+                            <p class="logo">
+                                <span>Verified</span>                                <img src="https://images.untp.beer/resize?width=176&height=176&background=255,255,255&extend=white&stripmeta=true&url=https://utfb-images.untappd.com/9a83x4i3c163rt9ttuzdgnmamq4l?auto=compress" alt="White Crow Craft Beer & Kitchen logo">
+                            </p><p class="text">
+                                <span class="name">White Crow Craft Beer & Kitchen</span>
+
+                                <span class="location">Warszawa, Województwo mazowieckie                                        </span>                            </p>
+                        </a>
+                    </div>
+
+        			                    <p class="more"><a class="track-click" data-track="sidebar" data-href=":user/toplocations" href="/user/ysilvestrov/venues">See All Venues</a></p>
+                            	</div>
+    	</div>
+        <script type="text/javascript">
+            $(document).ready(function() {
+                createImpressionTracker();
+            });
+        </script>
+    	        <div class="box">
+            <div class="content">
+                <h3>Likes</h3>
+                <div class="drinkers">
+                                            <a class="tip track-click" data-track="sidebar" data-href=":user/viewLikeBrewery" href="/SilverForkBrewery" title="Silver Fork Brewery" ><span><img src="https://assets.untappd.com/site/brewery_logos/brewery-492625_f9487.jpeg" alt="Silver Fork Brewery avatar"></span></a>
+                                                <a class="tip track-click" data-track="sidebar" data-href=":user/viewLikeBrewery" href="/SilverSpoonBrewery" title="Silver Spoon Brewery" ><span><img src="https://assets.untappd.com/site/brewery_logos/brewery-390260_cd128.jpeg" alt="Silver Spoon Brewery avatar"></span></a>
+                                        </div>
+            </div>
+        </div>
+        		</div>
+		
+
+</div>
+<script type="text/javascript">
+$(document).ready(function() {
+	if ($(".sidebar").is(":visible")) {
+		var sidebarHeight = $(".sidebar")[0].scrollHeight;
+		$(".profile_left").css("min-height", sidebarHeight + 108 + "px");
+	}
+})
+</script>
+	<script>
+	$(document).ready(function() {
+
+		$(".block").on("click", function(e) {
+
+			e.stopPropagation();
+			e.preventDefault();
+
+			var type = $(this).attr('data-block');
+			var userId = $(this).attr("data-user-id");
+
+			var msg = type === "true" ? 'Are you sure you want to un-block this user? You will need to re-friend them to interact with their content.' : 'Are you sure you want to block this user? This user will not be able to see your activity while logged into the app or website.';
+
+			if (confirm(msg)) {
+				$.ajax({
+					url: "/apireqs/blockuser/"+userId,
+					type: "POST",
+					dataType: "json",
+					error: function(xhr)
+					{
+						$.notifyBar({
+							html: "Hmm. Something went wrong. Please try again!",
+							delay: 2000,
+							animationSpeed: "normal"
+						});
+					},
+					success: function(html)
+					{
+
+						if (html.error) {
+							$.notifyBar({
+								html: html.error,
+								delay: 2000,
+								animationSpeed: "normal"
+							});
+						} else {
+							window.location.reload();
+						}
+					}
+				});
+			}
+
+			return false;
+
+		});
+		$(".more_checkins_logged").on("click", function() {
+			var _this = $(this);
+			$(_this).hide();
+			$(".stream-loading").addClass("active");
+
+			var offset = $("#main-stream .item:last").attr('data-checkin-id');
+			var user = $(this).attr("data-user-name");
+
+			$.ajax({
+				url: "/profile/more_feed/"+user+"/"+offset+"?v2=true",
+				type: "GET",
+				error: function(xhr)
+				{
+					$(".stream-loading").removeClass("active");
+					$(_this).show();
+					$.notifyBar({
+						html: "Hmm. Something went wrong. Please try again!",
+						delay: 2000,
+						animationSpeed: "normal"
+					});
+				},
+				success: function(html)
+				{
+					$(".stream-loading").removeClass("active");
+
+					if (html == "") {
+						$(".more_checkins").hide();
+					}
+					else {
+						$(_this).show();
+						$("#main-stream").append(html);
+						$(".tip").tipsy({fade: true});
+						refreshTime(".timezoner", "D MMM YY");
+					}
+				}
+			});
+
+			return false;
+		});
+	});
+	</script>
+	<script type="text/javascript" language="Javascript" src="https://untappd.com/assets/v3/js/common/min/profile_page_min.js?v=2.8.37"></script>
+	
+
+		<iframe src="/profile/stats?id=3266672&type=profile&is_supporter=1&nomobile=true" width="0" height="0" tabindex="-1" title="empty" class="hidden"></iframe><script type="text/javascript">
+	$(document).ready(function() {
+		var hC = $(".sidebar").height();
+		$(".cont").css("min-height", hC);
+
+		$(".report-user").on("click", function(e) {
+			e.stopPropagation();
+			e.preventDefault();
+			var url = $(this).attr('data-report-url');
+			window.location.href = url;
+			return false;
+		})
+
+		$(".friend-more").on("click", function(e) {
+			$(".friend-more-pop").toggle();
+			return false;
+		})
+	})
+</script>
+<style>
+#pmLink {
+	visibility: hidden;
+    color: #8a4500;
+    font: inherit;
+    line-height: inherit;
+    text-decoration: none;
+    cursor: pointer;
+    background: transparent;
+    border: none;
+    margin: 0;
+    padding: 0;
+}
+
+#pmLink:hover {
+	visibility: visible;
+    color: #c60;
+}
+</style>
+
+	<footer class="">
+		<div class="footer-nav">
+			<div class="footer-inner">
+				<ul>
+					<li>
+						<a class="track-click" data-track="footer" data-href=":footer/businesses" href="https://utfb.untappd.com/">Untappd for Business</a>
+					</li>
+					<li>
+						<a class="track-click" data-track="footer" data-href=":footer/businesses/blog" href="https://lounge.untappd.com/">Untappd for Business Blog</a>
+					</li>
+					<li>
+						<a class="track-click" data-track="footer" data-href=":footer/breweries" href="https://untappd.com/breweries">Breweries</a>
+					</li>
+					<li>
+						<a class="track-click" data-track="footer" data-href=":footer/shop" href="https://untappd.com/shop">Shop</a>
+					</li>
+					<li>
+						<a class="track-click" data-track="footer" data-href=":footer/support" href="http://help.untappd.com/">Support</a>
+					</li>
+					<li>
+						<a class="track-click" data-track="footer" data-href=":footer/careers" href="/careers">Careers</a>
+					</li>
+					<li>
+						<a class="track-click" data-track="footer" data-href=":footer/api" href="/api/">API</a>
+					</li>
+					<li>
+						<a class="track-click" data-track="footer" data-href=":footer/terms" href="/terms">Terms</a>
+					</li>
+					<li>
+						<a class="track-click" data-track="footer" data-href=":footer/privacy" href="/privacy">Privacy</a>
+					</li>
+					<li>
+						<a class="track-click" data-track="footer" data-href=":footer/cookie" href="/cookie">Cookie Policy</a>
+					</li>
+					<li>
+						<!-- https://freestarhelp.zendesk.com/hc/en-us/articles/34424330233364-Freestar-Sourcepoint-CMP-Implementation -->
+						<button id="pmLink">Privacy Manager</button>
+					</li>
+					<li>
+						<a class="track-click" data-track="footer" data-href=":footer/personal_data" href="/privacy/personal-data">Manage Personal Data</a>
+					</li>
+				</ul>
+			</div>
+		</div>
+		<ul class="social">
+    <li><a class="track-click" data-track="footer" data-href=":footer/social/twitter" href="https://bit.ly/3T6pKK6" target="_blank"><img src="https://untappd.com/assets/custom/homepage/images/icon-twitter.svg" alt="Icon twitter" /></a></li>
+    <li><a class="track-click" data-track="footer" data-href=":footer/social/facebook" href="https://bit.ly/3RVLffu" target="_blank"><img src="https://untappd.com/assets/custom/homepage/images/icon-facebook.svg" alt="Icon facebook" /></a></li>
+    <li><a class="track-click" data-track="home" data-href=":footer/social/instagram" href="https://bit.ly/3EyG9D5" target="_blank"><img src="https://untappd.com/assets/custom/homepage/images/icon-instagram.svg" alt="Icon instagram" /></a></li>
+</ul>	</footer>
+
+<script type="text/javascript">
+	// polyfill for ie11
+	function getUrlParameter(name) {
+		name = name.replace(/[\[]/, '\\[').replace(/[\]]/, '\\]');
+		var regex = new RegExp('[\\?&]' + name + '=([^&#]*)');
+		var results = regex.exec(location.search);
+		return results === null ? '' : decodeURIComponent(results[1].replace(/\+/g, ' '));
+	};
+
+	$(document).ready(function() {
+		// remove any access tokens, preserve other elements
+		if (history.replaceState) {
+			if (location.href.indexOf("access_token=") >= 0) {
+				const accessTokenURL = getUrlParameter("access_token");
+				let currentURL = location.href;
+				let finalURL = currentURL.replace(`access_token=${accessTokenURL}`, '');
+
+				// if the url has a "&" already in it, then remove the "?" and replace the first "&" with an "?"
+				if (finalURL.indexOf("&") >= 0) {
+					finalURL = finalURL.replace("?", "").replace("&", "?");
+				} else {
+					finalURL = finalURL.split("?")[0];
+				}
+
+				history.replaceState(null, "", finalURL);
+			}
+		}
+	})
+</script>
+
+<script type="text/javascript">
+	// Clear Text Feild
+	function clearText(thefield) {
+		if (thefield.defaultValue == thefield.value)
+			thefield.value = ""
+	}
+</script>
+
+
+<script src="https://aa.agkn.com/adscores/s.js?sid=9112310028&em=2258a9f1b57ad608d3d5b7fdbdbf4995494778ff"></script>
+</body>
+</html>

--- a/tmp/beerrepublic.json
+++ b/tmp/beerrepublic.json
@@ -1,0 +1,666 @@
+[
+  {
+    "brewery": "Finback",
+    "name": "Dark Pyramid / Glass Pyramid"
+  },
+  {
+    "brewery": "Finback",
+    "name": "Backcountry Trail"
+  },
+  {
+    "brewery": "Finback",
+    "name": "Orange Crush / RaR"
+  },
+  {
+    "brewery": "Finback",
+    "name": "Aqualung / Hackney"
+  },
+  {
+    "brewery": "Finback",
+    "name": "If Whales Could Fly"
+  },
+  {
+    "brewery": "Finback",
+    "name": "Same Team"
+  },
+  {
+    "brewery": "Finback",
+    "name": "Sit Back"
+  },
+  {
+    "brewery": "Finback",
+    "name": "No One Else Can Take Your Place"
+  },
+  {
+    "brewery": "Counterpart",
+    "name": "Strange Beast / Nano Cinco"
+  },
+  {
+    "brewery": "Counterpart",
+    "name": "Dream Taker / Sir John"
+  },
+  {
+    "brewery": "Counterpart",
+    "name": "Dead Sea 2 / Le Ketch"
+  },
+  {
+    "brewery": "Counterpart",
+    "name": "SEVEN"
+  },
+  {
+    "brewery": "Counterpart",
+    "name": "Empire Hazelnut Coffee / Brasserie du Bas"
+  },
+  {
+    "brewery": "Counterpart",
+    "name": "Empire Macadamia Nut / Brasserie du Bas"
+  },
+  {
+    "brewery": "Counterpart",
+    "name": "Afterglow"
+  },
+  {
+    "brewery": "Counterpart",
+    "name": "Drip (Freestyle Nectaron, Motueka, Rakau)"
+  },
+  {
+    "brewery": "Counterpart",
+    "name": "Waimea Flow"
+  },
+  {
+    "brewery": "Beer Tree",
+    "name": "Chromosphere"
+  },
+  {
+    "brewery": "Beer Tree",
+    "name": "Photosphere"
+  },
+  {
+    "brewery": "Beer Tree",
+    "name": "Canopy"
+  },
+  {
+    "brewery": "Beer Tree",
+    "name": "Any Day's Haze"
+  },
+  {
+    "brewery": "Beer Tree",
+    "name": "Kaleidoscope Kölsch: Peach"
+  },
+  {
+    "brewery": "Beer Tree",
+    "name": "Canyons"
+  },
+  {
+    "brewery": "Beer Tree",
+    "name": "Cerveza"
+  },
+  {
+    "brewery": "Eppig",
+    "name": "10:45 to Denver"
+  },
+  {
+    "brewery": "Sir John",
+    "name": "BLAST"
+  },
+  {
+    "brewery": "Sir John",
+    "name": "L'Autoroute De La Mort / Brasserie du Bas"
+  },
+  {
+    "brewery": "Sir John",
+    "name": "Copy of A Copy of A Copy"
+  },
+  {
+    "brewery": "Sir John",
+    "name": "Dairy Kwing"
+  },
+  {
+    "brewery": "Sir John",
+    "name": "Kafé Krème"
+  },
+  {
+    "brewery": "Autodidact",
+    "name": "Broken Teeth / Bad Bones"
+  },
+  {
+    "brewery": "Autodidact",
+    "name": "Acid Hologram"
+  },
+  {
+    "brewery": "Autodidact",
+    "name": "Retrospect"
+  },
+  {
+    "brewery": "Beer Zombies",
+    "name": "Zombie HWhip: Blood Orange Raspberry Lemonade"
+  },
+  {
+    "brewery": "Beer Zombies",
+    "name": "Zombie HWhip: Zombie Milk"
+  },
+  {
+    "brewery": "Beer Zombies",
+    "name": "Zombie Wars"
+  },
+  {
+    "brewery": "Mason Ale Works",
+    "name": "Emperor"
+  },
+  {
+    "brewery": "Mason Ale Works",
+    "name": "The Royalist"
+  },
+  {
+    "brewery": "Mason Ale Works",
+    "name": "Cask & Crown"
+  },
+  {
+    "brewery": "Mason Ale Works",
+    "name": "Chosen One"
+  },
+  {
+    "brewery": "Mason Ale Works",
+    "name": "Fruit Bomb: Black Currant"
+  },
+  {
+    "brewery": "Mason Ale Works",
+    "name": "Fruit Bomb: Peach Apricot"
+  },
+  {
+    "brewery": "Mason Ale Works",
+    "name": "Hop Dogs"
+  },
+  {
+    "brewery": "Sir John",
+    "name": "Tercel Verte Nitro"
+  },
+  {
+    "brewery": "Sir John",
+    "name": "P'tit Monstre / Nano Cinco"
+  },
+  {
+    "brewery": "Sir John",
+    "name": "With Eyes Wide Open / DankHouse"
+  },
+  {
+    "brewery": "Sir John",
+    "name": "Dancing Bears 2.0 / Boréale"
+  },
+  {
+    "brewery": "Sir John",
+    "name": "Haunter / Third Moon"
+  },
+  {
+    "brewery": "Sir John",
+    "name": "Rêves Électriques / WILLS"
+  },
+  {
+    "brewery": "Sir John",
+    "name": "Orlok / Blackout"
+  },
+  {
+    "brewery": "Sir John",
+    "name": "La Dernière Danse"
+  },
+  {
+    "brewery": "Sir John",
+    "name": "Mets-y De La Zoune / Toltèk & Le Ketch"
+  },
+  {
+    "brewery": "Sir John",
+    "name": "À L'ombre De L'Ange"
+  },
+  {
+    "brewery": "Third Moon",
+    "name": "Haunter / Sir John"
+  },
+  {
+    "brewery": "Sir John",
+    "name": "Funky"
+  },
+  {
+    "brewery": "Sir John",
+    "name": "Un Grand 2/2"
+  },
+  {
+    "brewery": "Sir John",
+    "name": "Double Freshly Frozen"
+  },
+  {
+    "brewery": "Sir John",
+    "name": "Anatomie Du Temps"
+  },
+  {
+    "brewery": "Counterpart",
+    "name": "Dream Taker / Sir John"
+  },
+  {
+    "brewery": "Sir John",
+    "name": "Kafé Krème"
+  },
+  {
+    "brewery": "Sir John",
+    "name": "Dairy Kwing"
+  },
+  {
+    "brewery": "Sir John",
+    "name": "Copy of A Copy of A Copy"
+  },
+  {
+    "brewery": "Sir John",
+    "name": "L'Autoroute De La Mort / Brasserie du Bas"
+  },
+  {
+    "brewery": "Sir John",
+    "name": "BLAST"
+  },
+  {
+    "brewery": "Autodidact",
+    "name": "Inner Paths"
+  },
+  {
+    "brewery": "Autodidact",
+    "name": "Full Circle"
+  },
+  {
+    "brewery": "Autodidact",
+    "name": "Usurper"
+  },
+  {
+    "brewery": "Autodidact",
+    "name": "Daylily"
+  },
+  {
+    "brewery": "Autodidact",
+    "name": "Captain Dan's Wings"
+  },
+  {
+    "brewery": "Autodidact",
+    "name": "Venona"
+  },
+  {
+    "brewery": "Autodidact",
+    "name": "Retrospect"
+  },
+  {
+    "brewery": "Autodidact",
+    "name": "Broken Teeth / Bad Bones"
+  },
+  {
+    "brewery": "Autodidact",
+    "name": "Acid Hologram"
+  },
+  {
+    "brewery": "Finback",
+    "name": "Dark Pyramid / Glass Pyramid"
+  },
+  {
+    "brewery": "Finback",
+    "name": "Backcountry Trail"
+  },
+  {
+    "brewery": "Finback",
+    "name": "Orange Crush / RaR"
+  },
+  {
+    "brewery": "Finback",
+    "name": "Aqualung / Hackney"
+  },
+  {
+    "brewery": "Finback",
+    "name": "If Whales Could Fly"
+  },
+  {
+    "brewery": "Finback",
+    "name": "Same Team"
+  },
+  {
+    "brewery": "Finback",
+    "name": "Sit Back"
+  },
+  {
+    "brewery": "Finback",
+    "name": "No One Else Can Take Your Place"
+  },
+  {
+    "brewery": "Counterpart",
+    "name": "Strange Beast / Nano Cinco"
+  },
+  {
+    "brewery": "Counterpart",
+    "name": "Dream Taker / Sir John"
+  },
+  {
+    "brewery": "Counterpart",
+    "name": "Dead Sea 2 / Le Ketch"
+  },
+  {
+    "brewery": "Counterpart",
+    "name": "SEVEN"
+  },
+  {
+    "brewery": "Counterpart",
+    "name": "Empire Hazelnut Coffee / Brasserie du Bas"
+  },
+  {
+    "brewery": "Counterpart",
+    "name": "Empire Macadamia Nut / Brasserie du Bas"
+  },
+  {
+    "brewery": "Counterpart",
+    "name": "Afterglow"
+  },
+  {
+    "brewery": "Counterpart",
+    "name": "Drip (Freestyle Nectaron, Motueka, Rakau)"
+  },
+  {
+    "brewery": "Counterpart",
+    "name": "Waimea Flow"
+  },
+  {
+    "brewery": "Beer Tree",
+    "name": "Chromosphere"
+  },
+  {
+    "brewery": "Beer Tree",
+    "name": "Photosphere"
+  },
+  {
+    "brewery": "Beer Tree",
+    "name": "Canopy"
+  },
+  {
+    "brewery": "Beer Tree",
+    "name": "Any Day's Haze"
+  },
+  {
+    "brewery": "Beer Tree",
+    "name": "Kaleidoscope Kölsch: Peach"
+  },
+  {
+    "brewery": "Beer Tree",
+    "name": "Canyons"
+  },
+  {
+    "brewery": "Beer Tree",
+    "name": "Cerveza"
+  },
+  {
+    "brewery": "Eppig",
+    "name": "10:45 to Denver"
+  },
+  {
+    "brewery": "Sir John",
+    "name": "BLAST"
+  },
+  {
+    "brewery": "Sir John",
+    "name": "L'Autoroute De La Mort / Brasserie du Bas"
+  },
+  {
+    "brewery": "Sir John",
+    "name": "Copy of A Copy of A Copy"
+  },
+  {
+    "brewery": "Sir John",
+    "name": "Dairy Kwing"
+  },
+  {
+    "brewery": "Sir John",
+    "name": "Kafé Krème"
+  },
+  {
+    "brewery": "Autodidact",
+    "name": "Broken Teeth / Bad Bones"
+  },
+  {
+    "brewery": "Autodidact",
+    "name": "Acid Hologram"
+  },
+  {
+    "brewery": "Autodidact",
+    "name": "Retrospect"
+  },
+  {
+    "brewery": "Beer Zombies",
+    "name": "Zombie HWhip: Blood Orange Raspberry Lemonade"
+  },
+  {
+    "brewery": "Beer Zombies",
+    "name": "Zombie HWhip: Zombie Milk"
+  },
+  {
+    "brewery": "Beer Zombies",
+    "name": "Zombie Wars"
+  },
+  {
+    "brewery": "Mason Ale Works",
+    "name": "Emperor"
+  },
+  {
+    "brewery": "Mason Ale Works",
+    "name": "The Royalist"
+  },
+  {
+    "brewery": "Mason Ale Works",
+    "name": "Cask & Crown"
+  },
+  {
+    "brewery": "Mason Ale Works",
+    "name": "Chosen One"
+  },
+  {
+    "brewery": "Mason Ale Works",
+    "name": "Fruit Bomb: Black Currant"
+  },
+  {
+    "brewery": "Mason Ale Works",
+    "name": "Fruit Bomb: Peach Apricot"
+  },
+  {
+    "brewery": "Mason Ale Works",
+    "name": "Hop Dogs"
+  },
+  {
+    "brewery": "Cigar City",
+    "name": "Florida Man"
+  },
+  {
+    "brewery": "Oskar Blues",
+    "name": "Double Dale’s"
+  },
+  {
+    "brewery": "Firestone Walker",
+    "name": "Mind Haze Brain Melter"
+  },
+  {
+    "brewery": "Other Half",
+    "name": "Oh..."
+  },
+  {
+    "brewery": "Cigar City",
+    "name": "Cosmic Crown"
+  },
+  {
+    "brewery": "Founders",
+    "name": "Más Agave Grapefruit"
+  },
+  {
+    "brewery": "Other Half",
+    "name": "Green Dots"
+  },
+  {
+    "brewery": "AleSmith",
+    "name": ".394 Pale Ale"
+  },
+  {
+    "brewery": "Other Half",
+    "name": "Double Citra Daydream"
+  },
+  {
+    "brewery": "Toppling Goliath",
+    "name": "Mind Your Unwind /  Hop Butcher For The World"
+  },
+  {
+    "brewery": "Other Half",
+    "name": "Hop Showers"
+  },
+  {
+    "brewery": "Trillium",
+    "name": "Melcher Street"
+  },
+  {
+    "brewery": "Brujos",
+    "name": "Clavicula Nox"
+  },
+  {
+    "brewery": "SingleCut",
+    "name": "Eric More Cowbell!"
+  },
+  {
+    "brewery": "Rogue",
+    "name": "Pumpkin Patch Ale"
+  },
+  {
+    "brewery": "Trillium",
+    "name": "Mettle"
+  },
+  {
+    "brewery": "Other Half",
+    "name": "Nectar Diamonds"
+  },
+  {
+    "brewery": "Belching Beaver",
+    "name": "Deftones Imperial Phantom Bride"
+  },
+  {
+    "brewery": "Bronx",
+    "name": "Smile My Guy Happy Hoppy IPA"
+  },
+  {
+    "brewery": "Toppling Goliath",
+    "name": "Dino Break"
+  },
+  {
+    "brewery": "Toppling Goliath",
+    "name": "Krush Double Dry Hop Pseudo Sue"
+  },
+  {
+    "brewery": "Firestone Walker",
+    "name": "Whiskey Barrel Wheat Wine"
+  },
+  {
+    "brewery": "Other Half",
+    "name": "Tens of Hundreds"
+  },
+  {
+    "brewery": "Clown Shoes",
+    "name": "Pecan Pie Porter"
+  },
+  {
+    "brewery": "Grand Teton",
+    "name": "Amber Ale"
+  },
+  {
+    "brewery": "Knee Deep",
+    "name": "Lupulin River / Kern River"
+  },
+  {
+    "brewery": "Allagash",
+    "name": "Haunted House"
+  },
+  {
+    "brewery": "Belching Beaver",
+    "name": "Must Be the Honey"
+  },
+  {
+    "brewery": "The Shed",
+    "name": "Mountain Ale"
+  },
+  {
+    "brewery": "Dry Dock",
+    "name": "Apricot Blonde"
+  },
+  {
+    "brewery": "Smuttynose",
+    "name": "Old Brown Dog Ale"
+  },
+  {
+    "brewery": "Knee Deep",
+    "name": "Simtra"
+  },
+  {
+    "brewery": "Firestone Walker",
+    "name": "Rye Chai Cha"
+  },
+  {
+    "brewery": "Cellarmaker",
+    "name": "Coffee & Cigarettes"
+  },
+  {
+    "brewery": "Wachusett",
+    "name": "Pumpkin Ale"
+  },
+  {
+    "brewery": "Magnify",
+    "name": "Double Vanilla Mind Over Matter"
+  },
+  {
+    "brewery": "Noon Whistle",
+    "name": "Fuzzy Smack"
+  },
+  {
+    "brewery": "The Veil",
+    "name": "Master Shredder"
+  },
+  {
+    "brewery": "Fidens",
+    "name": "Power Beyond Control"
+  },
+  {
+    "brewery": "Firestone Walker",
+    "name": "Waukesha Press"
+  },
+  {
+    "brewery": "Reuben's",
+    "name": "Robust Porter"
+  },
+  {
+    "brewery": "Other Half",
+    "name": "Juice Giant"
+  },
+  {
+    "brewery": "Trillium",
+    "name": "Mosaic Dry Hopped Fort Point"
+  },
+  {
+    "brewery": "The Rare Barrel",
+    "name": "Strawberry Small Acts"
+  },
+  {
+    "brewery": "The Veil",
+    "name": "S.U.R.E."
+  },
+  {
+    "brewery": "Oud Beersel",
+    "name": "Winter Lambiek"
+  },
+  {
+    "brewery": "Prairie",
+    "name": "Seasick Crocodile"
+  },
+  {
+    "brewery": "The Veil",
+    "name": "New Mirage"
+  },
+  {
+    "brewery": "The Rare Barrel",
+    "name": "Feed the Monster 2021"
+  },
+  {
+    "brewery": "Brasserie du Bas-Canada",
+    "name": "Réflexion"
+  }
+]

--- a/tmp/capture-more-feed.js
+++ b/tmp/capture-more-feed.js
@@ -1,0 +1,40 @@
+// Capture Untappd "Show More" (more_feed) response for the check-in sync fix (#145).
+//
+// HOW TO USE:
+// 1. In your browser, LOG IN to Untappd and open your profile:
+//       https://untappd.com/user/ysilvestrov
+// 2. Open DevTools (F12) -> Console.
+// 3. Paste this whole file's contents into the Console and press Enter.
+// 4. It downloads "ysilvestrov_more_feed_1577238079.txt" to your browser's Downloads.
+//    (The Console also prints the length + first 200 chars so you can confirm it's
+//     real data and not a redirect to /home.)
+// 5. Get that file onto the server into ./tmp/ the same way you transferred the
+//    earlier captures, and tell Claude.
+//
+// Must run in the untappd.com page context (NOT a file:// page) so it carries your
+// login cookies. The X-Requested-With header is what stops Untappd 307-redirecting
+// the request to /home (it only serves more_feed to XHR requests).
+
+(async () => {
+  const user = 'ysilvestrov';
+  const offset = '1577238079'; // oldest check-in id from page 1 (the cursor to page past)
+  const url = `/profile/more_feed/${user}/${offset}?v2=true`;
+  try {
+    const res = await fetch(url, {
+      headers: { 'X-Requested-With': 'XMLHttpRequest' },
+      credentials: 'include',
+    });
+    const body = await res.text();
+    console.log('status:', res.status, res.redirected ? '(REDIRECTED!)' : '', 'length:', body.length);
+    console.log('starts with:', body.slice(0, 200));
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(new Blob([body], { type: 'text/plain' }));
+    a.download = `${user}_more_feed_${offset}.txt`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    console.log('Downloaded', a.download, '— move it into ./tmp/ on the server.');
+  } catch (e) {
+    console.error('capture failed:', e);
+  }
+})();

--- a/tmp/profile.ts
+++ b/tmp/profile.ts
@@ -1,0 +1,32 @@
+import Database from 'better-sqlite3';
+import { readFileSync } from 'node:fs';
+import { loadCatalog } from '../src/storage/beers';
+import { prepareBeer, makePreparedCatalog, breweryAliases, breweryAliasesMatch } from '../src/domain/matcher';
+
+async function main(): Promise<void> {
+  const db = new Database('/var/lib/warsaw-beer-bot/bot.db', { readonly: true });
+  const catalog = loadCatalog(db);
+  const beers = JSON.parse(readFileSync('tmp/beerrepublic.json', 'utf8'));
+
+  let tPrep = performance.now();
+  const prepared = catalog.map(prepareBeer);
+  const pc = makePreparedCatalog(prepared);
+  tPrep = performance.now() - tPrep;
+
+  // Per-beer: time the exact-filter brewery-alias scan over the whole catalog.
+  let tAliasScan = 0, poolHits = 0, emptyPool = 0;
+  for (const item of beers) {
+    const ia = breweryAliases(item.brewery);
+    const t = performance.now();
+    let pool = 0;
+    for (const c of prepared) if (breweryAliasesMatch(c.aliases, ia)) pool++;
+    tAliasScan += performance.now() - t;
+    if (pool === 0) emptyPool++; else poolHits++;
+  }
+  console.log(`catalog=${catalog.length} beers=${beers.length}`);
+  console.log(`prepareCatalog=${tPrep.toFixed(0)}ms`);
+  console.log(`aliasScan(1x per beer)=${tAliasScan.toFixed(0)}ms  -> exact+fuzzy do this 2x`);
+  console.log(`beers with brewery in catalog=${poolHits}  emptyPool(->fullSearcher)=${emptyPool}`);
+  db.close();
+}
+void main();

--- a/tmp/proto.ts
+++ b/tmp/proto.ts
@@ -1,0 +1,41 @@
+import Database from 'better-sqlite3';
+import { readFileSync } from 'node:fs';
+import { loadCatalog } from '../src/storage/beers';
+import { prepareBeer, breweryAliases, breweryAliasesMatch } from '../src/domain/matcher';
+
+const firstTok = (a: string) => a.split(' ', 1)[0];
+
+async function main(): Promise<void> {
+  const db = new Database('/var/lib/warsaw-beer-bot/bot.db', { readonly: true });
+  const catalog = loadCatalog(db);
+  const beers = JSON.parse(readFileSync('tmp/beerrepublic.json', 'utf8'));
+  const prepared = catalog.map(prepareBeer);
+
+  // Build first-token -> rows index
+  const idx = new Map<string, typeof prepared>();
+  for (const c of prepared) for (const a of c.aliases) {
+    const k = firstTok(a);
+    let b = idx.get(k); if (!b) idx.set(k, b = []);
+    if (b[b.length-1] !== c) b.push(c);
+  }
+
+  let mismatch = 0, tIdx = 0, tFull = 0;
+  for (const item of beers) {
+    const ia = breweryAliases(item.brewery);
+    // full scan (baseline)
+    let t = performance.now();
+    const full = prepared.filter((c) => breweryAliasesMatch(c.aliases, ia));
+    tFull += performance.now() - t;
+    // indexed
+    t = performance.now();
+    const seen = new Set<typeof prepared[0]>();
+    for (const a of ia) for (const c of (idx.get(firstTok(a)) ?? [])) {
+      if (!seen.has(c) && breweryAliasesMatch(c.aliases, ia)) seen.add(c);
+    }
+    tIdx += performance.now() - t;
+    if (seen.size !== full.length || !full.every((c) => seen.has(c))) mismatch++;
+  }
+  console.log(`fullScan=${tFull.toFixed(0)}ms indexed=${tIdx.toFixed(0)}ms mismatchBeers=${mismatch}/${beers.length}`);
+  db.close();
+}
+void main();

--- a/tmp/repro.ts
+++ b/tmp/repro.ts
@@ -1,0 +1,18 @@
+import Database from 'better-sqlite3';
+import { readFileSync } from 'node:fs';
+import { loadCatalog } from '../src/storage/beers';
+import { matchBeerList } from '../src/domain/match-list';
+
+async function main(): Promise<void> {
+  const db = new Database('/var/lib/warsaw-beer-bot/bot.db', { readonly: true });
+  const catalog = loadCatalog(db);
+  const beers = JSON.parse(readFileSync('tmp/beerrepublic.json', 'utf8'));
+  const t0 = performance.now();
+  const results = await matchBeerList(catalog, new Set(), new Map(), beers);
+  const ms = performance.now() - t0;
+  const matched = results.filter((r) => r.matched_beer !== null).length;
+  console.log(`catalog=${catalog.length} beers=${beers.length}`);
+  console.log(`total=${ms.toFixed(0)}ms perBeer=${(ms/beers.length).toFixed(1)}ms matched=${matched}/${beers.length}`);
+  db.close();
+}
+void main();

--- a/tmp/ysilvestrov_maxid_1577238079.html
+++ b/tmp/ysilvestrov_maxid_1577238079.html
@@ -1,0 +1,2822 @@
+<!DOCTYPE html>
+
+<html lang="en">
+
+<head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# untappd: http://ogp.me/ns/fb/untappd#">
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+
+			<title>Yuriy Silvestrov on Untappd</title>
+		
+	<meta property="og:site_name" content="Untappd" />
+
+	<!-- meta block -->
+			<meta name="description" content="Yuriy Silvestrov Check-in Activity on Untappd with beer ratings, venues and more." />
+		<meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width" />
+	  		<meta property="fb:app_id" content="153339744679495" />
+  		<meta property="og:url"    content="https://untappd.com/user/ysilvestrov" />
+		<meta property="og:title"  content="Yuriy Silvestrov" />
+					<meta property="og:image" content="https://next.untappd.com/og/user/ysilvestrov.png" />
+						<meta property="og:image:width"  content="1200" />
+			<meta property="og:image:height" content="630" />
+					<meta property="og:description" content="Yuriy Silvestrov Check-in Activity on Untappd with beer ratings, venues and more." />
+
+		<meta property="og:type"   content="profile" />
+				<meta name="twitter:card" content="summary_large_image">
+		<meta name="twitter:site" content="@untappd">
+		<meta name="twitter:title" content="Yuriy Silvestrov on Untappd">
+		<meta name="twitter:description" content="Yuriy Silvestrov Check-in Activity on Untappd with beer ratings, venues and more.">
+		<meta name="twitter:image" content="https://next.untappd.com/og/user/ysilvestrov.png">
+		<meta name="twitter:domain" content="untappd.com">
+		<meta name="twitter:app:name:iphone" content="Untappd">
+        <meta name="twitter:app:name:android" content="Untappd">
+        <meta name="twitter:app:id:iphone" content="id449141888">
+        <meta name="twitter:app:id:googleplay" content="com.untappdllc.app">
+		<meta name="robots" content="noindex, nofollow"><meta name="referrer" content="origin-when-crossorigin">
+	<meta name="author" content="The Untappd Team" />
+	<meta name="Copyright" content="Copyright Untappd 2026. All Rights Reserved." />
+	<meta name="DC.title" content="Untappd" />
+			<meta name="DC.subject" content="Yuriy Silvestrov Check-in Activity on Untappd with beer ratings, venues and more." />
+			<meta name="DC.creator" content="The Untappd Team" />
+
+	<meta name="google-site-verification" content="EnR7QavTgiLCzZCCOv_OARCHsHhFwkwnJdG0Sti9Amg" />
+	<meta name="bitly-verification" content="b3080898518a"/>
+
+	<!-- favicon -->
+	<link rel="apple-touch-icon" sizes="144x144" href="https://untappd.com/assets/apple-touch-icon.png">
+	<link rel="icon" type="image/png" href="https://untappd.com/assets/favicon-32x32-v2.png" sizes="32x32">
+	<link rel="icon" type="image/png" href="https://untappd.com/assets/favicon-16x16-v2.png" sizes="16x16">
+	<link rel="manifest" href="https://untappd.com/assets/manifest.json">
+	<link rel="mask-icon" href="https://untappd.com/assets/safari-pinned-tab.svg" color="#5bbad5">
+
+	<link rel="stylesheet"
+    	href="https://untappd.com/assets/css/tailwind.css?v=2.8.37">
+	</link>
+
+			<link rel="stylesheet" href="https://untappd.com/assets/css/master.min.css?v=4.5.42" />
+		<link rel="stylesheet" href="https://untappd.com/assets/v3/css/style.css?v=4.5.42" />
+		<link rel="stylesheet" href="https://untappd.com/assets/design-system/css/styles.css?v=4.5.42" />
+		<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+		<link href="https://fonts.googleapis.com/css?family=Material+Icons|Material+Icons+Outlined|Material+Icons+Two+Tone|Material+Icons+Round|Material+Icons+Sharp" rel="stylesheet">
+			<script src="https://untappd.com/assets/v3/js/common/min/site_common_min.js?v=2.8.37"></script>
+				<link rel="stylesheet" href="https://untappd.com/assets/css/facybox.min.css?v=4.5.42" />
+			
+		<link rel="stylesheet" href="https://untappd.com/assets/css/jquery.notifyBar.min.css?v=4.5.42" />
+		<link rel="stylesheet" href="https://untappd.com/assets/css/tipsy.min.css?v=4.5.42" type="text/css" media="screen" title="no title" charset="utf-8">
+		
+		<script type="text/javascript" language="Javascript">
+			$(document).ready(function(){
+				$(".tip").tipsy({fade: true});
+				$('.badge_hint').tipsy({gravity: 's', fade: true});
+				$('.disabled').tipsy({gravity: 'n', fade: true});
+
+				refreshTime(".timezoner", "D MMM YY", true);
+
+				$(".tab").click(function(){
+					$(".tab-area li").removeClass('active');
+					$(this).parent().addClass('active');
+					$(".list").hide();
+					$($(this).attr("href")).show();
+					return false;
+				});
+			});
+
+			</script>
+			<!-- For IE -->
+	<script type="text/javascript" language="Javascript">
+	onChangeInterval = "";
+	if(!(window.console && console.log)) {
+	  console = {
+	    log: function(){},
+	    debug: function(){},
+	    info: function(){},
+	    warn: function(){},
+	    error: function(){}
+	  };
+	}
+	</script>
+	
+	<!-- algoliasearch -->
+	<script type="text/javascript" src="https://untappd.com/assets/libs/js/algoliasearch.min.js?v2.8.37"></script>
+	<script type="text/javascript" src="https://untappd.com/assets/libs/js/autocomplete.min.js?v2.8.37"></script>
+	<script type="text/javascript" src="https://untappd.com/assets/libs/js/lodash.min.js?v2.8.37"></script>
+	<script type="text/javascript" src="https://untappd.com/assets/js/global/autosearch_tracking.min.js?v2.8.37"></script>
+
+	<script>
+        !function(e,a,t,n,s,i,c){e.AlgoliaAnalyticsObject=s,e.aa=e.aa||function(){(e.aa.queue=e.aa.queue||[]).push(arguments)},i=a.createElement(t),c=a.getElementsByTagName(t)[0],i.async=1,i.src="https://cdn.jsdelivr.net/npm/search-insights@0.0.14",c.parentNode.insertBefore(i,c)}(window,document,"script",0,"aa");
+
+        // Initialize library
+        aa('init', {
+        applicationID: '9WBO4RQ3HO',
+        apiKey: '1d347324d67ec472bb7132c66aead485',
+        })
+    </script>
+
+
+			<!-- Google Tag Manager -->
+		<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+		new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+		j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+		'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+		})(window,document,'script','dataLayer','GTM-N4DVXTR');</script>
+		<!-- End Google Tag Manager -->
+	
+	<script src="https://untappd.com/assets/v3/js/venue-impression-tracker.js"></script>
+
+	<script type="text/javascript">
+		var clevertap = {event:[], profile:[], account:[], onUserLogin:[], region: 'us1', notifications:[], privacy:[]};
+        clevertap.account.push({"id": "865-K5R-W96Z"});
+        clevertap.privacy.push({optOut: false}); //set the flag to true, if the user of the device opts out of sharing their data
+        clevertap.privacy.push({useIP: true}); //set the flag to true, if the user agrees to share their IP data
+        (function () {
+                var wzrk = document.createElement('script');
+                wzrk.type = 'text/javascript';
+                wzrk.async = true;
+                wzrk.src = ('https:' == document.location.protocol ? 'https://d2r1yp2w7bby2u.cloudfront.net' : 'http://static.clevertap.com') + '/js/clevertap.min.js';
+                var s = document.getElementsByTagName('script')[0];
+                s.parentNode.insertBefore(wzrk, s);
+        })();
+	</script>
+
+    
+<!-- Freestar Ads -->
+<!-- Below is a recommended list of pre-connections, which allow the network to establish each connection quicker, speeding up response times and improving ad performance. -->
+<link rel="preconnect" href="https://a.pub.network/" crossorigin />
+<link rel="preconnect" href="https://b.pub.network/" crossorigin />
+<link rel="preconnect" href="https://c.pub.network/" crossorigin />
+<link rel="preconnect" href="https://d.pub.network/" crossorigin />
+<link rel="preconnect" href="https://c.amazon-adsystem.com" crossorigin />
+<link rel="preconnect" href="https://s.amazon-adsystem.com" crossorigin />
+<link rel="preconnect" href="https://btloader.com/" crossorigin />
+<link rel="preconnect" href="https://api.btloader.com/" crossorigin />
+<link rel="preconnect" href="https://cdn.confiant-integrations.net" crossorigin />
+<!-- Below is a link to a CSS file that accounts for Cumulative Layout Shift, a new Core Web Vitals subset that Google uses to help rank your site in search -->
+<!-- The file is intended to eliminate the layout shifts that are seen when ads load into the page. If you don't want to use this, simply remove this file -->
+<!-- To find out more about CLS, visit https://web.dev/vitals/ -->
+<link rel="stylesheet" href="https://a.pub.network/untappd-com/cls.css">
+<script data-cfasync="false" type="text/javascript">
+    var isLoggedIn = true;
+    console.log("freestar_init", `isLoggedIn: ${isLoggedIn}`);
+
+    var env = 'PROD';
+
+    var freestar = freestar || {};
+    freestar.queue = freestar.queue || [];
+    freestar.queue.push(function () {
+        if (env !== 'PROD') {   
+            googletag.pubads().set('page_url', 'https://untappd.com/'); // Makes ads fill in non-prod environments
+        }
+    });
+    freestar.config = freestar.config || {};
+    if (isLoggedIn) {
+        // https://freestarhelp.zendesk.com/hc/en-us/articles/34516941197460-Disabling-Products
+        freestar.config.disabledProducts = {
+            stickyFooter: true,
+            video: true,
+            stickyRail: true,
+            pushdown: true,
+            dynamicAds: true,
+            sideWall: true,
+            pageGrabber: true,
+            googleInterstitial: true,
+            videoAdhesion: true,
+            iai: true,
+        };  
+    }
+    freestar.config.enabled_slots = [];
+    freestar.initCallback = function () { (freestar.config.enabled_slots.length === 0) ? freestar.initCallbackCalled = false : freestar.newAdSlots(freestar.config.enabled_slots) };
+</script>
+
+
+<script src="https://a.pub.network/untappd-com/pubfig.min.js" data-cfasync="false" async></script>
+<script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js?network-code=15184186" ></script>
+<!-- End Freestar Ads -->
+    <!-- Freestar Ad Sticky Styling: https://resources.freestar.com/docs/sticky-ads-1 -->
+    <style>
+    div.sticky {
+        position: -webkit-sticky; /* Safari */
+        position: sticky;
+        top: 84px; /* Navbar height */
+    }
+    </style>
+
+</head>
+<style type="text/css">
+	.hidden {display: none;}
+	.main {
+       margin-top: 0px !important;
+   }
+</style>
+<script src="https://untappd.com/assets/libs/js/feather-icons@4.29.2.min.js"></script>
+<body onunload="">
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-N4DVXTR" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+<script type="text/javascript">
+		clevertap.event.push("pageview_user");
+	</script>
+
+<script type="text/javascript">
+    $(document).ready(function() {
+        $('a[data-href=":logout"]').on('click', function(event) {
+            clevertap.event.push("logout");
+        });
+        $('a[data-href=":external/help"]').on('click', function(event) {
+            clevertap.event.push("pageview_help");
+        });
+        $('a[data-href=":store"]').on('click', function(event) {
+            clevertap.event.push("pageview_store");
+        });
+        $('a[href="/admin"]').on('click', function(event) {
+          clevertap.event.push("pageview_admin");
+        });
+
+            });
+</script>
+<div id="mobile_nav_user">
+
+         <div class="nav_user_header">
+        <img src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" >
+        <p>Yuriy Silvestrov</p>
+      </div>
+      <ul>
+
+      
+        <li><a class="track-click" data-track="mobile_menu" data-href=":home" href="/home">Recent Activity</a></li>
+        <li><a class="track-click" data-track="mobile_menu" data-href=":user/profile" href="/user/ysilvestrov">My Profile</a></li>
+
+        <li><a class="track-click" data-track="mobile_menu" data-href=":stats" href="/stats">Personal Stats</a></li>
+        
+        <li><a class="track-click" data-track="mobile_menu" data-href=":user/beerhistory" href="/user/ysilvestrov/beers">Beer History</a></li>
+        <li><a href="#">My Events</a></li>
+        <li><a class="track-click" data-track="mobile_menu" data-href=":user/friends" href="/user/ysilvestrov/friends">Friends</a></li>
+        <li><a class="track-click" data-track="mobile_menu" data-href=":user/lists" href="/user/ysilvestrov/lists/">Lists</a></li>
+        <li><a class="track-click" data-track="mobile_menu" data-href=":user/badges" href="/user/ysilvestrov/badges">Badges</a></li>
+        <li><a class="track-click" data-track="mobile_menu" data-href=":user/venues" href="/user/ysilvestrov/venues">Venues</a></li>
+        <li><a class="track-click" data-track="mobile_menu" data-href=":account/settings" href="/account/settings">Account Settings</a></li>
+        <li><a class="track-click" data-track="mobile_menu" data-href=":logout" href="/logout">Logout</a></li>
+
+          </ul>
+    </div>
+
+<div id="mobile_nav_site">
+  <form class="search_box" method="get" action="/search">
+    <input type="text" class="track-focus search-input-desktop" autocomplete="off" data-track="desktop_search" placeholder="Find a drink, brewery or bar..." name="q" aria-label="Find a drink, brewery or bar search" />
+    <input type="submit" value="Submit the form!" style="position: absolute; top: 0; left: 0; z-index: 0; width: 1px; height: 1px; visibility: hidden;" />
+    <div class="autocomplete">
+    </div>
+  </form>
+  <ul>
+    <li><a class="track-click" data-track="mobile_menu" data-href=":blog" href="/blog">Blog</a></li>
+    <li><a class="track-click" data-track="mobile_menu" data-href=":beer/top_rated" href="/beer/top_rated">Top Rated</a></li>
+    <li><a class="track-click" data-track="mobile_menu" data-href=":supporter" href="/supporter">Insiders</a></li>
+    <li><a class="track-click" data-track="mobile_menu" data-href=":external/help" target="_blank" href="http://help.untappd.com">Help</a></li>
+    <li><a class="track-click" data-track="mobile_menu" data-href=":shop" target="_blank" href="https://untappd.com/shop">Shop</a></li>
+          <li><a class="track-click" data-track="mobile_menu" data-href=":sidebar/logout" href="/logout">Logout</a></li>
+        </ul>
+</div>
+<header>
+
+  <div class="inner mt-2">
+
+		<a class="track-click logo" style="margin-top: 2px;" data-track="desktop_header" data-href=":root" href="/">
+			<img src="https://untappd.com/assets/design-system/ut-brand-dark.svg" class="" alt="Untappd"/>
+		</a>
+
+          <div class="user_nav_btn">
+        <div style="position: relative;" >
+          <img  src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="ysilvestrov avatar">
+          <div data-brewery-portal-badge style="position: absolute; top: 0; right: 0; width: 10px; height: 10px; border-radius: 50%; background-color: #ffc000; z-index: 1000; display: none;">
+          </div>
+        </div>
+
+        <div class="nav_user_desktop">
+
+          <ul>
+
+            
+              <li><a class="track-click" data-track="desktop_menu" data-href=":home" href="/home">Recent Activity</a></li>
+              <li><a class="track-click" data-track="desktop_menu" data-href=":user/profile" href="/user/ysilvestrov">My Profile</a></li>
+
+              <li><a class="track-click" data-track="desktop_menu" data-href=":stats" href="/stats">Personal Stats</a></li>
+              
+              <li><a class="track-click" data-track="desktop_menu" data-href=":user/beerhistory" href="/user/ysilvestrov/beers">Beer History</a></li>
+              <li><a class="track-click" data-track="desktop_menu" data-href=":user/friends" href="/user/ysilvestrov/friends">Friends</a></li>
+              <li><a class="track-click" data-track="desktop_menu" data-href=":user/lists" href="/user/ysilvestrov/lists/">Lists</a></li>
+              <li><a class="track-click" data-track="desktop_menu" data-href=":user/badges" href="/user/ysilvestrov/badges">Badges</a></li>
+              <li><a class="track-click" data-track="desktop_menu" data-href=":user/venues" href="/user/ysilvestrov/venues">Venues</a></li>
+              <li><a class="track-click" data-track="desktop_menu" data-href=":account/settings" href="/account/settings">Account Settings</a></li>
+              <li><a class="track-click" data-track="desktop_menu" data-href=":logout" href="/logout">Logout</a></li>
+
+            
+          </ul>
+        </div>
+
+      </div>
+    
+    <div class="mobile_menu_btn">Menu</div>
+
+    <div id="nav_site">
+      <ul>
+        <li><a class="track-click" data-track="desktop_menu" data-href=":blog" href="/blog">Blog</a></li>
+        <li><a class="track-click" data-track="desktop_menu" data-href=":beer/top_rated" href="/beer/top_rated">Top Rated</a></li>
+        <li><a class="track-click" data-track="desktop_menu" data-href=":supporter" href="/supporter">Insiders</a></li>
+        <li><a class="track-click" data-track="desktop_menu" data-href=":external/help" target="_blank" href="http://help.untappd.com">Help</a></li>
+        <li><a class="track-click" data-track="desktop_menu" data-href=":shop" target="_blank" href="https://untappd.com/shop">Shop</a></li>
+      </ul>
+      <form class="search_box" method="get" action="/search">
+        <input type="text" class="track-focus search-input-desktop" autocomplete="off" data-track="desktop_search" placeholder="Find a drink, brewery or bar..." name="q" aria-label="Find a drink, brewery or bar search" />
+        <input type="submit" value="Submit the form!" style="position: absolute; top: 0; left: 0; z-index: 0; width: 1px; height: 1px; visibility: hidden;" />
+        <div class="autocomplete">
+        </div>
+      </form>
+    </div>
+    </div>
+</header>
+<style type="text/css">
+    .ac-selected {
+        background-color: #f8f8f8;
+    }
+</style>
+
+<div class="nav_open_overlay"></div>
+<div id="slide">
+
+<script>
+$(document).ready(() => {
+	$(".hide-notice-banner").on("click", function(e) {
+		e.preventDefault();
+		$(this).parent().parent().slideUp();
+		$.post(`/account/hide_notice_wildcard`, {cookie: $(this).attr('data-cookie-name')}, (data) => {
+			console.log(data);
+		}).fail((err) => {
+			console.error(err);
+		})
+	})
+
+	$(".hide-notice-simple").on("click", function(e) {
+		e.preventDefault();
+		$(this).parent().parent().slideUp();
+	})
+
+	feather.replace()
+})
+</script>
+
+<div class="cont user_profile">
+
+	<div class="profile_header" style="background-image: url('https://assets.untappd.com/site/assets/v3/images/cover_default.jpg'); background-position: center -0px" data-offset="0" data-image-url="https://assets.untappd.com/site/assets/v3/images/cover_default.jpg">
+
+		<div class="profile_header_loader">
+				<div id="floatingCirclesG">
+				  <div class="f_circleG" id="frotateG_01"></div>
+				  <div class="f_circleG" id="frotateG_02"></div>
+				  <div class="f_circleG" id="frotateG_03"></div>
+				  <div class="f_circleG" id="frotateG_04"></div>
+				  <div class="f_circleG" id="frotateG_05"></div>
+				  <div class="f_circleG" id="frotateG_06"></div>
+				  <div class="f_circleG" id="frotateG_07"></div>
+				  <div class="f_circleG" id="frotateG_08"></div>
+				</div>
+			</div>
+			<form id="coverPostionForm" style="display: none;">
+				<input type="hidden" name="offset" id="offset_cover">
+			</form>
+
+			<img class="cover_move" id="cover_photo_move" style="display: none;" src="https://assets.untappd.com/site/assets/v3/images/cover_default.jpg"/>
+
+			<div class="save-btn" style="display: none;">
+    		<a href="#" class="cancel-cover button grey track-click" data-track="profile" data-href=":coverphoto/cancelFinal">Cancel</a>
+    		<a href="#" class="save-cover button yellow track-click" data-track="profile" data-href=":coverphoto/saveFinal">Save Changes</a>
+ 			</div>
+			
+		<div class="content">
+							<form id="myFileForm" enctype="multipart/form-data">
+					<input type="file" id="fileInput" name="file" />
+				</form>
+				<div class="edit-cover">
+					<div class="edit-cover-holder">
+						<a class="edit-cover-image   track-click" data-track="profile" data-href=":coverphoto/change" href="#">Change</a><a class="adjust-cover-image track-click" data-track="profile" data-href=":coverphoto/adjust" href="#">Adjust</a><a class="remove-cover-image track-click" data-track="profile" data-href=":coverphoto/remove" href="#">Remove</a>
+					</div>
+				</div>
+
+				
+
+			<div class="user-info">
+				<div class="user-avatar">
+											<a href="/insiders" class="track-click" data-track="profile" data-href=":info/supporter" aria-label="insider"><span class="supporter"></span></a>
+											<div class="avatar-holder">
+						<img src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=125&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="User avatar">
+					</div>
+				</div><div class="info">
+					<h1>
+						Yuriy Silvestrov					</h1>
+					<div class="user-details">
+					<p class="username">ysilvestrov</p>
+						<p class="location">Warsaw</p>						<div class="social">
+																<p>
+										<a class="sq track-click" target="_blank" data-track="profile" data-href=":foursquare" href="https://foursquare.com/user/580666072">Foursquare</a>
+									</p>
+															</div>
+					</div>
+
+					<div class="stats">
+													<a href="/user/ysilvestrov" class="track-click" data-track="profile" data-href=":stats/general">
+								<span class="stat">12,407</span>
+								<span class="title">Total</span>
+							</a><a href="/user/ysilvestrov/beers" class="track-click" data-track="profile" data-href=":stats/beerhistory">
+								<span class="stat">11,548</span>
+								<span class="title">Unique</span>
+							</a><a href="/user/ysilvestrov/badges" class="track-click" data-track="profile" data-href=":stats/badges">
+								<span class="stat">6,678</span>
+								<span class="title">Badges</span>
+							</a><a href="/user/ysilvestrov/friends" class="track-click" data-track="profile" data-href=":stats/friends">
+								<span class="stat">154</span>
+								<span class="title">Friends</span>
+							</a>
+							
+					</div>
+
+					<div class="friend-button">
+
+						
+											</div>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	
+		<div class="profile_left">
+
+								<div class="photo-boxes">
+						<p><a href="/user/ysilvestrov/checkin/1578245453"><img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_15/126c53d3bf17347be7836822c4de38b0_c_1578245453_raw.jpg" alt="Recent check-in photo 1" /></a></p><p><a href="/user/ysilvestrov/checkin/1578231855"><img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_15/fac2c1b1706634e5cb1d730db6830669_c_1578231855_raw.jpg" alt="Recent check-in photo 2" /></a></p><p><a href="/user/ysilvestrov/checkin/1578224019"><img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_15/f1823729bfb0fbfbbe843cb0612db085_c_1578224019_raw.jpg" alt="Recent check-in photo 3" /></a></p><p><a href="/user/ysilvestrov/checkin/1578218159"><img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_15/f171035bfd107ba8b0f33b1d257743cd_c_1578218159_raw.jpg" alt="Recent check-in photo 4" /></a></p><p><a href="/user/ysilvestrov/photos"><span class="all">See All</span><img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_13/344ab989416b81a376620d8880420bab_c_1577501144_raw.jpg" alt="See all photos"></a></p>					</div>
+					
+			<div class="activity box">
+
+				<div class="content">
+												<h3>Your Recent Activity</h3>
+												<div id="main-stream">
+						
+			<div class="item " id="checkin_1578245453" data-checkin-id="1578245453">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/pohjala-emberwood/6421621" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6421621_b50b1_sm.jpeg" alt="Emberwood by Põhjala">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-9448532-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking an <a href="/b/pohjala-emberwood/6421621">Emberwood</a> by <a  href="/Pohjala">Põhjala</a> at <a href="/v/os-gorczewska-200/9448532">Os. Górczewska 200</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1578245453">
+									Чоколяда, копчене, смачне									</p>
+
+									
+								<p class="purchased" data-track-venue-impression="venue_id-12250363-type-checkin_feed">Purchased at <a href="/v/onemorebeer/12250363">OneMoreBeer</a></p>									<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/bottle@3x.png" alt="Bottle">
+										          <span>Bottle</span>
+										        </p>
+												<div class="caps " data-rating="4.5">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-50"></div>
+	</div>								    </div>
+									
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/esodin">
+																	<img src="https://assets.untappd.com/profile/e05c5d9aa3ed082e8354ab144e716a96_100x100.jpg" alt="Eugene Sodin avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/AlexFavorov">
+																	<img src="https://assets.untappd.com/profile/db287f406553168adbdc3a5e961b24e5_100x100.jpg" alt="Alex Favorov avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/eastern_european_beergeek">
+																	<img src="https://assets.untappd.com/profile/1fdf28d5abe5fb2af5d7d227f7d611da_100x100.jpg" alt="Eastern European Beergeek  avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1578245453" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_15/126c53d3bf17347be7836822c4de38b0_c_1578245453_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1578245453">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1578245453" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1578245453" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Mon, 15 Jun 2026 19:25:26 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1578245453" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1578245453">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>2</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="Astro-nat" href="/user/Astro-nat" title="Natali Astrowska" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/90a720216262d00799c526b254f7f2bb_100x100.jpg" alt="Natali Astrowska avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="Helen_Holyf" href="/user/Helen_Holyf" title="Helen Holyf" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/7bcac31154c0e22bdb36b6bfc9c5489d_100x100.jpg" alt="Helen Holyf avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1578245453" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1578245453" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1578245453'),$('#commentForm_1578245453 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1578245453" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1578245453" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1578231855" data-checkin-id="1578231855">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/coopers-best-extra-stout/4933" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-4933_c8252_sm.jpeg" alt="Best Extra Stout by Coopers">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-9448532-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/coopers-best-extra-stout/4933">Best Extra Stout</a> by <a  href="/CoopersBrewery">Coopers</a> at <a href="/v/os-gorczewska-200/9448532">Os. Górczewska 200</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1578231855">
+									Чоколяда, гірке, пересмажений солод, кислинка. Дивне									</p>
+
+																					<p class="comment-text-orginial" id="translateorg_1578231855" style="display: none;"></p>
+												<div class="translate"><a href="#" class="translate-text" data-checkin-id="1578231855">Translate</a></div>
+												
+								<p class="purchased" data-track-venue-impression="venue_id-5770655-type-checkin_feed">Purchased at <a href="/v/auchan/5770655">Auchan</a></p>									<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/bottle@3x.png" alt="Bottle">
+										          <span>Bottle</span>
+										        </p>
+												<div class="caps " data-rating="3.5">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-50"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+																			<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/promo/4434d775ba_UTC-WorldPint-Badges-01_2.png" alt="World Pint 2026: Australia">
+											<span>Earned the World Pint 2026: Australia badge!</span>
+										</span>
+										
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/AlexFavorov">
+																	<img src="https://assets.untappd.com/profile/db287f406553168adbdc3a5e961b24e5_100x100.jpg" alt="Alex Favorov avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/JurgenChe">
+																	<img src="https://assets.untappd.com/profile/1b6fb9917d398a52b6078f2f2ca46ed1_100x100.png" alt="Yurii Chetverykov avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/annaklym">
+																	<img src="https://assets.untappd.com/profile/57ee93afe7e46d0211bcd0be2dba073f_100x100.jpg" alt="Анна Клименко avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/esodin">
+																	<img src="https://assets.untappd.com/profile/e05c5d9aa3ed082e8354ab144e716a96_100x100.jpg" alt="Eugene Sodin avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/eastern_european_beergeek">
+																	<img src="https://assets.untappd.com/profile/1fdf28d5abe5fb2af5d7d227f7d611da_100x100.jpg" alt="Eastern European Beergeek  avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1578231855" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_15/fac2c1b1706634e5cb1d730db6830669_c_1578231855_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1578231855">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1578231855" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1578231855" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Mon, 15 Jun 2026 18:19:33 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1578231855" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1578231855">Delete Check-In</a>						</div>
+
+						<div class="cheers" style="display: none;">								<span class="count"><span>0</span></span>
+								<span class="toast-list"></span>
+														</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1578231855" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1578231855" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1578231855'),$('#commentForm_1578231855 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1578231855" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1578231855" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1578224019" data-checkin-id="1578224019">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/saku-olletehas-karl-friedrich-kali-kirss/6214005" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6214005_b4baf_sm.jpeg" alt="Karl Friedrich Kali Kirss by Saku Õlletehas">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-9448532-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/saku-olletehas-karl-friedrich-kali-kirss/6214005">Karl Friedrich Kali Kirss</a> by <a  href="/w/saku-olletehas/1094">Saku Õlletehas</a> at <a href="/v/os-gorczewska-200/9448532">Os. Górczewska 200</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1578224019">
+									Химозна вишня, солодке, та й таке									</p>
+
+									
+								<p class="purchased" data-track-venue-impression="venue_id-5770655-type-checkin_feed">Purchased at <a href="/v/auchan/5770655">Auchan</a></p>									<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/can@3x.png" alt="Can">
+										          <span>Can</span>
+										        </p>
+												<div class="caps " data-rating="3.5">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-50"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+																			<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/badges/bdg_KvassRyeot_2020_sm.jpg" alt="Kvass RYEot (Level 14)">
+											<span>Earned the Kvass RYEot (Level 14) badge!</span>
+										</span>
+										
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/eastern_european_beergeek">
+																	<img src="https://assets.untappd.com/profile/1fdf28d5abe5fb2af5d7d227f7d611da_100x100.jpg" alt="Eastern European Beergeek  avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/esodin">
+																	<img src="https://assets.untappd.com/profile/e05c5d9aa3ed082e8354ab144e716a96_100x100.jpg" alt="Eugene Sodin avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/AlexFavorov">
+																	<img src="https://assets.untappd.com/profile/db287f406553168adbdc3a5e961b24e5_100x100.jpg" alt="Alex Favorov avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/JurgenChe">
+																	<img src="https://assets.untappd.com/profile/1b6fb9917d398a52b6078f2f2ca46ed1_100x100.png" alt="Yurii Chetverykov avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/annaklym">
+																	<img src="https://assets.untappd.com/profile/57ee93afe7e46d0211bcd0be2dba073f_100x100.jpg" alt="Анна Клименко avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1578224019" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_15/f1823729bfb0fbfbbe843cb0612db085_c_1578224019_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1578224019">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1578224019" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1578224019" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Mon, 15 Jun 2026 17:37:29 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1578224019" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1578224019">Delete Check-In</a>						</div>
+
+						<div class="cheers" style="display: none;">								<span class="count"><span>0</span></span>
+								<span class="toast-list"></span>
+														</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1578224019" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1578224019" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1578224019'),$('#commentForm_1578224019 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1578224019" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1578224019" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1578218159" data-checkin-id="1578218159">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/moon-lark-brewery-non-alcoholic-czech-pils-nealko-5-deg-extra-horka/6647823" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6647823_0b37a_sm.jpeg" alt="Non-Alcoholic Czech Pils / Nealko 5° Extra Hořká by Moon Lark Brewery">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-9448532-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/moon-lark-brewery-non-alcoholic-czech-pils-nealko-5-deg-extra-horka/6647823">Non-Alcoholic Czech Pils / Nealko 5° Extra Hořká</a> by <a  href="/MoonLarkBrewery">Moon Lark Brewery</a> at <a href="/v/os-gorczewska-200/9448532">Os. Górczewska 200</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1578218159">
+									Гарна безалко									</p>
+
+									
+								<p class="purchased" data-track-venue-impression="venue_id-12963055-type-checkin_feed">Purchased at <a href="/v/kaufland/12963055">Kaufland</a></p>									<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/bottle@3x.png" alt="Bottle">
+										          <span>Bottle</span>
+										        </p>
+												<div class="caps " data-rating="4">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+																			<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/badges/bdg_LagerJack_sm.jpg" alt="Lager Jack (Level 57)">
+											<span>Earned the Lager Jack (Level 57) badge!</span>
+										</span>
+										
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/esodin">
+																	<img src="https://assets.untappd.com/profile/e05c5d9aa3ed082e8354ab144e716a96_100x100.jpg" alt="Eugene Sodin avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/AlexFavorov">
+																	<img src="https://assets.untappd.com/profile/db287f406553168adbdc3a5e961b24e5_100x100.jpg" alt="Alex Favorov avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/JurgenChe">
+																	<img src="https://assets.untappd.com/profile/1b6fb9917d398a52b6078f2f2ca46ed1_100x100.png" alt="Yurii Chetverykov avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/eastern_european_beergeek">
+																	<img src="https://assets.untappd.com/profile/1fdf28d5abe5fb2af5d7d227f7d611da_100x100.jpg" alt="Eastern European Beergeek  avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1578218159" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_15/f171035bfd107ba8b0f33b1d257743cd_c_1578218159_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1578218159">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1578218159" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1578218159" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Mon, 15 Jun 2026 17:06:26 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1578218159" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1578218159">Delete Check-In</a>						</div>
+
+						<div class="cheers" style="display: none;">								<span class="count"><span>0</span></span>
+								<span class="toast-list"></span>
+														</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1578218159" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1578218159" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1578218159'),$('#commentForm_1578218159 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1578218159" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1578218159" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1577501144" data-checkin-id="1577501144">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/palatum-hazy-ipa-mbc/5423687" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/brewery_logos/brewery-270446_8b440.jpeg" alt="Hazy IPA (MBC) by Palatum">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-12359853-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/palatum-hazy-ipa-mbc/5423687">Hazy IPA (MBC)</a> by <a  href="/BrowarPalatum">Palatum</a> at <a href="/v/willa-ogrodnikow/12359853">Willa Ogrodników</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1577501144">
+									Охмілене, гірке, соковите, доволі смачно									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/draft@3x.png" alt="Draft">
+										          <span>Draft</span>
+										        </p>
+												<div class="caps " data-rating="4.2">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-20"></div>
+	</div>								    </div>
+									
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1577501144" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_13/344ab989416b81a376620d8880420bab_c_1577501144_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1577501144">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1577501144" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1577501144" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Sat, 13 Jun 2026 12:06:44 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1577501144" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1577501144">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>1</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1577501144" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1577501144" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1577501144'),$('#commentForm_1577501144 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1577501144" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1577501144" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1577350490" data-checkin-id="1577350490">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/seoul-brewery-disco-bong-bong-rye-fruit-sour/6599426" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6599426_55fd7_sm.jpeg" alt="DISCO BONG BONG RYE FRUIT SOUR by 서울브루어리ㅣSEOUL BREWERY">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-10592162-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/seoul-brewery-disco-bong-bong-rye-fruit-sour/6599426">DISCO BONG BONG RYE FRUIT SOUR</a> by <a  href="/SeoulBrewery">서울브루어리ㅣSEOUL BREWERY</a> at <a href="/v/pinta-warszawa-craft-beer-food/10592162">PINTA Warszawa Craft Beer & Food</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1577350490">
+									Норм кислячок									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/draft@3x.png" alt="Draft">
+										          <span>Draft</span>
+										        </p>
+												<div class="caps " data-rating="3.8">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-80"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+																			<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/promo/dacc277d2e_SOUTH-KOREA-UTC-WorldPint-Badges-07.png" alt="World Pint 2026: South Korea">
+											<span>Earned the World Pint 2026: South Korea badge!</span>
+										</span>
+										
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/Black_mzfk">
+																	<img src="https://assets.untappd.com/profile/c48718cf62242ead68e5309884791628_100x100.jpg" alt="Mykola Bortnychuk avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1577350490" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_12/3adb415e6c9466da3dfcee8c4900b04a_c_1577350490_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1577350490">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1577350490" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1577350490" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Fri, 12 Jun 2026 21:23:39 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1577350490" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1577350490">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>2</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="nyakove" href="/user/nyakove" title="Mykhailo Dykun" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/6d3ba80291124794db1a990f33237fb0_100x100.jpg" alt="Mykhailo Dykun avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1577350490" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1577350490" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1577350490'),$('#commentForm_1577350490 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1577350490" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1577350490" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1577349937" data-checkin-id="1577349937">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/nepo-brewing-top-tier/6748324" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/brewery_logos/brewery-192779_0e99d.jpeg" alt="Top-tier by Nepo Brewing">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-10592162-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/nepo-brewing-top-tier/6748324">Top-tier</a> by <a  href="/BrowarNepomucen">Nepo Brewing</a> at <a href="/v/pinta-warszawa-craft-beer-food/10592162">PINTA Warszawa Craft Beer & Food</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1577349937">
+									Норм іпашка									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/draft@3x.png" alt="Draft">
+										          <span>Draft</span>
+										        </p>
+												<div class="caps " data-rating="4.2">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-20"></div>
+	</div>								    </div>
+									
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/Black_mzfk">
+																	<img src="https://assets.untappd.com/profile/c48718cf62242ead68e5309884791628_100x100.jpg" alt="Mykola Bortnychuk avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1577349937" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_12/5550c4bc16249c8d37ffd851c479f752_c_1577349937_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1577349937">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1577349937" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1577349937" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Fri, 12 Jun 2026 21:22:25 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1577349937" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1577349937">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>2</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="Nesh05" href="/user/Nesh05" title="Oleksandr Bogachov" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/108d6fb78e50a061b264b0578e51caed_100x100.jpg" alt="Oleksandr Bogachov avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1577349937" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1577349937" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1577349937'),$('#commentForm_1577349937 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1577349937" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1577349937" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1577333058" data-checkin-id="1577333058">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/pinta-barrel-brewing-patience-5th-anniversary-2026/6655583" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6655583_88c2e_sm.jpeg" alt="Patience 5th Anniversary (2026) by PINTA Barrel Brewing">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-11769928-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/pinta-barrel-brewing-patience-5th-anniversary-2026/6655583">Patience 5th Anniversary (2026)</a> by <a  href="/PINTABarrelBrewing">PINTA Barrel Brewing</a> at <a href="/v/hopito-chmielna/11769928">Hopito Chmielna</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1577333058">
+									Вме ще топ									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/bottle@3x.png" alt="Bottle">
+										          <span>Bottle</span>
+										        </p>
+												<div class="caps " data-rating="4.9">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-90"></div>
+	</div>								    </div>
+									
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Connoisseur">
+																	<img src="https://assets.untappd.com/profile/4a2ca4a782c24e072988b781352672c4_100x100.jpeg" alt="Victor  avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/Black_mzfk">
+																	<img src="https://assets.untappd.com/profile/c48718cf62242ead68e5309884791628_100x100.jpg" alt="Mykola Bortnychuk avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1577333058" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_12/88ee0d631a83acccf5b0d7b989128dc7_c_1577333058_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1577333058">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1577333058" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1577333058" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Fri, 12 Jun 2026 20:46:34 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1577333058" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1577333058">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>3</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="Nesh05" href="/user/Nesh05" title="Oleksandr Bogachov" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/108d6fb78e50a061b264b0578e51caed_100x100.jpg" alt="Oleksandr Bogachov avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="svitlanalana" href="/user/svitlanalana" title="Lana" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/ba31a55574f315078a68d2e6077353c8_100x100.jpg" alt="Lana avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1577333058" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1577333058" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1577333058'),$('#commentForm_1577333058 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1577333058" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1577333058" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1577329184" data-checkin-id="1577329184">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/sadyba-dropsy/6533724" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6533724_6a208_sm.jpeg" alt="Dropsy by Sadyba">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-11769928-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/sadyba-dropsy/6533724">Dropsy</a> by <a  href="/w/sadyba/581444">Sadyba</a> at <a href="/v/hopito-chmielna/11769928">Hopito Chmielna</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1577329184">
+									Наче норм									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/draft@3x.png" alt="Draft">
+										          <span>Draft</span>
+										        </p>
+												<div class="caps " data-rating="3.9">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-90"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+									
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/Black_mzfk">
+																	<img src="https://assets.untappd.com/profile/c48718cf62242ead68e5309884791628_100x100.jpg" alt="Mykola Bortnychuk avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Connoisseur">
+																	<img src="https://assets.untappd.com/profile/4a2ca4a782c24e072988b781352672c4_100x100.jpeg" alt="Victor  avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1577329184" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_12/a99db013b2459429a1ae0c4a27504eb7_c_1577329184_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1577329184">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1577329184" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1577329184" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Fri, 12 Jun 2026 20:38:55 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1577329184" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1577329184">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>1</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1577329184" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1577329184" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1577329184'),$('#commentForm_1577329184 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1577329184" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1577329184" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1577315325" data-checkin-id="1577315325">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/carlsberg-ukraine-lvivske-porter-lvivske-porter/17427" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-17427_d4f82_sm.jpeg" alt="Lvivske Porter (Львівське Портер) by Carlsberg Ukraine">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-11769928-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/carlsberg-ukraine-lvivske-porter-lvivske-porter/17427">Lvivske Porter (Львівське Портер)</a> by <a  href="/w/carlsberg-ukraine/4697">Carlsberg Ukraine</a> at <a href="/v/hopito-chmielna/11769928">Hopito Chmielna</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1577315325">
+									Бочеовий варіант. Дуже смачно насправді									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/bottle@3x.png" alt="Bottle">
+										          <span>Bottle</span>
+										        </p>
+												<div class="caps " data-rating="4">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+																			<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/badges/bdg_SupportforUkraine_sm.jpg" alt="Support for Ukraine (Level 96)">
+											<span>Earned the Support for Ukraine (Level 96) badge!</span>
+										</span>
+										
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Connoisseur">
+																	<img src="https://assets.untappd.com/profile/4a2ca4a782c24e072988b781352672c4_100x100.jpeg" alt="Victor  avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/Black_mzfk">
+																	<img src="https://assets.untappd.com/profile/c48718cf62242ead68e5309884791628_100x100.jpg" alt="Mykola Bortnychuk avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1577315325" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_12/da71586c2d556302d3067372bfea1dc1_c_1577315325_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1577315325">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1577315325" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1577315325" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Fri, 12 Jun 2026 20:14:08 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1577315325" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1577315325">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>3</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="ozerova" href="/user/ozerova" title="Alona Ozerova" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/32b6ee38b32a094a267bb390cbfc86cb_100x100.jpg" alt="Alona Ozerova avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="nyakove" href="/user/nyakove" title="Mykhailo Dykun" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/6d3ba80291124794db1a990f33237fb0_100x100.jpg" alt="Mykhailo Dykun avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1577315325" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1577315325" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1577315325'),$('#commentForm_1577315325 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1577315325" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1577315325" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1577305648" data-checkin-id="1577305648">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/browar-stu-mostow-green-fury/6671151" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6671151_d09f2_sm.jpeg" alt="Green Fury by Browar Stu Mostów">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-11769928-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/browar-stu-mostow-green-fury/6671151">Green Fury</a> by <a  href="/BrowarStuMostow">Browar Stu Mostów</a> at <a href="/v/hopito-chmielna/11769928">Hopito Chmielna</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1577305648">
+									Йолка, тіло, смачно									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/draft@3x.png" alt="Draft">
+										          <span>Draft</span>
+										        </p>
+												<div class="caps " data-rating="4.1">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-10"></div>
+	</div>								    </div>
+									
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/Black_mzfk">
+																	<img src="https://assets.untappd.com/profile/c48718cf62242ead68e5309884791628_100x100.jpg" alt="Mykola Bortnychuk avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Connoisseur">
+																	<img src="https://assets.untappd.com/profile/4a2ca4a782c24e072988b781352672c4_100x100.jpeg" alt="Victor  avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1577305648" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_12/354fda89bb32e000ef77856793f8c8b1_c_1577305648_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1577305648">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1577305648" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1577305648" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Fri, 12 Jun 2026 19:57:17 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1577305648" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1577305648">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>1</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1577305648" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1577305648" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1577305648'),$('#commentForm_1577305648 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1577305648" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1577305648" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1577302563" data-checkin-id="1577302563">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/cydr-chyliczki-stary-sad-2023/5828405" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/brewery_logos/brewery-271740_52802.jpeg" alt="Stary Sad 2023 by Cydr Chyliczki">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-11769928-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/cydr-chyliczki-stary-sad-2023/5828405">Stary Sad 2023</a> by <a  href="/CydrChyliczki">Cydr Chyliczki</a> at <a href="/v/hopito-chmielna/11769928">Hopito Chmielna</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1577302563">
+									Наче норм									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/draft@3x.png" alt="Draft">
+										          <span>Draft</span>
+										        </p>
+												<div class="caps " data-rating="4">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+									
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/Black_mzfk">
+																	<img src="https://assets.untappd.com/profile/c48718cf62242ead68e5309884791628_100x100.jpg" alt="Mykola Bortnychuk avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Connoisseur">
+																	<img src="https://assets.untappd.com/profile/4a2ca4a782c24e072988b781352672c4_100x100.jpeg" alt="Victor  avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1577302563" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_12/374237dbbdc305f2d788985179b70b2f_c_1577302563_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1577302563">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1577302563" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1577302563" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Fri, 12 Jun 2026 19:51:45 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1577302563" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1577302563">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>1</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1577302563" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1577302563" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1577302563'),$('#commentForm_1577302563 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1577302563" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1577302563" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1577255517" data-checkin-id="1577255517">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/white-crow-brew-dept-la-tomatina-originale-vol-3/6584367" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6584367_30aa6_sm.jpeg" alt="La Tomatina Originale vol.3 by White Crow Brew Dept ">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-12617758-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/white-crow-brew-dept-la-tomatina-originale-vol-3/6584367">La Tomatina Originale vol.3</a> by <a  href="/WhiteCrowBrewDivision">White Crow Brew Dept </a> at <a href="/v/white-crow-craft-beer-and-kitchen/12617758">White Crow Craft Beer & Kitchen</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1577255517">
+									Гостре, смачне									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/taster@3x.png" alt="Taster">
+										          <span>Taster</span>
+										        </p>
+												<div class="caps " data-rating="4.6">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-60"></div>
+	</div>								    </div>
+									
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Connoisseur">
+																	<img src="https://assets.untappd.com/profile/4a2ca4a782c24e072988b781352672c4_100x100.jpeg" alt="Victor  avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1577255517" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_12/21df86329a0aae70df34f296406dec98_c_1577255517_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1577255517">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1577255517" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1577255517" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Fri, 12 Jun 2026 18:30:34 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1577255517" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1577255517">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>1</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1577255517" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1577255517" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1577255517'),$('#commentForm_1577255517 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1577255517" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1577255517" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1577247607" data-checkin-id="1577247607">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/funky-fluid-funky-on-tour-islay/6728427" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6728427_cdd3e_sm.jpeg" alt="Funky On Tour: Islay by Funky Fluid">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-12767316-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/funky-fluid-funky-on-tour-islay/6728427">Funky On Tour: Islay</a> by <a  href="/FunkyFluid">Funky Fluid</a> at <a href="/v/offside/12767316">Offside</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1577247607">
+									Дуже норм peated. 0.25 на бурбонову версію									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/can@3x.png" alt="Can">
+										          <span>Can</span>
+										        </p>
+												<div class="caps " data-rating="4.5">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-50"></div>
+	</div>								    </div>
+																			<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/badges/aae45250bb4d36b264f1165ab0a6d94c_sm.jpeg" alt="White Guard LvL2 (Level 32)">
+											<span>Earned the White Guard LvL2 (Level 32) badge!</span>
+										</span>
+										
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/Black_mzfk">
+																	<img src="https://assets.untappd.com/profile/c48718cf62242ead68e5309884791628_100x100.jpg" alt="Mykola Bortnychuk avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Connoisseur">
+																	<img src="https://assets.untappd.com/profile/4a2ca4a782c24e072988b781352672c4_100x100.jpeg" alt="Victor  avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1577247607" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_12/9c64c7326557f31a3089bbd221b6689f_c_1577247607_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1577247607">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1577247607" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1577247607" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Fri, 12 Jun 2026 18:15:33 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1577247607" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1577247607">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>1</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1577247607" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1577247607" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1577247607'),$('#commentForm_1577247607 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1577247607" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1577247607" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1577238079" data-checkin-id="1577238079">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/fuerst-wiacek-berlin-cool-jumper/6728184" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/brewery_logos/brewery-314016_5eba0.jpeg" alt="Cool Jumper by FUERST WIACEK Berlin">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-12617758-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/fuerst-wiacek-berlin-cool-jumper/6728184">Cool Jumper</a> by <a  href="/fuerstwiacekbrew">FUERST WIACEK Berlin</a> at <a href="/v/white-crow-craft-beer-and-kitchen/12617758">White Crow Craft Beer & Kitchen</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1577238079">
+									Кисленьке									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/taster@3x.png" alt="Taster">
+										          <span>Taster</span>
+										        </p>
+												<div class="caps " data-rating="3.7">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-70"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+																			<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/badges/bdg_DasBoot16_sm.jpg" alt="Das Boot (Level 72)">
+											<span>Earned the Das Boot (Level 72) badge!</span>
+										</span>
+										
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Connoisseur">
+																	<img src="https://assets.untappd.com/profile/4a2ca4a782c24e072988b781352672c4_100x100.jpeg" alt="Victor  avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/Black_mzfk">
+																	<img src="https://assets.untappd.com/profile/c48718cf62242ead68e5309884791628_100x100.jpg" alt="Mykola Bortnychuk avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1577238079" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_12/5205f868da62cc102719b2544f8a6025_c_1577238079_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1577238079">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1577238079" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1577238079" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Fri, 12 Jun 2026 17:57:01 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1577238079" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1577238079">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>2</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="ozerova" href="/user/ozerova" title="Alona Ozerova" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/32b6ee38b32a094a267bb390cbfc86cb_100x100.jpg" alt="Alona Ozerova avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1577238079" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1577238079" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1577238079'),$('#commentForm_1577238079 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1577238079" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1577238079" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+						<script type="text/javascript" src="https://untappd.com/assets/v3/js/common/min/feed_scripts_min.js?v=2.8.37"></script>
+			<style type="text/css">
+				.translate {
+					color: #000;
+				    font-weight: 600;
+				    font-size: 12px;
+				    text-transform: uppercase;
+				    margin-bottom: 0px;
+				    margin-top: 15px;
+				    margin-bottom: 10px;
+				}
+			</style>
+								<script type="text/javascript">
+						$(document).on("click", ".translate-text", function() {
+							const _this = this;
+
+							const checkinId = $(_this).attr("data-checkin-id");
+
+							if ($(_this).text() == "See Original") {
+								$(_this).html("Translate");
+								const orgText = $(`#translateorg_${checkinId}`).html();
+								$(`#translate_${checkinId}`).html(orgText);
+								$(`#translateorg_${checkinId}`).html('');
+							} else {
+								const orgText = $(`#translate_${checkinId}`).html();
+								$(`#translateorg_${checkinId}`).html(orgText);
+
+								$(_this).attr("disabled", "true");
+		   						$(_this).html("Loading....");
+
+		   						$.ajax({
+									url: `/apireqs/translate/${checkinId}`,
+									type: "GET",
+									dataType: "json",
+									headers: {
+									    'Accept': 'application/json',
+									    'Accept-Language': navigator.language
+									},
+								    error: function(html)
+									{
+										$(_this).attr("disabled", "false");
+						   				$(_this).html("Translate");
+
+										var tct = "Something went horribly wrong. Please refresh the page and try again.";
+
+										$.notifyBar({
+											html: tct,
+											delay: 2000,
+											animationSpeed: "normal"
+										  })
+									},
+									success: function(html)
+									{
+										if (!html.error) {
+											$(_this).attr("disabled", "false");
+						   					$(_this).html("See Original");
+											$(`#translate_${checkinId}`).html(html.data.translated_text);
+										} else {
+
+											$(_this).attr("disabled", "false");
+						   					$(_this).html("Translate");
+
+											$.notifyBar({
+												html: html.error,
+												delay: 2000,
+												animationSpeed: "normal"
+										  })
+										}
+									}
+								});
+							}
+
+							return false;
+						})
+					</script>
+					
+			<script id="delete-checkin-container" type="text/x-handlebars-template">
+				<div class="delete-confirm-checkin"></div>
+			</script>
+			<script id="delete-checkin-template" type="text/x-handlebars-template">
+				<div class="modal delete-confirm"><div class="inner"><div class="top"><a class="close" href="#"></a><h3 style="margin-bottom: 0px; padding-bottom: 0px; border-bottom: none;">Confirm Check-in Deletion</h3></div><div class="error" id="delete-checkin-error" style="display: none;"></div><div class="delete-confirm-message" style="padding: 24px; text-align: center; -moz-box-sizing: border-box; box-sizing: border-box;"><p><strong>Warning</strong> - Are you sure you want to delete this check-in? This cannot be undone. All badges that are associated with this check-in will be removed.</p><div class="inner-container" style="width: 80%; margin: 15px auto;"><a href="#" class="check-confirm-deletion" data-checkin-id="{{checkin_id}}" style="margin-top: 15px;">Confirm Deletion</a><p id="checkin-delete-loader" class="stream-loading"><span></span></p></div></div></div></div>
+			</script>
+			<script id="comment-template" type="text/x-handlebars-template">
+				{{#each items}}<div class="comment" id="comment_{{this.comment_id}}"><div class="avatar"><div class="avatar-holder">{{#if this.user.supporter}} <span class="supporter"></span>{{/if}}<a href="/user/{{this.user.user_name}}"><img src="{{this.user.user_avatar}}" alt="Your Avatar"></a></div></div><div class="text"><p><a href="/user/{{this.user.user_name}}">{{this.user.first_name}} {{this.user.last_name}}</a>: <abbr id="checkincomment_{{this.comment_id}}">{{{this.comment}}}</abbr></p><p class="meta"><span class="time timezoner">{{this.created_at}}</span>{{#if this.comment_editor}}<a href="#" class="comment-edit" data-comment-id="{{this.comment_id}}">Edit</a>{{/if}}{{#if this.comment_owner}}<a href="#" class="comment-delete" data-comment-id="{{this.comment_id}}">Delete</a>{{/if}}</p></div></div>{{#if this.comment_editor}}<div class="comment" id="commentedit_{{this.comment_id}}" style="display: none;"><div class="avatar"><div class="avatar-holder">{{#if this.user.supporter}} <span class="supporter"></span>{{/if}}<a href="/user/{{this.user.user_name}}"><img src="{{this.user.user_avatar}}" alt="Your Avatar"></a></div></div><div class="text"><form class="editing"><p class="editerror_{{this.comment_id}} post-error" style="display: none;">There was a problem posting your comment, please try again.</p><textarea name="comment" id="commentBox_{{this.comment_id}}" onkeydown="limitTextReverse($('#commentBox_{{this.comment_id}}'),$('#commentedit_{{this.comment_id}} .myCount'), 140);">{{{this.comment}}}</textarea><span class="comment-loading" style="display: none;"></span><span class="counter"><abbr class="myCount">0</abbr>/140</span><span class="actions"><a href="#" class="submit comment-update-save" data-comment-id="{{this.comment_id}}">Update</a><a href="#" data-comment-id="{{this.comment_id}}" class="cancel comment-update-cancel">Cancel</a></span></form></div></div>{{/if}}{{/each}}
+			</script>
+			<script type="text/javascript">
+				$(document).ready(function() {
+					createImpressionTracker();
+				});
+			</script>
+			
+					</div>
+
+
+				<a href="#" data-user-name="ysilvestrov" class="yellow button more_checkins more_checkins_logged track-click" data-track="profile" data-href=":feed/showmore">Show More</a>
+						<p class="stream-loading"><span></span></p>
+									</div>
+			</div>
+		</div>
+
+		<div class="sidebar">
+
+
+			       <div class="box">
+            <div class="content">
+                <h3>Lists</h3>
+                                    <div class="list-item list-none">
+                        <div class="labels">
+                            <a href="/user/ysilvestrov/lists/11839499" aria-label="List image">
+                                <img src="https://assets.untappd.com/site/beer_logos/beer-65758_58817_sm.jpeg" alt="Beer label"><img src="https://assets.untappd.com/site/beer_logos/beer-7884_f1d70_sm.jpeg" alt="Beer label"><img src="https://assets.untappd.com/site/beer_logos/beer-5129955_a9541_sm.jpeg" alt="Beer label"><img src="https://assets.untappd.com/site/beer_logos/beer-70951_9a907_sm.jpeg" alt="Beer label">                            </a>
+                        </div>
+                        <div class="details">
+                            <span class="name"><a href="/user/ysilvestrov/lists/11839499">Silver Spoon Nest</a></span>
+                            <span class="meta">17 Items &bull; Updated <abbr class="format-date" data-date="Mon, 15 Jun 2026 19:25:35 +0000"></abbr></span>
+                        </div>
+                    </div>
+
+                                        <div class="list-item list-none">
+                        <div class="labels">
+                            <a href="/user/ysilvestrov/lists/12193314" aria-label="List image">
+                                <img src="https://assets.untappd.com/site/assets/images/temp/badge-beer-default.png" alt="Beer label"><img src="https://assets.untappd.com/site/beer_logos/beer-6630153_b50f7_sm.jpeg" alt="Beer label">                            </a>
+                        </div>
+                        <div class="details">
+                            <span class="name"><a href="/user/ysilvestrov/lists/12193314">No&Low</a></span>
+                            <span class="meta">2 Items &bull; Updated <abbr class="format-date" data-date="Mon, 15 Jun 2026 17:37:40 +0000"></abbr></span>
+                        </div>
+                    </div>
+
+                                        <div class="list-item list-none">
+                        <div class="labels">
+                            <a href="/user/ysilvestrov/lists/12745229" aria-label="List image">
+                                <img src="https://assets.untappd.com/site/beer_logos/beer-5825687_1452f_sm.jpeg" alt="Beer label"><img src="https://assets.untappd.com/site/beer_logos/beer-6512265_40888_sm.jpeg" alt="Beer label"><img src="https://assets.untappd.com/site/beer_logos/beer-6482949_c1802_sm.jpeg" alt="Beer label"><img src="https://assets.untappd.com/site/beer_logos/beer-6524976_72e17_sm.jpeg" alt="Beer label">                            </a>
+                        </div>
+                        <div class="details">
+                            <span class="name"><a href="/user/ysilvestrov/lists/12745229">Silver Spon Nest Premium</a></span>
+                            <span class="meta">17 Items &bull; Updated <abbr class="format-date" data-date="Fri, 12 Jun 2026 15:05:39 +0000"></abbr></span>
+                        </div>
+                    </div>
+
+                                        <div class="list-item list-none">
+                        <div class="labels">
+                            <a href="/user/ysilvestrov/lists/11720173" aria-label="List image">
+                                <img src="https://assets.untappd.com/site/beer_logos/beer-6126390_13c88_sm.jpeg" alt="Beer label"><img src="https://assets.untappd.com/site/assets/images/temp/badge-beer-default.png" alt="Beer label"><img src="https://assets.untappd.com/site/assets/images/temp/badge-beer-default.png" alt="Beer label"><img src="https://assets.untappd.com/site/beer_logos/beer-6480418_6e8d0_sm.jpeg" alt="Beer label">                            </a>
+                        </div>
+                        <div class="details">
+                            <span class="name"><a href="/user/ysilvestrov/lists/11720173">Silver Spoon Sharing</a></span>
+                            <span class="meta">24 Items &bull; Updated <abbr class="format-date" data-date="Sun, 31 May 2026 18:26:54 +0000"></abbr></span>
+                        </div>
+                    </div>
+
+                                        <div class="list-item list-none">
+                        <div class="labels">
+                            <a href="/user/ysilvestrov/lists/11839504" aria-label="List image">
+                                <img src="https://assets.untappd.com/site/beer_logos/beer-5571254_df826_sm.jpeg" alt="Beer label"><img src="https://assets.untappd.com/site/beer_logos/beer-6240545_cd945_sm.jpeg" alt="Beer label"><img src="https://assets.untappd.com/site/beer_logos/beer-5885268_6f148_sm.jpeg" alt="Beer label"><img src="https://assets.untappd.com/site/beer_logos/beer-65555_8d5a7_sm.jpeg" alt="Beer label">                            </a>
+                        </div>
+                        <div class="details">
+                            <span class="name"><a href="/user/ysilvestrov/lists/11839504">Kossutha 2A Misc</a></span>
+                            <span class="meta">12 Items &bull; Updated <abbr class="format-date" data-date="Sat, 04 Apr 2026 20:53:23 +0000"></abbr></span>
+                        </div>
+                    </div>
+
+                                                        <p class="more"><a class="track-click" data-track="sidebar" data-href=":userlists/lists" href="/user/ysilvestrov/lists/"">See All Lists</a></p>
+                                </div>
+
+        </div>
+        <script type="text/javascript">
+        $(document).ready(function() {
+            $('.format-date').each(function() {
+                $(this).html(moment($(this).attr('data-date')).format('MMM Do, YYYY'))
+            });
+        })
+        </script>
+                    <div class="box sb-events">
+                <div class="content">
+
+                    <h3>
+                        Your Events                    </h3>
+                    <div class="sb-event-list">
+                        <div class="sb-event-none">
+                            <p>You have not marked any events as Interested or Going.<br><br>
+                            <a href="/nearby/events">Find great events near you!</a></p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+              <div class="box">
+    <div class="content">
+      <h3>Badges</h3>
+      <div class="drinkers">
+                  <a class="tip track-click" data-track="sidebar" data-href=":user/viewbadge" href="/user/ysilvestrov/badges/1399228900" title="World Pint 2026: Australia" ><span><img src="https://assets.untappd.com/promo/4434d775ba_UTC-WorldPint-Badges-01_2.png" alt="World Pint 2026: Australia badge logo"></span></a>
+                  <a class="tip track-click" data-track="sidebar" data-href=":user/viewbadge" href="/user/ysilvestrov/badges/1398198338" title="World Pint 2026: South Korea" ><span><img src="https://assets.untappd.com/promo/dacc277d2e_SOUTH-KOREA-UTC-WorldPint-Badges-07.png" alt="World Pint 2026: South Korea badge logo"></span></a>
+                  <a class="tip track-click" data-track="sidebar" data-href=":user/viewbadge" href="/user/ysilvestrov/badges/1398005557" title="World Pint 2026: Germany" ><span><img src="https://assets.untappd.com/promo/2f830ebd30_GERMANY-UTC-WorldPint-Badges-38.png" alt="World Pint 2026: Germany badge logo"></span></a>
+                  <a class="tip track-click" data-track="sidebar" data-href=":user/viewbadge" href="/user/ysilvestrov/badges/1395542435" title="Beer for Keeping" ><span><img src="https://assets.untappd.com/badges/bdg_BeerForKeeping_md.jpg" alt="Beer for Keeping badge logo"></span></a>
+                  <a class="tip track-click" data-track="sidebar" data-href=":user/viewbadge" href="/user/ysilvestrov/badges/1391731259" title="Flying Saucer - American Craft Beer Week" ><span><img src="https://assets.untappd.com/badges/acbw26badge.jpg" alt="Flying Saucer - American Craft Beer Week badge logo"></span></a>
+                  <a class="tip track-click" data-track="sidebar" data-href=":user/viewbadge" href="/user/ysilvestrov/badges/1391731257" title="American Craft Beer Week (2026)" ><span><img src="https://assets.untappd.com/promo/64f0cda29a_ACBW26-Untappd-Badge.png" alt="American Craft Beer Week (2026) badge logo"></span></a>
+                  <a class="tip track-click" data-track="sidebar" data-href=":user/viewbadge" href="/user/ysilvestrov/badges/1389335606" title="Beer Gear Summer Giveaway" ><span><img src="https://assets.untappd.com/badges/BeerGear-Summer-2026-Badge_1000x1000.jpg" alt="Beer Gear Summer Giveaway badge logo"></span></a>
+                  <a class="tip track-click" data-track="sidebar" data-href=":user/viewbadge" href="/user/ysilvestrov/badges/1386691093" title="Saison Day (2026)" ><span><img src="https://assets.untappd.com/promo/5085f7f5f5_saison_day_badge_2026.png" alt="Saison Day (2026) badge logo"></span></a>
+                  <a class="tip track-click" data-track="sidebar" data-href=":user/viewbadge" href="/user/ysilvestrov/badges/1385208631" title="Belgian Beer Badge" ><span><img src="https://assets.untappd.com/badges/TVL_UNTAPPD_ALGEMEEN_3.jpg" alt="Belgian Beer Badge badge logo"></span></a>
+                  <a class="tip track-click" data-track="sidebar" data-href=":user/viewbadge" href="/user/ysilvestrov/badges/1384858676" title="New York Craft Beer Day" ><span><img src="https://assets.untappd.com/badges/NYUntappd_Badge.jpg" alt="New York Craft Beer Day badge logo"></span></a>
+                  <a class="tip track-click" data-track="sidebar" data-href=":user/viewbadge" href="/user/ysilvestrov/badges/1389360144" title="Fourtitude (Level 3)" ><span><img src="https://assets.untappd.com/promo/d18e73a69f_UTC-QIPA-Style-Badge_1000x1000.png" alt="Fourtitude (Level 3) badge logo"></span></a>
+                  <a class="tip track-click" data-track="sidebar" data-href=":user/viewbadge" href="/user/ysilvestrov/badges/1385370283" title="Beer Geek Madness 2026 (Level 23)" ><span><img src="https://assets.untappd.com/badges/99818665cdc4459fd70e0c89241834b7_md.jpeg" alt="Beer Geek Madness 2026 (Level 23) badge logo"></span></a>
+                <p class="more"><a href="/user/ysilvestrov/badges" class="track-click" data-track="sidebar" data-href=":user/recentbadges">See All Badges</a></p>
+      </div>
+    </div>
+  </div>
+          <div class="box">
+            <div class="content">
+                <h3>Top Beers</h3>                    <div class="item">
+                        <a href="/b/funky-fluid-la-tomatina/5895601" class="track-click" data-track="sidebar" data-href=":beer/toplist">
+                            <p class="logo">
+                                    <img src="https://assets.untappd.com/site/beer_logos/beer-5895601_9952b_sm.jpeg" alt="La Tomatina label">
+                            </p><p class="text">
+                                <span class="name">La Tomatina</span>
+                                <span class="brewery">Funky Fluid</span>                            </p>
+                        </a>
+                    </div>
+                                        <div class="item">
+                        <a href="/b/lervig-coconuts/2553376" class="track-click" data-track="sidebar" data-href=":beer/toplist">
+                            <p class="logo">
+                                    <img src="https://assets.untappd.com/site/beer_logos/beer-2553376_d41bd_sm.jpeg" alt="Coconuts label">
+                            </p><p class="text">
+                                <span class="name">Coconuts</span>
+                                <span class="brewery">LERVIG</span>                            </p>
+                        </a>
+                    </div>
+                                        <div class="item">
+                        <a href="/b/omnipollo-anagram-blueberry-cheesecake-stout/1501093" class="track-click" data-track="sidebar" data-href=":beer/toplist">
+                            <p class="logo">
+                                    <img src="https://assets.untappd.com/site/beer_logos/beer-1501093_d8066_sm.jpeg" alt="Anagram Blueberry Cheesecake Stout label">
+                            </p><p class="text">
+                                <span class="name">Anagram Blueberry Cheesecake Stout</span>
+                                <span class="brewery">Omnipollo</span>                            </p>
+                        </a>
+                    </div>
+                                        <div class="item">
+                        <a href="/b/brewdog-cocoa-psycho/273455" class="track-click" data-track="sidebar" data-href=":beer/toplist">
+                            <p class="logo">
+                                    <img src="https://assets.untappd.com/site/beer_logos/beer-273455_ca7d6_sm.jpeg" alt="Cocoa Psycho label">
+                            </p><p class="text">
+                                <span class="name">Cocoa Psycho</span>
+                                <span class="brewery">BrewDog</span>                            </p>
+                        </a>
+                    </div>
+                                        <div class="item">
+                        <a href="/b/cydr-chyliczki-lodowy-2017/2937479" class="track-click" data-track="sidebar" data-href=":beer/toplist">
+                            <p class="logo">
+                                    <img src="https://assets.untappd.com/site/assets/images/temp/badge-beer-default.png" alt="Lodowy 2017 label">
+                            </p><p class="text">
+                                <span class="name">Lodowy 2017</span>
+                                <span class="brewery">Cydr Chyliczki</span>                            </p>
+                        </a>
+                    </div>
+                                                <p class="more"><a class="track-click" data-track="sidebar" data-href=":user/beerhistory" href="/user/ysilvestrov/beers">See All Beers</a></p>
+                                        </div>
+        </div>
+            	<div class="box">
+        	<div class="content">
+                <h3>Top Venues</h3>                    <div class="item" data-track-venue-impression="venue_id-11941787-type-top_venues">
+                        <a href="/v/silver-spoon-nest/11941787" class="track-click" data-track="sidebar" data-href=":venue/toplist">
+                            <p class="logo">
+                                                                <img src="https://ss3.4sqi.net/img/categories_v2/nightlife/pub_bg_512.png" alt="Silver Spoon Nest logo">
+                            </p><p class="text">
+                                <span class="name">Silver Spoon Nest</span>
+
+                                <span class="location">Warszawa, Województwo mazowieckie                                        </span>                            </p>
+                        </a>
+                    </div>
+
+        			                    <div class="item" data-track-venue-impression="venue_id-5378424-type-top_venues">
+                        <a href="/v/black-door-pub/5378424" class="track-click" data-track="sidebar" data-href=":venue/toplist">
+                            <p class="logo">
+                                                                <img src="https://ss3.4sqi.net/img/categories_v2/nightlife/pub_bg_512.png" alt="Black Door Pub logo">
+                            </p><p class="text">
+                                <span class="name">Black Door Pub</span>
+
+                                <span class="location">Харків, Харківська обл.                                        </span>                            </p>
+                        </a>
+                    </div>
+
+        			                    <div class="item" data-track-venue-impression="venue_id-11142155-type-top_venues">
+                        <a href="/v/warsaw-beer-festival-warszawski-festiwal-piwa/11142155" class="track-click" data-track="sidebar" data-href=":venue/toplist">
+                            <p class="logo">
+                                <span>Verified</span>                                <img src="https://images.untp.beer/resize?width=176&height=176&background=255,255,255&extend=white&stripmeta=true&url=https://utfb-images.untappd.com/aqlndes4fiuk9knpzif4blmpifhv?auto=compress" alt="Warszawski Festiwal Piwa logo">
+                            </p><p class="text">
+                                <span class="name">Warszawski Festiwal Piwa</span>
+
+                                <span class="location">Warsaw, Województwo mazowieckie                                        </span>                            </p>
+                        </a>
+                    </div>
+
+        			                    <div class="item" data-track-venue-impression="venue_id-10791463-type-top_venues">
+                        <a href="/v/lviv-craft-beer-university-of-st-christopher/10791463" class="track-click" data-track="sidebar" data-href=":venue/toplist">
+                            <p class="logo">
+                                <span>Verified</span>                                <img src="https://images.untp.beer/resize?width=176&height=176&background=255,255,255&extend=white&stripmeta=true&url=https://utfb-images.untappd.com/27pv83z3nxvdznhhd42b2gmft1sl?auto=compress" alt="Lviv Craft Beer University of St. Christopher logo">
+                            </p><p class="text">
+                                <span class="name">Lviv Craft Beer University of St. Christopher</span>
+
+                                <span class="location">Львів, Львівська обл.                                        </span>                            </p>
+                        </a>
+                    </div>
+
+        			                    <div class="item" data-track-venue-impression="venue_id-12617758-type-top_venues">
+                        <a href="/v/white-crow-craft-beer-and-kitchen/12617758" class="track-click" data-track="sidebar" data-href=":venue/toplist">
+                            <p class="logo">
+                                <span>Verified</span>                                <img src="https://images.untp.beer/resize?width=176&height=176&background=255,255,255&extend=white&stripmeta=true&url=https://utfb-images.untappd.com/9a83x4i3c163rt9ttuzdgnmamq4l?auto=compress" alt="White Crow Craft Beer & Kitchen logo">
+                            </p><p class="text">
+                                <span class="name">White Crow Craft Beer & Kitchen</span>
+
+                                <span class="location">Warszawa, Województwo mazowieckie                                        </span>                            </p>
+                        </a>
+                    </div>
+
+        			                    <p class="more"><a class="track-click" data-track="sidebar" data-href=":user/toplocations" href="/user/ysilvestrov/venues">See All Venues</a></p>
+                            	</div>
+    	</div>
+        <script type="text/javascript">
+            $(document).ready(function() {
+                createImpressionTracker();
+            });
+        </script>
+    	        <div class="box">
+            <div class="content">
+                <h3>Likes</h3>
+                <div class="drinkers">
+                                            <a class="tip track-click" data-track="sidebar" data-href=":user/viewLikeBrewery" href="/SilverForkBrewery" title="Silver Fork Brewery" ><span><img src="https://assets.untappd.com/site/brewery_logos/brewery-492625_f9487.jpeg" alt="Silver Fork Brewery avatar"></span></a>
+                                                <a class="tip track-click" data-track="sidebar" data-href=":user/viewLikeBrewery" href="/SilverSpoonBrewery" title="Silver Spoon Brewery" ><span><img src="https://assets.untappd.com/site/brewery_logos/brewery-390260_cd128.jpeg" alt="Silver Spoon Brewery avatar"></span></a>
+                                        </div>
+            </div>
+        </div>
+        		</div>
+		
+
+</div>
+<script type="text/javascript">
+$(document).ready(function() {
+	if ($(".sidebar").is(":visible")) {
+		var sidebarHeight = $(".sidebar")[0].scrollHeight;
+		$(".profile_left").css("min-height", sidebarHeight + 108 + "px");
+	}
+})
+</script>
+	<script>
+	$(document).ready(function() {
+
+		$(".block").on("click", function(e) {
+
+			e.stopPropagation();
+			e.preventDefault();
+
+			var type = $(this).attr('data-block');
+			var userId = $(this).attr("data-user-id");
+
+			var msg = type === "true" ? 'Are you sure you want to un-block this user? You will need to re-friend them to interact with their content.' : 'Are you sure you want to block this user? This user will not be able to see your activity while logged into the app or website.';
+
+			if (confirm(msg)) {
+				$.ajax({
+					url: "/apireqs/blockuser/"+userId,
+					type: "POST",
+					dataType: "json",
+					error: function(xhr)
+					{
+						$.notifyBar({
+							html: "Hmm. Something went wrong. Please try again!",
+							delay: 2000,
+							animationSpeed: "normal"
+						});
+					},
+					success: function(html)
+					{
+
+						if (html.error) {
+							$.notifyBar({
+								html: html.error,
+								delay: 2000,
+								animationSpeed: "normal"
+							});
+						} else {
+							window.location.reload();
+						}
+					}
+				});
+			}
+
+			return false;
+
+		});
+		$(".more_checkins_logged").on("click", function() {
+			var _this = $(this);
+			$(_this).hide();
+			$(".stream-loading").addClass("active");
+
+			var offset = $("#main-stream .item:last").attr('data-checkin-id');
+			var user = $(this).attr("data-user-name");
+
+			$.ajax({
+				url: "/profile/more_feed/"+user+"/"+offset+"?v2=true",
+				type: "GET",
+				error: function(xhr)
+				{
+					$(".stream-loading").removeClass("active");
+					$(_this).show();
+					$.notifyBar({
+						html: "Hmm. Something went wrong. Please try again!",
+						delay: 2000,
+						animationSpeed: "normal"
+					});
+				},
+				success: function(html)
+				{
+					$(".stream-loading").removeClass("active");
+
+					if (html == "") {
+						$(".more_checkins").hide();
+					}
+					else {
+						$(_this).show();
+						$("#main-stream").append(html);
+						$(".tip").tipsy({fade: true});
+						refreshTime(".timezoner", "D MMM YY");
+					}
+				}
+			});
+
+			return false;
+		});
+	});
+	</script>
+	<script type="text/javascript" language="Javascript" src="https://untappd.com/assets/v3/js/common/min/profile_page_min.js?v=2.8.37"></script>
+	
+
+		<iframe src="/profile/stats?id=3266672&type=profile&is_supporter=1&nomobile=true" width="0" height="0" tabindex="-1" title="empty" class="hidden"></iframe><script type="text/javascript">
+	$(document).ready(function() {
+		var hC = $(".sidebar").height();
+		$(".cont").css("min-height", hC);
+
+		$(".report-user").on("click", function(e) {
+			e.stopPropagation();
+			e.preventDefault();
+			var url = $(this).attr('data-report-url');
+			window.location.href = url;
+			return false;
+		})
+
+		$(".friend-more").on("click", function(e) {
+			$(".friend-more-pop").toggle();
+			return false;
+		})
+	})
+</script>
+<style>
+#pmLink {
+	visibility: hidden;
+    color: #8a4500;
+    font: inherit;
+    line-height: inherit;
+    text-decoration: none;
+    cursor: pointer;
+    background: transparent;
+    border: none;
+    margin: 0;
+    padding: 0;
+}
+
+#pmLink:hover {
+	visibility: visible;
+    color: #c60;
+}
+</style>
+
+	<footer class="">
+		<div class="footer-nav">
+			<div class="footer-inner">
+				<ul>
+					<li>
+						<a class="track-click" data-track="footer" data-href=":footer/businesses" href="https://utfb.untappd.com/">Untappd for Business</a>
+					</li>
+					<li>
+						<a class="track-click" data-track="footer" data-href=":footer/businesses/blog" href="https://lounge.untappd.com/">Untappd for Business Blog</a>
+					</li>
+					<li>
+						<a class="track-click" data-track="footer" data-href=":footer/breweries" href="https://untappd.com/breweries">Breweries</a>
+					</li>
+					<li>
+						<a class="track-click" data-track="footer" data-href=":footer/shop" href="https://untappd.com/shop">Shop</a>
+					</li>
+					<li>
+						<a class="track-click" data-track="footer" data-href=":footer/support" href="http://help.untappd.com/">Support</a>
+					</li>
+					<li>
+						<a class="track-click" data-track="footer" data-href=":footer/careers" href="/careers">Careers</a>
+					</li>
+					<li>
+						<a class="track-click" data-track="footer" data-href=":footer/api" href="/api/">API</a>
+					</li>
+					<li>
+						<a class="track-click" data-track="footer" data-href=":footer/terms" href="/terms">Terms</a>
+					</li>
+					<li>
+						<a class="track-click" data-track="footer" data-href=":footer/privacy" href="/privacy">Privacy</a>
+					</li>
+					<li>
+						<a class="track-click" data-track="footer" data-href=":footer/cookie" href="/cookie">Cookie Policy</a>
+					</li>
+					<li>
+						<!-- https://freestarhelp.zendesk.com/hc/en-us/articles/34424330233364-Freestar-Sourcepoint-CMP-Implementation -->
+						<button id="pmLink">Privacy Manager</button>
+					</li>
+					<li>
+						<a class="track-click" data-track="footer" data-href=":footer/personal_data" href="/privacy/personal-data">Manage Personal Data</a>
+					</li>
+				</ul>
+			</div>
+		</div>
+		<ul class="social">
+    <li><a class="track-click" data-track="footer" data-href=":footer/social/twitter" href="https://bit.ly/3T6pKK6" target="_blank"><img src="https://untappd.com/assets/custom/homepage/images/icon-twitter.svg" alt="Icon twitter" /></a></li>
+    <li><a class="track-click" data-track="footer" data-href=":footer/social/facebook" href="https://bit.ly/3RVLffu" target="_blank"><img src="https://untappd.com/assets/custom/homepage/images/icon-facebook.svg" alt="Icon facebook" /></a></li>
+    <li><a class="track-click" data-track="home" data-href=":footer/social/instagram" href="https://bit.ly/3EyG9D5" target="_blank"><img src="https://untappd.com/assets/custom/homepage/images/icon-instagram.svg" alt="Icon instagram" /></a></li>
+</ul>	</footer>
+
+<script type="text/javascript">
+	// polyfill for ie11
+	function getUrlParameter(name) {
+		name = name.replace(/[\[]/, '\\[').replace(/[\]]/, '\\]');
+		var regex = new RegExp('[\\?&]' + name + '=([^&#]*)');
+		var results = regex.exec(location.search);
+		return results === null ? '' : decodeURIComponent(results[1].replace(/\+/g, ' '));
+	};
+
+	$(document).ready(function() {
+		// remove any access tokens, preserve other elements
+		if (history.replaceState) {
+			if (location.href.indexOf("access_token=") >= 0) {
+				const accessTokenURL = getUrlParameter("access_token");
+				let currentURL = location.href;
+				let finalURL = currentURL.replace(`access_token=${accessTokenURL}`, '');
+
+				// if the url has a "&" already in it, then remove the "?" and replace the first "&" with an "?"
+				if (finalURL.indexOf("&") >= 0) {
+					finalURL = finalURL.replace("?", "").replace("&", "?");
+				} else {
+					finalURL = finalURL.split("?")[0];
+				}
+
+				history.replaceState(null, "", finalURL);
+			}
+		}
+	})
+</script>
+
+<script type="text/javascript">
+	// Clear Text Feild
+	function clearText(thefield) {
+		if (thefield.defaultValue == thefield.value)
+			thefield.value = ""
+	}
+</script>
+
+
+<script src="https://aa.agkn.com/adscores/s.js?sid=9112310028&em=2258a9f1b57ad608d3d5b7fdbdbf4995494778ff"></script>
+</body>
+</html>

--- a/tmp/ysilvestrov_more_feed_1577238079.txt
+++ b/tmp/ysilvestrov_more_feed_1577238079.txt
@@ -1,0 +1,3197 @@
+
+			<div class="item " id="checkin_1577233492" data-checkin-id="1577233492">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/piwne-podziemie-beer-underground-oatkeeper/6438923" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6438923_6f5cc_sm.jpeg" alt="Oatkeeper by Piwne Podziemie / Beer Underground">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-12767316-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking an <a href="/b/piwne-podziemie-beer-underground-oatkeeper/6438923">Oatkeeper</a> by <a  href="/PiwnePodziemie">Piwne Podziemie / Beer Underground</a> at <a href="/v/offside/12767316">Offside</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1577233492">
+									Стаут як стаут									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/can@3x.png" alt="Can">
+										          <span>Can</span>
+										        </p>
+												<div class="caps " data-rating="3.5">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-50"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+									
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Connoisseur">
+																	<img src="https://assets.untappd.com/profile/4a2ca4a782c24e072988b781352672c4_100x100.jpeg" alt="Victor  avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/Black_mzfk">
+																	<img src="https://assets.untappd.com/profile/c48718cf62242ead68e5309884791628_100x100.jpg" alt="Mykola Bortnychuk avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1577233492" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_12/569a6e909c5b6e5a7dbdd7f91d41e60b_c_1577233492_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1577233492">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1577233492" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1577233492" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Fri, 12 Jun 2026 17:47:48 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1577233492" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1577233492">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>2</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="ozerova" href="/user/ozerova" title="Alona Ozerova" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/32b6ee38b32a094a267bb390cbfc86cb_100x100.jpg" alt="Alona Ozerova avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1577233492" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1577233492" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1577233492'),$('#commentForm_1577233492 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1577233492" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1577233492" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1577230158" data-checkin-id="1577230158">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/fuerst-wiacek-berlin-chin-music/5649510" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-5649510_264ec_sm.jpeg" alt="Chin Music by FUERST WIACEK Berlin">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-12617758-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/fuerst-wiacek-berlin-chin-music/5649510">Chin Music</a> by <a  href="/fuerstwiacekbrew">FUERST WIACEK Berlin</a> at <a href="/v/white-crow-craft-beer-and-kitchen/12617758">White Crow Craft Beer & Kitchen</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1577230158">
+									Трохи краще за попередні, норм									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/taster@3x.png" alt="Taster">
+										          <span>Taster</span>
+										        </p>
+												<div class="caps " data-rating="4.1">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-10"></div>
+	</div>								    </div>
+									
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Connoisseur">
+																	<img src="https://assets.untappd.com/profile/4a2ca4a782c24e072988b781352672c4_100x100.jpeg" alt="Victor  avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/Black_mzfk">
+																	<img src="https://assets.untappd.com/profile/c48718cf62242ead68e5309884791628_100x100.jpg" alt="Mykola Bortnychuk avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1577230158" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_12/6074f94cbbdab4d105841ff62378885e_c_1577230158_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1577230158">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1577230158" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1577230158" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Fri, 12 Jun 2026 17:40:52 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1577230158" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1577230158">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>2</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="ozerova" href="/user/ozerova" title="Alona Ozerova" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/32b6ee38b32a094a267bb390cbfc86cb_100x100.jpg" alt="Alona Ozerova avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1577230158" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1577230158" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1577230158'),$('#commentForm_1577230158 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1577230158" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1577230158" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1577222908" data-checkin-id="1577222908">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/fuerst-wiacek-berlin-disco-nap/6254508" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6254508_98e36_sm.jpeg" alt="Disco Nap by FUERST WIACEK Berlin">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-12617758-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/fuerst-wiacek-berlin-disco-nap/6254508">Disco Nap</a> by <a  href="/fuerstwiacekbrew">FUERST WIACEK Berlin</a> at <a href="/v/white-crow-craft-beer-and-kitchen/12617758">White Crow Craft Beer & Kitchen</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1577222908">
+									Наче норм									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/taster@3x.png" alt="Taster">
+										          <span>Taster</span>
+										        </p>
+												<div class="caps " data-rating="4">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+																			<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/badges/bdg_SuperStyleIPANewEnglandHazy_sm.jpg" alt="Super Style: IPA - New England / Hazy (Level 88)">
+											<span>Earned the Super Style: IPA - New England / Hazy (Level 88) badge!</span>
+										</span>
+										
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/Black_mzfk">
+																	<img src="https://assets.untappd.com/profile/c48718cf62242ead68e5309884791628_100x100.jpg" alt="Mykola Bortnychuk avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Connoisseur">
+																	<img src="https://assets.untappd.com/profile/4a2ca4a782c24e072988b781352672c4_100x100.jpeg" alt="Victor  avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1577222908" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_12/de5892e5f16301e5c7b68d6332248253_c_1577222908_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1577222908">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1577222908" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1577222908" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Fri, 12 Jun 2026 17:25:31 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1577222908" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1577222908">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>2</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="ozerova" href="/user/ozerova" title="Alona Ozerova" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/32b6ee38b32a094a267bb390cbfc86cb_100x100.jpg" alt="Alona Ozerova avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1577222908" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1577222908" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1577222908'),$('#commentForm_1577222908 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1577222908" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1577222908" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1577217241" data-checkin-id="1577217241">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/browar-artezan-squeeze-ruby-zing/6716840" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6716840_a0e74_sm.jpeg" alt="Squeeze: Ruby Zing by Browar Artezan">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-12617758-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/browar-artezan-squeeze-ruby-zing/6716840">Squeeze: Ruby Zing</a> by <a  href="/BrowarArtezan">Browar Artezan</a> at <a href="/v/white-crow-craft-beer-and-kitchen/12617758">White Crow Craft Beer & Kitchen</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1577217241">
+									Норм полуниця									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/taster@3x.png" alt="Taster">
+										          <span>Taster</span>
+										        </p>
+												<div class="caps " data-rating="4.2">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-20"></div>
+	</div>								    </div>
+																			<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/badges/bdg_SuperStyleSourFruited_sm.jpg" alt="Super Style: Sour - Fruited (Level 40)">
+											<span>Earned the Super Style: Sour - Fruited (Level 40) badge!</span>
+										</span>
+										
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Connoisseur">
+																	<img src="https://assets.untappd.com/profile/4a2ca4a782c24e072988b781352672c4_100x100.jpeg" alt="Victor  avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/Black_mzfk">
+																	<img src="https://assets.untappd.com/profile/c48718cf62242ead68e5309884791628_100x100.jpg" alt="Mykola Bortnychuk avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1577217241" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_12/7eba04849832469685e582ae8af5741c_c_1577217241_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1577217241">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1577217241" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1577217241" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Fri, 12 Jun 2026 17:13:25 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1577217241" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1577217241">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>2</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="ozerova" href="/user/ozerova" title="Alona Ozerova" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/32b6ee38b32a094a267bb390cbfc86cb_100x100.jpg" alt="Alona Ozerova avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1577217241" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1577217241" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1577217241'),$('#commentForm_1577217241 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1577217241" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1577217241" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1577213666" data-checkin-id="1577213666">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/fuerst-wiacek-berlin-abstract-birthday/6195316" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6195316_1f077_sm.jpeg" alt="Abstract Birthday by FUERST WIACEK Berlin">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-12617758-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking an <a href="/b/fuerst-wiacek-berlin-abstract-birthday/6195316">Abstract Birthday</a> by <a  href="/fuerstwiacekbrew">FUERST WIACEK Berlin</a> at <a href="/v/white-crow-craft-beer-and-kitchen/12617758">White Crow Craft Beer & Kitchen</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1577213666">
+									Трохи в кислинку, але загалом норм									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/taster@3x.png" alt="Taster">
+										          <span>Taster</span>
+										        </p>
+												<div class="caps " data-rating="4.1">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-10"></div>
+	</div>								    </div>
+																			<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/badges/aae45250bb4d36b264f1165ab0a6d94c_sm.jpeg" alt="White Guard LvL2 (Level 31)">
+											<span>Earned the White Guard LvL2 (Level 31) badge!</span>
+										</span>
+										
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/Black_mzfk">
+																	<img src="https://assets.untappd.com/profile/c48718cf62242ead68e5309884791628_100x100.jpg" alt="Mykola Bortnychuk avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Connoisseur">
+																	<img src="https://assets.untappd.com/profile/4a2ca4a782c24e072988b781352672c4_100x100.jpeg" alt="Victor  avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1577213666" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_12/6e85f0dfee02f4569471e65c7614f059_c_1577213666_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1577213666">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1577213666" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1577213666" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Fri, 12 Jun 2026 17:05:48 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1577213666" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1577213666">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>1</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1577213666" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1577213666" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1577213666'),$('#commentForm_1577213666 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1577213666" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1577213666" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1577210520" data-checkin-id="1577210520">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/fuerst-wiacek-berlin-high-five/4979024" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-4979024_b3add_sm.jpeg" alt="High Five by FUERST WIACEK Berlin">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-12617758-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/fuerst-wiacek-berlin-high-five/4979024">High Five</a> by <a  href="/fuerstwiacekbrew">FUERST WIACEK Berlin</a> at <a href="/v/white-crow-craft-beer-and-kitchen/12617758">White Crow Craft Beer & Kitchen</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1577210520">
+									Легеньке, наче норм									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/taster@3x.png" alt="Taster">
+										          <span>Taster</span>
+										        </p>
+												<div class="caps " data-rating="4">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+									
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Connoisseur">
+																	<img src="https://assets.untappd.com/profile/4a2ca4a782c24e072988b781352672c4_100x100.jpeg" alt="Victor  avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/Black_mzfk">
+																	<img src="https://assets.untappd.com/profile/c48718cf62242ead68e5309884791628_100x100.jpg" alt="Mykola Bortnychuk avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1577210520" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_12/7b15cb7e6223ce0fcce23a3f7dca9576_c_1577210520_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1577210520">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1577210520" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1577210520" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Fri, 12 Jun 2026 16:58:53 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1577210520" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1577210520">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>1</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1577210520" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1577210520" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1577210520'),$('#commentForm_1577210520 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1577210520" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1577210520" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1577209508" data-checkin-id="1577209508">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/fuerst-wiacek-berlin-schwarzbier/5186040" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-5186040_3aeac_sm.jpeg" alt="Schwarzbier by FUERST WIACEK Berlin">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-12617758-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/fuerst-wiacek-berlin-schwarzbier/5186040">Schwarzbier</a> by <a  href="/fuerstwiacekbrew">FUERST WIACEK Berlin</a> at <a href="/v/white-crow-craft-beer-and-kitchen/12617758">White Crow Craft Beer & Kitchen</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1577209508">
+									Солодке, чоколяда, наче норм									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/taster@3x.png" alt="Taster">
+										          <span>Taster</span>
+										        </p>
+												<div class="caps " data-rating="3.9">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-90"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+																			<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/badges/bdg_DasBoot16_sm.jpg" alt="Das Boot (Level 71)">
+											<span>Earned the Das Boot (Level 71) badge!</span>
+										</span>
+										
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/Black_mzfk">
+																	<img src="https://assets.untappd.com/profile/c48718cf62242ead68e5309884791628_100x100.jpg" alt="Mykola Bortnychuk avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Connoisseur">
+																	<img src="https://assets.untappd.com/profile/4a2ca4a782c24e072988b781352672c4_100x100.jpeg" alt="Victor  avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1577209508" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_12/437b746db9de553fa3af45ff650d43ba_c_1577209508_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1577209508">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1577209508" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1577209508" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Fri, 12 Jun 2026 16:56:43 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1577209508" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1577209508">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>1</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1577209508" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1577209508" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1577209508'),$('#commentForm_1577209508 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1577209508" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1577209508" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1577208479" data-checkin-id="1577208479">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/fuerst-wiacek-berlin-touch-grass/6301775" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6301775_f46dd_sm.jpeg" alt="Touch Grass by FUERST WIACEK Berlin">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-12617758-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/fuerst-wiacek-berlin-touch-grass/6301775">Touch Grass</a> by <a  href="/fuerstwiacekbrew">FUERST WIACEK Berlin</a> at <a href="/v/white-crow-craft-beer-and-kitchen/12617758">White Crow Craft Beer & Kitchen</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1577208479">
+									Наче норм, освіжаюче									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/taster@3x.png" alt="Taster">
+										          <span>Taster</span>
+										        </p>
+												<div class="caps " data-rating="3.7">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-70"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+																			<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/badges/bdg_FieldsOfGold_sm.jpg" alt="Fields of Gold (Level 17)">
+											<span>Earned the Fields of Gold (Level 17) badge!</span>
+										</span>
+										
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/Black_mzfk">
+																	<img src="https://assets.untappd.com/profile/c48718cf62242ead68e5309884791628_100x100.jpg" alt="Mykola Bortnychuk avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Connoisseur">
+																	<img src="https://assets.untappd.com/profile/4a2ca4a782c24e072988b781352672c4_100x100.jpeg" alt="Victor  avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1577208479" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_12/d3cb587352ecdd9aef7c9645a858451e_c_1577208479_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1577208479">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1577208479" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1577208479" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Fri, 12 Jun 2026 16:54:28 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1577208479" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1577208479">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>1</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1577208479" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1577208479" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1577208479'),$('#commentForm_1577208479 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1577208479" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1577208479" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1577206635" data-checkin-id="1577206635">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/schneider-weisse-g-schneider-and-sohn-festweisse-tap04/11827" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-11827_96405_sm.jpeg" alt="Festweisse (TAP04) by Schneider Weisse G. Schneider & Sohn">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-12617758-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/schneider-weisse-g-schneider-and-sohn-festweisse-tap04/11827">Festweisse (TAP04)</a> by <a  href="/schneiderweisse">Schneider Weisse G. Schneider & Sohn</a> at <a href="/v/white-crow-craft-beer-and-kitchen/12617758">White Crow Craft Beer & Kitchen</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1577206635">
+									Смачне, банани, хміль									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/taster@3x.png" alt="Taster">
+										          <span>Taster</span>
+										        </p>
+												<div class="caps " data-rating="4">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+																			<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/promo/2f830ebd30_GERMANY-UTC-WorldPint-Badges-38.png" alt="World Pint 2026: Germany">
+											<span>Earned the World Pint 2026: Germany badge!</span>
+										</span>
+										
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/Black_mzfk">
+																	<img src="https://assets.untappd.com/profile/c48718cf62242ead68e5309884791628_100x100.jpg" alt="Mykola Bortnychuk avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Connoisseur">
+																	<img src="https://assets.untappd.com/profile/4a2ca4a782c24e072988b781352672c4_100x100.jpeg" alt="Victor  avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1577206635" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_12/806eb0ad3c74618e688e9a3c0a4e48e6_c_1577206635_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1577206635">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1577206635" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1577206635" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Fri, 12 Jun 2026 16:50:17 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1577206635" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1577206635">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>1</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1577206635" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1577206635" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1577206635'),$('#commentForm_1577206635 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1577206635" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1577206635" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1576995961" data-checkin-id="1576995961">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/moon-lark-brewery-non-alcoholic-pils/6590016" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6590016_4d7e0_sm.jpeg" alt="Non-Alcoholic Pils by Moon Lark Brewery">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-9448532-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/moon-lark-brewery-non-alcoholic-pils/6590016">Non-Alcoholic Pils</a> by <a  href="/MoonLarkBrewery">Moon Lark Brewery</a> at <a href="/v/os-gorczewska-200/9448532">Os. Górczewska 200</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1576995961">
+									Норм лагер									</p>
+
+									
+								<p class="purchased" data-track-venue-impression="venue_id-12963055-type-checkin_feed">Purchased at <a href="/v/kaufland/12963055">Kaufland</a></p>									<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/can@3x.png" alt="Can">
+										          <span>Can</span>
+										        </p>
+												<div class="caps " data-rating="3.6">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-60"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+																			<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/badges/bdg_NewNewBrewThurs_sm.jpg" alt="New Brew Thursday (Level 74)">
+											<span>Earned the New Brew Thursday (Level 74) badge!</span>
+										</span>
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1576995961" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_11/f512db8ca7a56bde42e8ab91856354f5_c_1576995961_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1576995961">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1576995961" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1576995961" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Thu, 11 Jun 2026 18:50:34 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1576995961" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1576995961">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>1</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1576995961" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1576995961" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1576995961'),$('#commentForm_1576995961 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1576995961" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1576995961" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1576680948" data-checkin-id="1576680948">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/browar-sady-zlota-pyra-smoked-baltic-porter/6568954" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6568954_6888c_sm.jpeg" alt="Złota Pyra - Smoked Baltic Porter by Browar Sady">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-9448532-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/browar-sady-zlota-pyra-smoked-baltic-porter/6568954">Złota Pyra - Smoked Baltic Porter</a> by <a  href="/BrowarSady">Browar Sady</a> at <a href="/v/os-gorczewska-200/9448532">Os. Górczewska 200</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1576680948">
+									Копчена чоколяда									</p>
+
+									
+								<p class="purchased" data-track-venue-impression="venue_id-9038768-type-checkin_feed">Purchased at <a href="/v/piwny-kolektyw/9038768">Piwny Kolektyw</a></p>									<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/bottle@3x.png" alt="Bottle">
+										          <span>Bottle</span>
+										        </p>
+												<div class="caps " data-rating="4.4">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-40"></div>
+	</div>								    </div>
+									
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/ozerova">
+																	<img src="https://assets.untappd.com/profile/32b6ee38b32a094a267bb390cbfc86cb_100x100.jpg" alt="Alona Ozerova avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Lialit">
+																	<img src="https://assets.untappd.com/profile/519698a144f07bad0aa61c2ebb9fb7d9_100x100.jpg" alt="Елена Гаврилова avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/esodin">
+																	<img src="https://assets.untappd.com/profile/e05c5d9aa3ed082e8354ab144e716a96_100x100.jpg" alt="Eugene Sodin avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/Sensor87">
+																	<img src="https://assets.untappd.com/profile/935d7c8afb9dbdd943dc08292aab6aff_100x100.jpg" alt="Roman  avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/AlexFavorov">
+																	<img src="https://assets.untappd.com/profile/db287f406553168adbdc3a5e961b24e5_100x100.jpg" alt="Alex Favorov avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/exhilarate">
+																	<img src="https://assets.untappd.com/profile/065ae37ce2e3b61c0d20e64537e703b5_100x100.jpg" alt="Vitalii Vepsha avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1576680948" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_09/8f874c71396ec55913dada06ff8707d5_c_1576680948_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1576680948">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1576680948" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1576680948" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Tue, 09 Jun 2026 19:35:21 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1576680948" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1576680948">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>3</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="Mr_Pitkin" href="/user/Mr_Pitkin" title="Stanislav Kipra" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/79fd99a84106c257e71f6f4859762337_100x100.jpg" alt="Stanislav Kipra avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="ozerova" href="/user/ozerova" title="Alona Ozerova" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/32b6ee38b32a094a267bb390cbfc86cb_100x100.jpg" alt="Alona Ozerova avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1576680948" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1576680948" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1576680948'),$('#commentForm_1576680948 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1576680948" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1576680948" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1576665269" data-checkin-id="1576665269">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/inne-beczki-aurora/6369033" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6369033_a9ff9_sm.jpeg" alt="HopGang: Aurora by Inne Beczki">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-9448532-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/inne-beczki-aurora/6369033">HopGang: Aurora</a> by <a  href="/InneBeczki">Inne Beczki</a> at <a href="/v/os-gorczewska-200/9448532">Os. Górczewska 200</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1576665269">
+									Охмілене, але трохи та й таке									</p>
+
+									
+								<p class="purchased" data-track-venue-impression="venue_id-6241714-type-checkin_feed">Purchased at <a href="/v/lidl/6241714">Lidl</a></p>									<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/can@3x.png" alt="Can">
+										          <span>Can</span>
+										        </p>
+												<div class="caps " data-rating="3.7">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-70"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+									
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Lialit">
+																	<img src="https://assets.untappd.com/profile/519698a144f07bad0aa61c2ebb9fb7d9_100x100.jpg" alt="Елена Гаврилова avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/esodin">
+																	<img src="https://assets.untappd.com/profile/e05c5d9aa3ed082e8354ab144e716a96_100x100.jpg" alt="Eugene Sodin avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/Sensor87">
+																	<img src="https://assets.untappd.com/profile/935d7c8afb9dbdd943dc08292aab6aff_100x100.jpg" alt="Roman  avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/AlexFavorov">
+																	<img src="https://assets.untappd.com/profile/db287f406553168adbdc3a5e961b24e5_100x100.jpg" alt="Alex Favorov avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/exhilarate">
+																	<img src="https://assets.untappd.com/profile/065ae37ce2e3b61c0d20e64537e703b5_100x100.jpg" alt="Vitalii Vepsha avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/ozerova">
+																	<img src="https://assets.untappd.com/profile/32b6ee38b32a094a267bb390cbfc86cb_100x100.jpg" alt="Alona Ozerova avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1576665269" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_09/c4d3c4fc59e6184b98e249c282d6ac13_c_1576665269_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1576665269">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1576665269" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1576665269" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Tue, 09 Jun 2026 18:20:00 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1576665269" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1576665269">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>4</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="ozerova" href="/user/ozerova" title="Alona Ozerova" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/32b6ee38b32a094a267bb390cbfc86cb_100x100.jpg" alt="Alona Ozerova avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="Sensor87" href="/user/Sensor87" title="Roman" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/935d7c8afb9dbdd943dc08292aab6aff_100x100.jpg" alt="Roman avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="Mr_Pitkin" href="/user/Mr_Pitkin" title="Stanislav Kipra" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/79fd99a84106c257e71f6f4859762337_100x100.jpg" alt="Stanislav Kipra avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1576665269" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1576665269" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1576665269'),$('#commentForm_1576665269 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1576665269" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1576665269" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1576656988" data-checkin-id="1576656988">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/maryensztadt-klasycznie-maryensztadt-classics-maryensztadt-klasycznie-pale-ale/6691803" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6691803_648d0_sm.jpeg" alt="Maryensztadt Klasycznie Pale Ale by Maryensztadt Klasycznie (Maryensztadt Classics)">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-9448532-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/maryensztadt-klasycznie-maryensztadt-classics-maryensztadt-klasycznie-pale-ale/6691803">Maryensztadt Klasycznie Pale Ale</a> by <a  href="/MaryensztadtClassics">Maryensztadt Klasycznie (Maryensztadt Classics)</a> at <a href="/v/os-gorczewska-200/9448532">Os. Górczewska 200</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1576656988">
+									Легке, фруктове, негірке									</p>
+
+									
+								<p class="purchased" data-track-venue-impression="venue_id-6241714-type-checkin_feed">Purchased at <a href="/v/lidl/6241714">Lidl</a></p>									<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/bottle@3x.png" alt="Bottle">
+										          <span>Bottle</span>
+										        </p>
+												<div class="caps " data-rating="4">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+									
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Lialit">
+																	<img src="https://assets.untappd.com/profile/519698a144f07bad0aa61c2ebb9fb7d9_100x100.jpg" alt="Елена Гаврилова avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/esodin">
+																	<img src="https://assets.untappd.com/profile/e05c5d9aa3ed082e8354ab144e716a96_100x100.jpg" alt="Eugene Sodin avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/Sensor87">
+																	<img src="https://assets.untappd.com/profile/935d7c8afb9dbdd943dc08292aab6aff_100x100.jpg" alt="Roman  avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/AlexFavorov">
+																	<img src="https://assets.untappd.com/profile/db287f406553168adbdc3a5e961b24e5_100x100.jpg" alt="Alex Favorov avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/exhilarate">
+																	<img src="https://assets.untappd.com/profile/065ae37ce2e3b61c0d20e64537e703b5_100x100.jpg" alt="Vitalii Vepsha avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/ozerova">
+																	<img src="https://assets.untappd.com/profile/32b6ee38b32a094a267bb390cbfc86cb_100x100.jpg" alt="Alona Ozerova avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1576656988" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_09/c2f8eb7325699772ad77892355695093_c_1576656988_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1576656988">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1576656988" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1576656988" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Tue, 09 Jun 2026 17:40:17 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1576656988" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1576656988">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>2</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="Mr_Pitkin" href="/user/Mr_Pitkin" title="Stanislav Kipra" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/79fd99a84106c257e71f6f4859762337_100x100.jpg" alt="Stanislav Kipra avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1576656988" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1576656988" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1576656988'),$('#commentForm_1576656988 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1576656988" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1576656988" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1576359388" data-checkin-id="1576359388">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/browar-za-miastem-srebrna-pyra/6446174" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6446174_bfe17_sm.jpeg" alt="Srebrna Pyra by Browar Za Miastem">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-9038768-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/browar-za-miastem-srebrna-pyra/6446174">Srebrna Pyra</a> by <a  href="/BrowarZaMiastem">Browar Za Miastem</a> at <a href="/v/piwny-kolektyw/9038768">Piwny Kolektyw</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1576359388">
+									Відчутна гірчинка, але й чоколядовість. Смачно									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/bottle@3x.png" alt="Bottle">
+										          <span>Bottle</span>
+										        </p>
+												<div class="caps " data-rating="4">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+									
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1576359388" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_07/652135907da2b215e77d4ffe3e693ea7_c_1576359388_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1576359388">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1576359388" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1576359388" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Sun, 07 Jun 2026 17:53:37 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1576359388" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1576359388">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>1</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1576359388" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1576359388" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1576359388'),$('#commentForm_1576359388 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1576359388" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1576359388" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1575852771" data-checkin-id="1575852771">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/gubernija-brewery-gubernija-rugile-gira-rugile-kvass/1387877" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-1387877_1ed1d_sm.jpeg" alt="Gubernija Rugilė Gira / Rugilė Kvass by Gubernija Brewery">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-9448532-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/gubernija-brewery-gubernija-rugile-gira-rugile-kvass/1387877">Gubernija Rugilė Gira / Rugilė Kvass</a> by <a  href="/GubernijaBrewery">Gubernija Brewery</a> at <a href="/v/os-gorczewska-200/9448532">Os. Górczewska 200</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1575852771">
+									Засолодкий, але пити можна									</p>
+
+									
+								<p class="purchased" data-track-venue-impression="venue_id-12963055-type-checkin_feed">Purchased at <a href="/v/kaufland/12963055">Kaufland</a></p>									<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/bottle@3x.png" alt="Bottle">
+										          <span>Bottle</span>
+										        </p>
+												<div class="caps " data-rating="3">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+									
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1575852771" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_06/afe028cce316cf4ba01da95390a68238_c_1575852771_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1575852771">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1575852771" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1575852771" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Sat, 06 Jun 2026 13:10:07 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1575852771" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1575852771">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>2</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="ozerova" href="/user/ozerova" title="Alona Ozerova" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/32b6ee38b32a094a267bb390cbfc86cb_100x100.jpg" alt="Alona Ozerova avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1575852771" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1575852771" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1575852771'),$('#commentForm_1575852771 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1575852771" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1575852771" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1575146557" data-checkin-id="1575146557">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/moon-lark-brewery-klasik-horky-lezak-12-deg/6590022" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6590022_bce1c_sm.jpeg" alt="Klasik. Hořký Ležák 12° by Moon Lark Brewery">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-9448532-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/moon-lark-brewery-klasik-horky-lezak-12-deg/6590022">Klasik. Hořký Ležák 12°</a> by <a  href="/MoonLarkBrewery">Moon Lark Brewery</a> at <a href="/v/os-gorczewska-200/9448532">Os. Górczewska 200</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1575146557">
+									Норм, класика									</p>
+
+									
+								<p class="purchased" data-track-venue-impression="venue_id-6241714-type-checkin_feed">Purchased at <a href="/v/lidl/6241714">Lidl</a></p>									<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/can@3x.png" alt="Can">
+										          <span>Can</span>
+										        </p>
+												<div class="caps " data-rating="3.5">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-50"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+									
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/esodin">
+																	<img src="https://assets.untappd.com/profile/e05c5d9aa3ed082e8354ab144e716a96_100x100.jpg" alt="Eugene Sodin avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/Sensor87">
+																	<img src="https://assets.untappd.com/profile/935d7c8afb9dbdd943dc08292aab6aff_100x100.jpg" alt="Roman  avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/AlexFavorov">
+																	<img src="https://assets.untappd.com/profile/db287f406553168adbdc3a5e961b24e5_100x100.jpg" alt="Alex Favorov avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/eastern_european_beergeek">
+																	<img src="https://assets.untappd.com/profile/1fdf28d5abe5fb2af5d7d227f7d611da_100x100.jpg" alt="Eastern European Beergeek  avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Lialit">
+																	<img src="https://assets.untappd.com/profile/519698a144f07bad0aa61c2ebb9fb7d9_100x100.jpg" alt="Елена Гаврилова avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/exhilarate">
+																	<img src="https://assets.untappd.com/profile/065ae37ce2e3b61c0d20e64537e703b5_100x100.jpg" alt="Vitalii Vepsha avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/ozerova">
+																	<img src="https://assets.untappd.com/profile/32b6ee38b32a094a267bb390cbfc86cb_100x100.jpg" alt="Alona Ozerova avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1575146557" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_03/60e4ba6c1016676add3ab7b8c4d462bd_c_1575146557_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1575146557">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1575146557" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1575146557" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Wed, 03 Jun 2026 18:09:01 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1575146557" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1575146557">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>1</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1575146557" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1575146557" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1575146557'),$('#commentForm_1575146557 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1575146557" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1575146557" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1575133813" data-checkin-id="1575133813">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/browar-birbant-nadia/6241004" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6241004_127d2_sm.jpeg" alt="Nadia by Browar Birbant">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-9448532-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/browar-birbant-nadia/6241004">Nadia</a> by <a  href="/BrowarBirbant">Browar Birbant</a> at <a href="/v/os-gorczewska-200/9448532">Os. Górczewska 200</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1575133813">
+									Наче норм									</p>
+
+									
+								<p class="purchased" data-track-venue-impression="venue_id-6241714-type-checkin_feed">Purchased at <a href="/v/lidl/6241714">Lidl</a></p>									<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/can@3x.png" alt="Can">
+										          <span>Can</span>
+										        </p>
+												<div class="caps " data-rating="3.9">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-90"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+									
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/exhilarate">
+																	<img src="https://assets.untappd.com/profile/065ae37ce2e3b61c0d20e64537e703b5_100x100.jpg" alt="Vitalii Vepsha avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/ozerova">
+																	<img src="https://assets.untappd.com/profile/32b6ee38b32a094a267bb390cbfc86cb_100x100.jpg" alt="Alona Ozerova avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/Lialit">
+																	<img src="https://assets.untappd.com/profile/519698a144f07bad0aa61c2ebb9fb7d9_100x100.jpg" alt="Елена Гаврилова avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/esodin">
+																	<img src="https://assets.untappd.com/profile/e05c5d9aa3ed082e8354ab144e716a96_100x100.jpg" alt="Eugene Sodin avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/Sensor87">
+																	<img src="https://assets.untappd.com/profile/935d7c8afb9dbdd943dc08292aab6aff_100x100.jpg" alt="Roman  avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/AlexFavorov">
+																	<img src="https://assets.untappd.com/profile/db287f406553168adbdc3a5e961b24e5_100x100.jpg" alt="Alex Favorov avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/eastern_european_beergeek">
+																	<img src="https://assets.untappd.com/profile/1fdf28d5abe5fb2af5d7d227f7d611da_100x100.jpg" alt="Eastern European Beergeek  avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1575133813" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_06_03/7ca9d77c9f767bb13deeb2771876e34b_c_1575133813_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1575133813">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1575133813" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1575133813" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Wed, 03 Jun 2026 17:16:12 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1575133813" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1575133813">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>2</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="ozerova" href="/user/ozerova" title="Alona Ozerova" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/32b6ee38b32a094a267bb390cbfc86cb_100x100.jpg" alt="Alona Ozerova avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1575133813" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1575133813" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1575133813'),$('#commentForm_1575133813 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1575133813" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1575133813" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1574746262" data-checkin-id="1574746262">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/other-half-brewing-co-ba-bananaversary-2026/6588532" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6588532_b34f1_sm.jpeg" alt="BA Bananaversary (2026) by Other Half Brewing Co.">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-2903749-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/other-half-brewing-co-ba-bananaversary-2026/6588532">BA Bananaversary (2026)</a> by <a  href="/OtherHalfBrewingCompany">Other Half Brewing Co.</a> at <a href="/v/jabeerwocky/2903749">Jabeerwocky</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1574746262">
+									Все ще топчік									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/draft@3x.png" alt="Draft">
+										          <span>Draft</span>
+										        </p>
+												<div class="caps " data-rating="4.8">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-80"></div>
+	</div>								    </div>
+									
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/nyakove">
+																	<img src="https://assets.untappd.com/profile/6d3ba80291124794db1a990f33237fb0_100x100.jpg" alt="Mykhailo Dykun avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/Black_mzfk">
+																	<img src="https://assets.untappd.com/profile/c48718cf62242ead68e5309884791628_100x100.jpg" alt="Mykola Bortnychuk avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/svitlanalana">
+																	<img src="https://assets.untappd.com/profile/ba31a55574f315078a68d2e6077353c8_100x100.jpg" alt="Lana  avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/sk11nt">
+																	<img src="https://assets.untappd.com/profile/211276dc695a326a779c67b8d2e4814d_100x100.jpg" alt="Dmytro Skintiian avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1574746262" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_05_31/e4d6f71b87b87a2fb2a405b76cd35dee_c_1574746262_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1574746262">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1574746262" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1574746262" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Sun, 31 May 2026 20:28:10 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1574746262" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1574746262">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>3</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="nyakove" href="/user/nyakove" title="Mykhailo Dykun" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/6d3ba80291124794db1a990f33237fb0_100x100.jpg" alt="Mykhailo Dykun avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="Connoisseur" href="/user/Connoisseur" title="Victor" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/4a2ca4a782c24e072988b781352672c4_100x100.jpeg" alt="Victor avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1574746262" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1574746262" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1574746262'),$('#commentForm_1574746262 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1574746262" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1574746262" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1574743647" data-checkin-id="1574743647">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/magic-road-vanilla-gorilla/6733302" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/brewery_logos/brewery-498802_0465a.jpeg" alt="Vanilla Gorilla by Magic Road">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-2903749-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/magic-road-vanilla-gorilla/6733302">Vanilla Gorilla</a> by <a  href="/MagicRoad">Magic Road</a> at <a href="/v/jabeerwocky/2903749">Jabeerwocky</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1574743647">
+									Солодке, смачне									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/draft@3x.png" alt="Draft">
+										          <span>Draft</span>
+										        </p>
+												<div class="caps " data-rating="4.5">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-50"></div>
+	</div>								    </div>
+																			<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/badges/bdg_FromTheCold_Core_sm.jpg" alt="From the Cold (Level 43)">
+											<span>Earned the From the Cold (Level 43) badge!</span>
+										</span>
+										
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/nyakove">
+																	<img src="https://assets.untappd.com/profile/6d3ba80291124794db1a990f33237fb0_100x100.jpg" alt="Mykhailo Dykun avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/Black_mzfk">
+																	<img src="https://assets.untappd.com/profile/c48718cf62242ead68e5309884791628_100x100.jpg" alt="Mykola Bortnychuk avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/svitlanalana">
+																	<img src="https://assets.untappd.com/profile/ba31a55574f315078a68d2e6077353c8_100x100.jpg" alt="Lana  avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/sk11nt">
+																	<img src="https://assets.untappd.com/profile/211276dc695a326a779c67b8d2e4814d_100x100.jpg" alt="Dmytro Skintiian avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1574743647" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_05_31/dde319da7eca38accca745a1e3973296_c_1574743647_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1574743647">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1574743647" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1574743647" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Sun, 31 May 2026 20:20:24 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1574743647" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1574743647">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>1</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1574743647" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1574743647" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1574743647'),$('#commentForm_1574743647 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1574743647" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1574743647" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1574739024" data-checkin-id="1574739024">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/browar-monsters-priest/6533020" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6533020_ebaa7_sm.jpeg" alt="Priest by Browar Monsters">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-2903749-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/browar-monsters-priest/6533020">Priest</a> by <a  href="/BrowarMonsters">Browar Monsters</a> at <a href="/v/jabeerwocky/2903749">Jabeerwocky</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1574739024">
+									Якись кислий йогурт. Та й таке									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/draft@3x.png" alt="Draft">
+										          <span>Draft</span>
+										        </p>
+												<div class="caps " data-rating="3.5">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-50"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+									
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/svitlanalana">
+																	<img src="https://assets.untappd.com/profile/ba31a55574f315078a68d2e6077353c8_100x100.jpg" alt="Lana  avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/nyakove">
+																	<img src="https://assets.untappd.com/profile/6d3ba80291124794db1a990f33237fb0_100x100.jpg" alt="Mykhailo Dykun avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/Black_mzfk">
+																	<img src="https://assets.untappd.com/profile/c48718cf62242ead68e5309884791628_100x100.jpg" alt="Mykola Bortnychuk avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/sk11nt">
+																	<img src="https://assets.untappd.com/profile/211276dc695a326a779c67b8d2e4814d_100x100.jpg" alt="Dmytro Skintiian avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1574739024" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_05_31/4feba87b068bfa5b4e20d9bf1cf91b97_c_1574739024_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1574739024">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1574739024" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1574739024" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Sun, 31 May 2026 20:07:16 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1574739024" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1574739024">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>1</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1574739024" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1574739024" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1574739024'),$('#commentForm_1574739024 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1574739024" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1574739024" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1574736562" data-checkin-id="1574736562">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/browar-stu-mostow-wild-special-wild-thing/6256447" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6256447_b7769_sm.jpeg" alt="Wild Special: Wild Thing by Browar Stu Mostów">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-2903749-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/browar-stu-mostow-wild-special-wild-thing/6256447">Wild Special: Wild Thing</a> by <a  href="/BrowarStuMostow">Browar Stu Mostów</a> at <a href="/v/jabeerwocky/2903749">Jabeerwocky</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1574736562">
+									Все ще смачно									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/draft@3x.png" alt="Draft">
+										          <span>Draft</span>
+										        </p>
+												<div class="caps " data-rating="4.1">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-10"></div>
+	</div>								    </div>
+									
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/sk11nt">
+																	<img src="https://assets.untappd.com/profile/211276dc695a326a779c67b8d2e4814d_100x100.jpg" alt="Dmytro Skintiian avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/nyakove">
+																	<img src="https://assets.untappd.com/profile/6d3ba80291124794db1a990f33237fb0_100x100.jpg" alt="Mykhailo Dykun avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/Black_mzfk">
+																	<img src="https://assets.untappd.com/profile/c48718cf62242ead68e5309884791628_100x100.jpg" alt="Mykola Bortnychuk avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/svitlanalana">
+																	<img src="https://assets.untappd.com/profile/ba31a55574f315078a68d2e6077353c8_100x100.jpg" alt="Lana  avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1574736562" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_05_31/9b77d22d72a91aa184b2346480f3c2bc_c_1574736562_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1574736562">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1574736562" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1574736562" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Sun, 31 May 2026 20:00:19 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1574736562" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1574736562">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>2</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="Craft_Farm" href="/user/Craft_Farm" title="Павло Заяць" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/a80791e7d88031efb7222f586a968652_100x100.jpg" alt="Павло Заяць avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1574736562" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1574736562" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1574736562'),$('#commentForm_1574736562 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1574736562" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1574736562" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1574734402" data-checkin-id="1574734402">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/tankbusters-co-paris-delight/6213561" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6213561_d66e1_sm.jpeg" alt="Paris Delight by TankBusters.Co">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-2903749-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/tankbusters-co-paris-delight/6213561">Paris Delight</a> by <a  href="/TankBusters">TankBusters.Co</a> at <a href="/v/jabeerwocky/2903749">Jabeerwocky</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1574734402">
+									Наче норм									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/taster@3x.png" alt="Taster">
+										          <span>Taster</span>
+										        </p>
+												<div class="caps " data-rating="3.9">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-90"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+									
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/sk11nt">
+																	<img src="https://assets.untappd.com/profile/211276dc695a326a779c67b8d2e4814d_100x100.jpg" alt="Dmytro Skintiian avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1574734402" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_05_31/5c9e2e21b5a57da8aef75c109820efb4_c_1574734402_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1574734402">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1574734402" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1574734402" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Sun, 31 May 2026 19:54:08 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1574734402" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1574734402">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>1</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1574734402" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1574734402" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1574734402'),$('#commentForm_1574734402 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1574734402" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1574734402" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1574701602" data-checkin-id="1574701602">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/van-moll-joie-de-vivre-2022/5027825" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-5027825_e4493_sm.jpeg" alt="Joie De Vivre (2022) by Van Moll">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-12767316-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/van-moll-joie-de-vivre-2022/5027825">Joie De Vivre (2022)</a> by <a  href="/VanMoll">Van Moll</a> at <a href="/v/offside/12767316">Offside</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1574701602">
+									Кисле, бочкове, смачний фландерс									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/bottle@3x.png" alt="Bottle">
+										          <span>Bottle</span>
+										        </p>
+												<div class="caps " data-rating="4.4">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-40"></div>
+	</div>								    </div>
+																			<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/badges/bdg_FlanDiddlyAnders_sm.jpg" alt="Flan-didly-anders (Level 9)">
+											<span>Earned the Flan-didly-anders (Level 9) badge!</span>
+										</span>
+										
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/nyakove">
+																	<img src="https://assets.untappd.com/profile/6d3ba80291124794db1a990f33237fb0_100x100.jpg" alt="Mykhailo Dykun avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/Black_mzfk">
+																	<img src="https://assets.untappd.com/profile/c48718cf62242ead68e5309884791628_100x100.jpg" alt="Mykola Bortnychuk avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/svitlanalana">
+																	<img src="https://assets.untappd.com/profile/ba31a55574f315078a68d2e6077353c8_100x100.jpg" alt="Lana  avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/sk11nt">
+																	<img src="https://assets.untappd.com/profile/211276dc695a326a779c67b8d2e4814d_100x100.jpg" alt="Dmytro Skintiian avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1574701602" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_05_31/ec34b7315f7d6261c2e00b1019d632b4_c_1574701602_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1574701602">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1574701602" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1574701602" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Sun, 31 May 2026 18:26:30 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1574701602" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1574701602">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>2</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																				<a class="user-toasts tip track-click" data-user-name="nyakove" href="/user/nyakove" title="Mykhailo Dykun" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/6d3ba80291124794db1a990f33237fb0_100x100.jpg" alt="Mykhailo Dykun avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1574701602" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1574701602" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1574701602'),$('#commentForm_1574701602 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1574701602" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1574701602" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1574693528" data-checkin-id="1574693528">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/browar-artezan-jungle-juice-capibara/6716844" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/beer_logos/beer-6716844_40e7a_sm.jpeg" alt="Jungle Juice: Capibara by Browar Artezan">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-12617758-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/browar-artezan-jungle-juice-capibara/6716844">Jungle Juice: Capibara</a> by <a  href="/BrowarArtezan">Browar Artezan</a> at <a href="/v/white-crow-craft-beer-and-kitchen/12617758">White Crow Craft Beer & Kitchen</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1574693528">
+									Солодке, фруктове, та й таке									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/taster@3x.png" alt="Taster">
+										          <span>Taster</span>
+										        </p>
+												<div class="caps " data-rating="3.5">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-50"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+																			<span class="badge">
+											<img loading="lazy" src="https://assets.untappd.com/badges/aae45250bb4d36b264f1165ab0a6d94c_sm.jpeg" alt="White Guard LvL2 (Level 30)">
+											<span>Earned the White Guard LvL2 (Level 30) badge!</span>
+										</span>
+										
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/svitlanalana">
+																	<img src="https://assets.untappd.com/profile/ba31a55574f315078a68d2e6077353c8_100x100.jpg" alt="Lana  avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/sk11nt">
+																	<img src="https://assets.untappd.com/profile/211276dc695a326a779c67b8d2e4814d_100x100.jpg" alt="Dmytro Skintiian avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/nyakove">
+																	<img src="https://assets.untappd.com/profile/6d3ba80291124794db1a990f33237fb0_100x100.jpg" alt="Mykhailo Dykun avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/Black_mzfk">
+																	<img src="https://assets.untappd.com/profile/c48718cf62242ead68e5309884791628_100x100.jpg" alt="Mykola Bortnychuk avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1574693528" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_05_31/7735f47cfb0db9bd4a6fcfef6e068b4a_c_1574693528_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1574693528">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1574693528" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1574693528" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Sun, 31 May 2026 18:04:45 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1574693528" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1574693528">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>1</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1574693528" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1574693528" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1574693528'),$('#commentForm_1574693528 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1574693528" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1574693528" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			
+			<div class="item " id="checkin_1574693054" data-checkin-id="1574693054">
+				<div class="">
+								<div class="avatar">
+					<div class="avatar-holder">
+						<span class="supporter"></span>						<a href="/user/ysilvestrov">
+							<img loading="lazy" src="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2" alt="Yuriy Silvestrov">
+						</a>
+					</div>
+				</div>
+				<div class="checkin">
+					<div class="top">
+													<a href="/b/slow-flow-group-smykan-renety-2024/6391450" class="label">
+								<img loading="lazy" src="https://assets.untappd.com/site/brewery_logos/brewery-262573_43812.jpeg" alt="Renety 2024 by Slow Flow Group (Smykan)">
+							</a>
+														<p class="text" data-track-venue-impression="venue_id-12617758-type-checkin_feed">
+								<a href="/user/ysilvestrov" class="user">Yuriy Silvestrov</a>  is drinking a <a href="/b/slow-flow-group-smykan-renety-2024/6391450">Renety 2024</a> by <a  href="/CydrSmykan">Slow Flow Group (Smykan)</a> at <a href="/v/white-crow-craft-beer-and-kitchen/12617758">White Crow Craft Beer & Kitchen</a>
+							</p>
+														<div class="checkin-comment">
+																	<p class="comment-text" id="translate_1574693054">
+									Норм яблуко									</p>
+
+									
+																	<div class="rating-serving">
+																						<p class="serving">
+										          <img src="https://assets.untappd.com/static_app_assets/new_serving_styles_2026/taster@3x.png" alt="Taster">
+										          <span>Taster</span>
+										        </p>
+												<div class="caps " data-rating="4">
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap cap-100"></div>
+		<div class="cap"></div>
+	</div>								    </div>
+									
+										<div class="tagged-friends">
+											<strong>Tagged Friends</strong>
+											<div>
+
+												
+														<div class="avatar">
+															<div class="avatar-holder">
+																																<a href="/user/sk11nt">
+																	<img src="https://assets.untappd.com/profile/211276dc695a326a779c67b8d2e4814d_100x100.jpg" alt="Dmytro Skintiian avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/Black_mzfk">
+																	<img src="https://assets.untappd.com/profile/c48718cf62242ead68e5309884791628_100x100.jpg" alt="Mykola Bortnychuk avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/svitlanalana">
+																	<img src="https://assets.untappd.com/profile/ba31a55574f315078a68d2e6077353c8_100x100.jpg" alt="Lana  avatar">
+																</a>
+															</div>
+														</div>
+													
+														<div class="avatar">
+															<div class="avatar-holder">
+																<span class="supporter"></span>																<a href="/user/nyakove">
+																	<img src="https://assets.untappd.com/profile/6d3ba80291124794db1a990f33237fb0_100x100.jpg" alt="Mykhailo Dykun avatar">
+																</a>
+															</div>
+														</div>
+																								</div>
+										</div>
+
+										
+								<span style="display: block; clear: both;"></span>
+
+							</div>
+														<p class="photo">
+								<a href="/user/ysilvestrov/checkin/1574693054" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckinphoto">
+									<img loading="lazy" src="https://images.untp.beer/crop?width=640&height=640&stripmeta=true&url=https://untappd.s3.amazonaws.com/photos/2026_05_31/24756c0c63bcb6d1b4e1e4b00859d378_c_1574693054_raw.jpg" alt="Check-in Photo">
+								</a>
+							</p>
+							
+					</div>
+
+					<div class="feedback">
+
+						<div class="actions_bar">
+																<p class="comment_btn">
+										<a href="#" role="button" class="button grey comment comment-btn track-click" data-track="activity_feed" data-href=":feed/comment" data-checkin-id="1574693054">
+											<span>Comment</span>
+										</a>
+									</p><p class="toast_btn">
+										<a href="#" role="button" class="button grey toast  track-click" data-track="activity_feed" data-href=":feed/toast" data-checkin-id= "1574693054" data-user-name="ysilvestrov" data-user-avatar="https://gravatar.com/avatar/c44cf11b647301dcb573bf874453d9b6?size=100&d=https%3A%2F%2Fassets.untappd.com%2Fsite%2Fassets%2Fimages%2Fdefault_avatar_v3_gravatar.jpg%3Fv%3D2">
+											<span>Toast</span>
+										</a>
+									</p>
+						</div>
+
+						<div class="bottom">
+							<a href="/user/ysilvestrov/checkin/1574693054" class="time timezoner track-click" data-track="activity_feed" data-href=":feed/viewcheckindate">Sun, 31 May 2026 18:03:24 +0000</a>
+							<a href="/user/ysilvestrov/checkin/1574693054" class="track-click" data-track="activity_feed" data-href=":feed/viewcheckintext">View Detailed Check-in</a>
+							<a href="#" class="delete-checkin track-click" data-track="activity_feed" data-href=":feed/deletecheckin" data-checkin-id="1574693054">Delete Check-In</a>						</div>
+
+						<div class="cheers" >								<span class="count">
+									<span>1</span>
+								</span><span class="toast-list">
+																			<a class="user-toasts tip track-click" data-user-name="proxmiff" href="/user/proxmiff" title="Alexius Prokofiev" data-track="activity_feed" data-href=":feed/userprofiletoast">
+											<img loading="lazy" src="https://assets.untappd.com/profile/af7225546a3744cceb01e2854c261f84_100x100.jpg" alt="Alexius Prokofiev avatar">
+										</a>
+																		</span>
+						      							</div>
+
+						<div class="comments">
+							<div class="comments-container">
+															</div>
+															<form id="commentForm_1574693054" class="input" style="display: none;" accept-charset="UTF-8">
+									<p class="post-error" style="display: none;">There was a problem posting your comment, please try again.</p>
+									<textarea placeholder="Leave a comment..." name="comment" id="commentBox_1574693054" class="commentBox" onkeydown="limitTextReverse($('#commentBox_1574693054'),$('#commentForm_1574693054 .myCount'), 140);"></textarea>
+									<span role="button" class="button grey btn-submit track-click" data-checkin-id="1574693054" data-track="activity_feed" data-href=":comment/post">Post<input type="submit" value="Post"></span>
+									<span class="comment-loading" style="display: none;"></span>
+									<span class="counter"><abbr class="myCount">0</abbr>/140</span>
+									<input type="hidden" name="checkin_id" value="1574693054" />
+								</form>
+								
+						</div>
+					</div>
+				</div>
+				</div>
+			</div>
+			


### PR DESCRIPTION
## Summary

Follow-up to #163. Manual testing showed check-in sync only ever loaded the **most recent page** and never went deeper — breaking both the non-Supporter full backfill and the festival top-up.

**Root cause (confirmed against real captures):** `https://untappd.com/user/<name>?max_id=<id>` **ignores `max_id`** — it always returns the newest 15 check-ins (a capture with `max_id` set was byte-identical to page 1). The real pagination is the "Show More" XHR endpoint `GET /profile/more_feed/<user>/<offset>?v2=true`, which returns a 25-item HTML **fragment** of older check-ins and **307-redirects to `/home`** unless the request carries `X-Requested-With: XMLHttpRequest`.

## Changes

- **Loop/SW (`feedUrl`, `fetchFeed`):** page 1 = full profile page; every older page = `more_feed` fragment with the `X-Requested-With` header. A redirect on `more_feed` is treated as an error rather than silently parsing `/home` as an empty feed.
- **Parser (`parseCheckinFeedPage`):** `nextMaxId` = oldest check-in id whenever items exist (dropped the `.more_checkins` gate — fragments have no button). Feed bottom is now a **zero-item page**.
- **Tests:** parser fragment test (no `.stats`/`.more_checkins` → cursor still advances); `feedUrl` unit test (full page vs `more_feed`); route test `PAGE_BOTTOM` updated to an empty page.
- **Release:** bump 0.7.1 + CHANGELOG; `spec.md` §4 pagination note corrected (documents `more_feed` + the `X-Requested-With` requirement and that `?max_id=` is ignored).

## Verification
- [x] Parser run against the **real** 25-item `more_feed` fragment: all 25 parsed, cursor = oldest id, paginates to older check-ins.
- [x] Server 726 tests green; extension 216 tests green; server `tsc` build + extension `tsc` clean.
- [ ] **Manual (post-merge):** link an account, Sync, confirm it pages past the first 15 and the count climbs toward the profile total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)