### PR TITLE
fix: normalize checkin_at date format (#190)

### DIFF
--- a/src/domain/checkin-time.test.ts
+++ b/src/domain/checkin-time.test.ts
@@ -1,0 +1,32 @@
+import { canonicalCheckinAt } from './checkin-time';
+
+describe('canonicalCheckinAt', () => {
+  it('converts RFC-2822 (extension feed format) to canonical UTC', () => {
+    // This is the exact format the extension feed parser stored, which broke
+    // lexicographic MAX(checkin_at) in /status.
+    expect(canonicalCheckinAt('Tue, 05 May 2026 21:40:37 +0000')).toBe('2026-05-05 21:40:37');
+    expect(canonicalCheckinAt('Wed, 29 Apr 2026 18:53:59 +0000')).toBe('2026-04-29 18:53:59');
+  });
+
+  it('passes through already-canonical "YYYY-MM-DD HH:MM:SS" unchanged', () => {
+    expect(canonicalCheckinAt('2016-04-15 19:06:47')).toBe('2016-04-15 19:06:47');
+  });
+
+  it('normalizes ISO-8601 with T/Z to canonical (space, no zone)', () => {
+    expect(canonicalCheckinAt('2026-04-22T10:00:00Z')).toBe('2026-04-22 10:00:00');
+    expect(canonicalCheckinAt('2026-04-22T10:00:00.123Z')).toBe('2026-04-22 10:00:00');
+  });
+
+  it('keeps an unparseable value as-is (defensive, never throws)', () => {
+    expect(canonicalCheckinAt('5 hours ago')).toBe('5 hours ago');
+    expect(canonicalCheckinAt('')).toBe('');
+  });
+
+  it('produces a chronologically sortable string for RFC inputs', () => {
+    // Lexicographic order of the canonical outputs must match chronology — the
+    // property MAX(checkin_at) relies on.
+    const a = canonicalCheckinAt('Wed, 29 Apr 2026 18:53:59 +0000');
+    const b = canonicalCheckinAt('Tue, 05 May 2026 21:40:37 +0000');
+    expect(b > a).toBe(true); // May 5 is later than Apr 29
+  });
+});

--- a/src/domain/checkin-time.ts
+++ b/src/domain/checkin-time.ts
@@ -1,0 +1,20 @@
+// Canonicalize a check-in timestamp to a sortable 'YYYY-MM-DD HH:MM:SS' (UTC).
+//
+// check-in timestamps arrive in source-dependent formats: `/import` stores the
+// Untappd export's ISO-ish `created_at` ("2016-04-15 19:06:47"), while the
+// extension feed parser stored the visible RFC-2822 string
+// ("Tue, 05 May 2026 21:40:37 +0000"). Mixing them breaks lexicographic
+// MAX(checkin_at)/ORDER BY (letters sort after digits, weekday name dominates),
+// which surfaced as a wrong/garbled date in `/status`. Normalizing on the way in
+// (and backfilling legacy rows) keeps the column sortable.
+export function canonicalCheckinAt(raw: string): string {
+  // Already date-first (YYYY-MM-DD then space or 'T'): take date+time, drop any
+  // zone/fractional suffix, normalize 'T' -> space. Pure string op, no Date
+  // parsing — so an already-UTC value can never be time-zone shifted.
+  if (/^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}/.test(raw)) {
+    return raw.slice(0, 19).replace('T', ' ');
+  }
+  const d = new Date(raw);
+  if (Number.isNaN(d.getTime())) return raw; // unparseable — keep as-is, never throw
+  return d.toISOString().slice(0, 19).replace('T', ' ');
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import { refreshOntap } from './jobs/refresh-ontap';
 import { refreshAllUntappd } from './jobs/refresh-untappd';
 import { dedupeBreweryAliases } from './jobs/dedupe-brewery-aliases';
 import { backfillNormalizedBrewery } from './jobs/backfill-normalized-brewery';
+import { backfillCheckinAt } from './jobs/backfill-checkin-at';
 import { cleanupPollutedOntap } from './jobs/cleanup-polluted-ontap';
 import { enrichOrphans } from './jobs/enrich-orphans';
 import { refreshTapRatings } from './jobs/refresh-tap-ratings';
@@ -43,6 +44,7 @@ async function main(): Promise<void> {
   const db = openDb(env.DATABASE_PATH);
   migrate(db);
   backfillNormalizedBrewery(db, log);
+  backfillCheckinAt(db, log);
   dedupeBreweryAliases(db, log);
   cleanupPollutedOntap(db, log);
   cleanupOldSnapshots(db, log, env.SNAPSHOT_RETENTION_DAYS);

--- a/src/jobs/backfill-checkin-at.test.ts
+++ b/src/jobs/backfill-checkin-at.test.ts
@@ -1,0 +1,56 @@
+import pino from 'pino';
+import { openDb } from '../storage/db';
+import { migrate } from '../storage/schema';
+import type { DB } from '../storage/db';
+import { backfillCheckinAt } from './backfill-checkin-at';
+
+const log = pino({ level: 'silent' });
+
+// Insert a checkin row with a raw (un-normalized) checkin_at, bypassing
+// mergeCheckin's normalization — simulates legacy rows written before the fix.
+function insertRaw(db: DB, id: string, checkinAt: string, telegramId = 1): void {
+  db.prepare(
+    'INSERT INTO checkins (checkin_id, telegram_id, beer_id, user_rating, checkin_at, venue) VALUES (?, ?, NULL, NULL, ?, NULL)',
+  ).run(id, telegramId, checkinAt);
+}
+
+function freshDb(): DB {
+  const db = openDb(':memory:');
+  migrate(db);
+  return db;
+}
+
+describe('backfillCheckinAt', () => {
+  it('rewrites legacy RFC-2822 rows to canonical UTC and counts them', () => {
+    const db = freshDb();
+    insertRaw(db, 'rfc1', 'Tue, 05 May 2026 21:40:37 +0000');
+    insertRaw(db, 'rfc2', 'Wed, 29 Apr 2026 18:53:59 +0000');
+    insertRaw(db, 'iso', '2016-04-15 19:06:47'); // already canonical — must be untouched
+
+    const { updated } = backfillCheckinAt(db, log);
+    expect(updated).toBe(2);
+
+    const rows = db
+      .prepare('SELECT checkin_id, checkin_at FROM checkins ORDER BY checkin_id')
+      .all() as Array<{ checkin_id: string; checkin_at: string }>;
+    expect(rows).toEqual([
+      { checkin_id: 'iso', checkin_at: '2016-04-15 19:06:47' },
+      { checkin_id: 'rfc1', checkin_at: '2026-05-05 21:40:37' },
+      { checkin_id: 'rfc2', checkin_at: '2026-04-29 18:53:59' },
+    ]);
+  });
+
+  it('is idempotent — a second run updates nothing', () => {
+    const db = freshDb();
+    insertRaw(db, 'rfc1', 'Tue, 05 May 2026 21:40:37 +0000');
+    expect(backfillCheckinAt(db, log).updated).toBe(1);
+    expect(backfillCheckinAt(db, log).updated).toBe(0);
+  });
+
+  it('leaves a clean ISO-only table completely untouched', () => {
+    const db = freshDb();
+    insertRaw(db, 'a', '2024-05-05 20:00:00');
+    insertRaw(db, 'b', '2023-01-01 10:00:00');
+    expect(backfillCheckinAt(db, log).updated).toBe(0);
+  });
+});

--- a/src/jobs/backfill-checkin-at.ts
+++ b/src/jobs/backfill-checkin-at.ts
@@ -1,0 +1,34 @@
+import type pino from 'pino';
+import type { DB } from '../storage/db';
+import { canonicalCheckinAt } from '../domain/checkin-time';
+
+export interface BackfillResult {
+  updated: number;
+}
+
+// One-time, idempotent normalization of checkins.checkin_at to the canonical
+// 'YYYY-MM-DD HH:MM:SS' (UTC) form. The extension feed sync historically stored
+// RFC-2822 strings ("Tue, 05 May 2026 21:40:37 +0000") which break lexicographic
+// MAX()/ORDER BY (and surfaced as a wrong/garbled date in /status, #190). Only
+// rows whose canonical form differs are rewritten, so re-runs are no-ops.
+export function backfillCheckinAt(db: DB, log: pino.Logger): BackfillResult {
+  const rows = db
+    .prepare('SELECT id, checkin_at FROM checkins')
+    .all() as Array<{ id: number; checkin_at: string }>;
+  const update = db.prepare('UPDATE checkins SET checkin_at = ? WHERE id = ?');
+  let updated = 0;
+
+  const tx = db.transaction((items: typeof rows) => {
+    for (const r of items) {
+      const fresh = canonicalCheckinAt(r.checkin_at);
+      if (fresh !== r.checkin_at) {
+        update.run(fresh, r.id);
+        updated++;
+      }
+    }
+  });
+  tx(rows);
+
+  log.info({ updated }, 'backfill-checkin-at done');
+  return { updated };
+}

--- a/src/storage/checkins.test.ts
+++ b/src/storage/checkins.test.ts
@@ -111,4 +111,23 @@ describe('latestCheckinAt', () => {
     mergeCheckin(db, { checkin_id: 'c', telegram_id: 2, beer_id: null, user_rating: null, checkin_at: '2025-09-09 09:00:00', venue: null });
     expect(latestCheckinAt(db, 1)).toBe('2024-05-05 20:00:00');
   });
+
+  it('picks the chronologically-latest row even when sources mix RFC and ISO (the /status bug)', () => {
+    const db = openDb(':memory:'); migrate(db);
+    // ISO from /import, RFC-2822 from the extension feed — pre-normalization
+    // these were stored verbatim and lexicographic MAX picked the wrong one.
+    mergeCheckin(db, { checkin_id: 'iso', telegram_id: 1, beer_id: null, user_rating: null, checkin_at: '2026-04-18 17:52:26', venue: null });
+    mergeCheckin(db, { checkin_id: 'rfc-late', telegram_id: 1, beer_id: null, user_rating: null, checkin_at: 'Tue, 05 May 2026 21:40:37 +0000', venue: null });
+    mergeCheckin(db, { checkin_id: 'rfc-mid', telegram_id: 1, beer_id: null, user_rating: null, checkin_at: 'Wed, 29 Apr 2026 18:53:59 +0000', venue: null });
+    expect(latestCheckinAt(db, 1)).toBe('2026-05-05 21:40:37');
+  });
+});
+
+describe('mergeCheckin checkin_at normalization', () => {
+  it('stores RFC-2822 timestamps in canonical UTC form', () => {
+    const db = openDb(':memory:'); migrate(db);
+    mergeCheckin(db, { checkin_id: 'x', telegram_id: 1, beer_id: null, user_rating: null, checkin_at: 'Wed, 29 Apr 2026 18:53:59 +0000', venue: null });
+    const row = db.prepare("SELECT checkin_at FROM checkins WHERE checkin_id = 'x'").get() as { checkin_at: string };
+    expect(row.checkin_at).toBe('2026-04-29 18:53:59');
+  });
 });

--- a/src/storage/checkins.ts
+++ b/src/storage/checkins.ts
@@ -1,4 +1,5 @@
 import type { DB } from './db';
+import { canonicalCheckinAt } from '../domain/checkin-time';
 
 export interface CheckinInput {
   checkin_id: string;
@@ -20,7 +21,7 @@ export function mergeCheckin(db: DB, c: CheckinInput): void {
        user_rating = excluded.user_rating,
        checkin_at = excluded.checkin_at,
        venue = excluded.venue`,
-  ).run(c.checkin_id, c.telegram_id, c.beer_id, c.user_rating, c.checkin_at, c.venue);
+  ).run(c.checkin_id, c.telegram_id, c.beer_id, c.user_rating, canonicalCheckinAt(c.checkin_at), c.venue);
 }
 
 export function checkinsForUser(db: DB, telegramId: number): CheckinRow[] {


### PR DESCRIPTION
## Summary
Fixes the garbled "last check-in" date in `/status` (#190) — and the underlying data bug it exposed.

**Root cause:** `checkins.checkin_at` was stored verbatim in source-dependent formats: ISO `YYYY-MM-DD HH:MM:SS` from `/import`, but **RFC-2822** (`Tue, 05 May 2026 21:40:37 +0000`) from the extension feed sync. `latestCheckinAt` uses `MAX(checkin_at)`, a lexicographic comparison — letters sort after digits and the weekday name dominates, so it returned the alphabetically-greatest weekday (`Wed…`) instead of the chronologically latest row, which `.slice(0,10)` then truncated to `"Wed, 29 Ap"`. (In prod: 32 of 43,333 rows were RFC, all on the one extension user, who was shown Apr 29 when their real latest was May 5.)

## Fix
1. **`canonicalCheckinAt`** (`src/domain/checkin-time.ts`) — pure normalizer to `YYYY-MM-DD HH:MM:SS` (UTC). Already-canonical values pass through via a string op (no `Date` re-parse → no TZ shift); RFC / ISO-with-`T`/`Z` are parsed and reformatted; unparseable input is kept as-is.
2. **Applied in `mergeCheckin`** — the single write path for both import and feed, so all future rows are canonical.
3. **Startup backfill** (`src/jobs/backfill-checkin-at.ts`, mirrors `backfill-normalized-brewery`) — rewrites the 32 legacy RFC rows; idempotent (only touches non-canonical rows). Wired into `index.ts` startup.

This also fixes the latent lexicographic corruption of `ORDER BY checkin_at DESC` in `checkinsForUser` (used by `latestRatingsByBeer`) for the extension user.

## Test Plan
- [x] `npm test` — 835 passing (10 new): canonicalizer (RFC/ISO-T-Z/passthrough/unparseable/sortability), `mergeCheckin` normalization, `latestCheckinAt` with mixed sources (the exact bug), backfill (rewrite/idempotency/untouched-ISO)
- [x] `npm run typecheck` + `npm run build` clean
- [ ] Post-deploy: confirm `/status` shows the correct latest date; `backfill-checkin-at done {updated:32}` in the journal

🤖 Generated with [Claude Code](https://claude.com/claude-code)