### PR TITLE
chore(codex): allow git and gh commands

### DIFF
--- a/.codex/rules/default.rules
+++ b/.codex/rules/default.rules
@@ -1,0 +1,13 @@
+# Автоматичний дозвіл для всіх команд Git
+prefix_rule(
+    pattern = ["git"],
+    decision = "allow",
+    justification = "Allow all git commands without prompting"
+)
+
+# Автоматичний дозвіл для всіх команд GitHub CLI
+prefix_rule(
+    pattern = ["gh"],
+    decision = "allow",
+    justification = "Allow all GitHub CLI commands without prompting"
+)


### PR DESCRIPTION
Codex sessions can run Git and GitHub CLI workflows without per-command approval, removing friction from branch, commit, push, PR, and CI follow-up operations. Other executables remain unaffected.

Verified with `codex execpolicy check`: `git` and `gh` resolve to `allow`, while an unrelated `curl` command matches no rule.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
