### PR TITLE
fix(matcher): preserve decimal release identifiers

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1098,6 +1098,9 @@ test-БД, §3.2 «no `await` ⇒ no race», §3.3 визначення «extern
   ABV-tiebreak (`ABV_TOLERANCE`). `normalizeName` зрізає рік, тож різні
   vintage/міцності одного пива (`Buzdygan Rozkoszy` 8.5% vs `… 2026` 9.8%)
   колапсують в однакову назву; ABV — єдиний сигнал, що їх розрізняє.
+  Десяткові release-ідентифікатори в назві (`Ambrosia 9.0`) натомість зберігаються
+  як токени і не можуть exact/fuzzy-матчитись до іншого релізу (`Ambrosia 8.0`).
+  Числовий tap-noise з `%`/`°`/`ABV` і чотиризначні vintage-роки далі зрізаються.
   `enrichOneOrphan` передає `beer.abv` у `lookupBeer`.
 - Збережений `normalized_brewery` — ключ ідемпотентності upsert; при зміні правил
   нормалізації перераховується на старті (`backfill-normalized-brewery.ts`).

--- a/src/domain/matcher.test.ts
+++ b/src/domain/matcher.test.ts
@@ -263,6 +263,19 @@ describe('vintage handling', () => {
   });
 });
 
+describe('decimal release identifiers', () => {
+  const releases: CatalogBeer[] = [
+    c({ id: 11185, brewery: 'FUNKY FLUID', name: 'Ambrosia 8.0', abv: 6.5 }),
+    c({ id: 10615, brewery: 'FUNKY FLUID', name: 'Ambrosia 7.0', abv: 6.7 }),
+    c({ id: 9859, brewery: 'FUNKY FLUID', name: 'Ambrosia 2025', abv: 6.5 }),
+    c({ id: 387, brewery: 'FUNKY FLUID', name: 'Ambrosia 5.0', abv: 6.8 }),
+  ];
+
+  test('does not match an unknown release to an older catalog row without ABV', () => {
+    expect(matchBeer({ brewery: 'FUNKY FLUID', name: 'Ambrosia 9.0' }, releases)).toBeNull();
+  });
+});
+
 test('ontap-style raw beer_ref + ABV maps to clean Untappd entry', () => {
   // Real-world scenario from issue #18: ontap parser used to leave
   // "Buzdygan Rozkoszy 24°·8,5% — Caribbean Imperial Stout" in beer_ref,

--- a/src/domain/normalize.test.ts
+++ b/src/domain/normalize.test.ts
@@ -27,6 +27,8 @@ test('strips numeric tokens (ABV / strength / years)', () => {
 test('preserves decimal release identifiers in beer names', () => {
   expect(normalizeName('Ambrosia 9.0')).toBe('ambrosia 9.0');
   expect(normalizeName('Ambrosia 8.0')).toBe('ambrosia 8.0');
+  expect(normalizeName(' Ambrosia 9,0 ')).toBe('ambrosia 9.0');
+  expect(normalizeName('Ambrosia 9.0 — IPA')).toBe('ambrosia 9.0');
 });
 
 test('strips every Polish diacritic', () => {

--- a/src/domain/normalize.test.ts
+++ b/src/domain/normalize.test.ts
@@ -24,6 +24,11 @@ test('strips numeric tokens (ABV / strength / years)', () => {
   expect(normalizeBrewery('Browar Stu 8,5%')).toBe('stu');
 });
 
+test('preserves decimal release identifiers in beer names', () => {
+  expect(normalizeName('Ambrosia 9.0')).toBe('ambrosia 9.0');
+  expect(normalizeName('Ambrosia 8.0')).toBe('ambrosia 8.0');
+});
+
 test('strips every Polish diacritic', () => {
   expect(normalizeBrewery('ąćęłńóśźż')).toBe('acelnoszz');
   expect(normalizeBrewery('ĄĆĘŁŃÓŚŹŻ')).toBe('acelnoszz');

--- a/src/domain/normalize.ts
+++ b/src/domain/normalize.ts
@@ -33,9 +33,21 @@ function stripDiacritics(s: string): string {
     .replace(/ł/g, 'l').replace(/Ł/g, 'L');
 }
 
+// Private-use sentinel survives baseNormalize's punctuation pass, then becomes a
+// canonical dot. Percentage/strength suffixes deliberately bypass this protection.
+const DECIMAL_SEPARATOR = '\uE000';
+
+function preserveDecimalIdentifiers(s: string): string {
+  return s.replace(
+    /\b(\d+)[.,](\d+)\b(?!\s*(?:%|°|abv\b))/gi,
+    `$1${DECIMAL_SEPARATOR}$2`,
+  );
+}
+
 export function baseNormalize(s: string): string {
   return stripDiacritics(s).toLowerCase()
-    .replace(/[^\p{L}\p{N}\s]/gu, ' ')
+    .replace(/[^\p{L}\p{N}\s\uE000]/gu, ' ')
+    .replaceAll(DECIMAL_SEPARATOR, '.')
     .replace(/\s+/g, ' ')
     .trim();
 }
@@ -62,7 +74,7 @@ export function stripLegalForm(s: string): string {
 }
 
 export function normalizeName(s: string): string {
-  const tokens = baseNormalize(s)
+  const tokens = baseNormalize(preserveDecimalIdentifiers(s))
     .split(' ')
     .filter((t) => t && !STYLE_WORDS.has(t) && !isNumericNoise(t));
   return tokens.join(' ');


### PR DESCRIPTION
Decimal release identifiers now remain part of beer identity, so `Ambrosia 9.0` no longer inherits the Untappd ID, rating, or drunk status of `Ambrosia 8.0`. Unknown releases stay unmatched and can proceed to enrichment, while percentage/strength noise and four-digit vintage handling remain unchanged.

Verified with 778 tests and a clean TypeScript build.

Fixes #178

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
