### PR TITLE
fix(extension): include BeerFreak ABV in matching

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed BeerFreak matching for same-name releases: when product details expose `Міцність`, the extension now sends that ABV to the matcher using bounded, cached detail-page lookups.
 - Fixed Flasker matching when product titles omit or abbreviate the brewery: trusted shop tags and product links now identify known breweries, and leading preview/sample labels are removed before matching.
 
 ## [0.9.0] - 2026-06-17

--- a/extension/src/content/index.test.ts
+++ b/extension/src/content/index.test.ts
@@ -50,6 +50,25 @@ describe('runOverlay', () => {
     expect(card.el.querySelector(`[${BADGE_MARKER}]`)).not.toBeNull();
   });
 
+  it('loads details for uncached cards before sending them to match', async () => {
+    const cached: Card = { el: cardEl(), brewery: 'Cached', name: 'Beer' };
+    const uncached: Card = { el: cardEl(), brewery: 'FUNKY FLUID', name: 'Ambrosia 9.0' };
+    await setCached(normalizeKey('Cached', 'Beer'), drunkResult('Cached', 'Beer'));
+    const adapter = {
+      ...adapterFor([cached, uncached]),
+      loadCardDetails: vi.fn(async (cards: Card[]) => {
+        cards[0].abv = 7.3;
+      }),
+    };
+    const sendMatch = vi.fn(async () => [drunkResult('FUNKY FLUID', 'Ambrosia 9.0')]);
+
+    await runOverlay(document, adapter, sendMatch);
+
+    expect(adapter.loadCardDetails).toHaveBeenCalledTimes(1);
+    expect(adapter.loadCardDetails).toHaveBeenCalledWith([uncached]);
+    expect(sendMatch).toHaveBeenCalledWith([{ brewery: 'FUNKY FLUID', name: 'Ambrosia 9.0', abv: 7.3 }]);
+  });
+
   it('awaits waitForGrid before parsing when the adapter defines it', async () => {
     const order: string[] = [];
     const card: Card = { el: cardEl(), brewery: 'B', name: 'N' };

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -1,4 +1,4 @@
-import type { SiteAdapter } from '../sites/types';
+import type { Card, SiteAdapter } from '../sites/types';
 import type { MatchResult, RawBeer } from '../api/types';
 import { getCached, setCached } from '../cache/store';
 import { normalizeKey } from '../shared/normalize';
@@ -20,7 +20,7 @@ export async function runOverlay(
     if (adapter.waitForGrid) await adapter.waitForGrid(doc);
     const cards = adapter.parseCards(doc);
 
-    const misses: { el: HTMLElement; key: string; raw: RawBeer }[] = [];
+    const misses: { el: HTMLElement; key: string; card: Card }[] = [];
     for (const card of cards) {
       const key = normalizeKey(card.brewery, card.name);
       const cached = await getCached(key);
@@ -28,24 +28,30 @@ export async function runOverlay(
         renderBadge(card.el, cached);
         markSeen(card.el);
       } else {
-        const raw: RawBeer =
-          card.abv !== undefined
-            ? { brewery: card.brewery, name: card.name, abv: card.abv }
-            : { brewery: card.brewery, name: card.name };
-        misses.push({ el: card.el, key, raw });
+        misses.push({ el: card.el, key, card });
       }
     }
     if (misses.length === 0) return;
 
+    if (adapter.loadCardDetails) await adapter.loadCardDetails(misses.map((m) => m.card));
+
+    const rawMisses: { el: HTMLElement; key: string; raw: RawBeer }[] = misses.map(({ el, key, card }) => ({
+      el,
+      key,
+      raw: card.abv !== undefined
+        ? { brewery: card.brewery, name: card.name, abv: card.abv }
+        : { brewery: card.brewery, name: card.name },
+    }));
+
     let results: MatchResult[];
     try {
-      results = await sendMatch(misses.map((m) => m.raw));
+      results = await sendMatch(rawMisses.map((m) => m.raw));
     } catch {
       return; // network/server error: leave the page untouched, retry next load
     }
 
     results.forEach((result, i) => {
-      const miss = misses[i];
+      const miss = rawMisses[i];
       if (!miss) return;
       renderBadge(miss.el, result);
       markSeen(miss.el);
@@ -54,7 +60,7 @@ export async function runOverlay(
 
     if (enrich) {
       const orphans = results
-        .map((result, i) => ({ result, miss: misses[i] }))
+        .map((result, i) => ({ result, miss: rawMisses[i] }))
         .filter(
           (x) =>
             x.miss &&

--- a/extension/src/sites/beerfreak.test.ts
+++ b/extension/src/sites/beerfreak.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { beerfreak } from './beerfreak';
+import { beerfreak, parseProductAbv } from './beerfreak';
 
 const html = readFileSync(resolve(__dirname, '../../tests/fixtures/beerfreak.html'), 'utf8');
 const PRODUCT_METADATA_RE = /products = \[[\s\S]*?\],\n    ids = \[[\s\S]*?\];/;
@@ -19,6 +19,35 @@ function metadataCard(id: number, title: string): string {
     </div>
   `;
 }
+
+function docWithProductCount(count: number): Document {
+  const products = Array.from({ length: count }, (_, i) => ({
+    id: 10_000 + i,
+    brand_title: 'FUNKY FLUID (Польща)',
+    title: `Funky Fluid Ambrosia ${i}`,
+    url: `https://beerfreak.org/funky-fluid-ambrosia-${i}/`,
+  }));
+  return new DOMParser().parseFromString(`
+    <div data-catalog-view-block="products">
+      ${products.map((product) => metadataCard(product.id, product.title)).join('')}
+    </div>
+    <script>
+      products = ${JSON.stringify(products)},
+      ids = [];
+    </script>
+  `, 'text/html');
+}
+
+const PRODUCT_PAGE_WITH_ABV = `
+  <table>
+    <tr class="product-features__row">
+      <th class="product-features__cell product-features__cell--h">
+        <span class="product-features__cell-title">Міцність</span>
+      </th>
+      <td class="product-features__cell">7.30</td>
+    </tr>
+  </table>
+`;
 
 function docWithProducts(products: unknown[]): Document {
   return new DOMParser().parseFromString(`
@@ -40,6 +69,10 @@ beforeAll(() => {
 });
 
 describe('beerfreak adapter', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('parses the Horoshop catalog cards', () => {
     expect(cards.length).toBeGreaterThan(20);
   });
@@ -95,6 +128,36 @@ describe('beerfreak adapter', () => {
       brewery: '',
       name: 'Volta Brewery SMOOTHIE BEAST: RED CURRANT, YUZU, BLUEBERRY, RASPBERRY, BERGAMOT',
     });
+  });
+
+  it('parses ABV from the product strength row', () => {
+    const doc = new DOMParser().parseFromString(PRODUCT_PAGE_WITH_ABV, 'text/html');
+
+    expect(parseProductAbv(doc)).toBe(7.3);
+  });
+
+  it('leaves malformed or missing product strength undefined', () => {
+    expect(parseProductAbv(new DOMParser().parseFromString('', 'text/html'))).toBeUndefined();
+    expect(parseProductAbv(new DOMParser().parseFromString(`
+      <tr class="product-features__row">
+        <th><span class="product-features__cell-title">Міцність</span></th>
+        <td class="product-features__cell">strong</td>
+      </tr>
+    `, 'text/html'))).toBeUndefined();
+  });
+
+  it('loads ABV from bounded product details requests', async () => {
+    const parsed = beerfreak.parseCards(docWithProductCount(21));
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      text: async () => PRODUCT_PAGE_WITH_ABV,
+    } as Response);
+
+    await beerfreak.loadCardDetails?.(parsed);
+
+    expect(fetchMock).toHaveBeenCalledTimes(20);
+    expect(parsed.slice(0, 20).every((card) => card.abv === 7.3)).toBe(true);
+    expect(parsed[20].abv).toBeUndefined();
   });
 
   it('does not define waitForGrid (SSR)', () => {

--- a/extension/src/sites/beerfreak.ts
+++ b/extension/src/sites/beerfreak.ts
@@ -8,10 +8,14 @@ interface ProductMeta {
   id: number;
   brand_title: string | null;
   title: string;
+  url?: string;
 }
 
 const BREWERY_NOISE_PREFIX_RE = /^(?:brewery|brewing|browar|brouwerij|brasserie)\s+/i;
 const LEADING_BREWERY_DESCRIPTORS = new Set(['brouwerij', 'brasserie', 'browar', 'pivovar', 'birrificio', 'brauerei']);
+const MAX_DETAIL_FETCHES_PER_PASS = 20;
+const detailUrls = new WeakMap<HTMLElement, string>();
+const abvByUrl = new Map<string, Promise<number | undefined>>();
 
 function text(el: Element | null): string {
   return el?.textContent?.replace(/\s+/g, ' ').trim() ?? '';
@@ -72,6 +76,40 @@ function productMeta(root: ParentNode): Map<number, ProductMeta> {
   return new Map();
 }
 
+function parseDecimal(value: string): number | undefined {
+  const normalized = value.replace(',', '.').trim();
+  if (!/^\d+(?:\.\d+)?$/.test(normalized)) return undefined;
+  const abv = Number(normalized);
+  return Number.isFinite(abv) ? abv : undefined;
+}
+
+export function parseProductAbv(root: ParentNode): number | undefined {
+  for (const row of Array.from(root.querySelectorAll('.product-features__row, tr'))) {
+    const label = text(row.querySelector('.product-features__cell-title, th'));
+    if (label !== 'Міцність') continue;
+    const valueCell = row.querySelector('td.product-features__cell, td');
+    const abv = parseDecimal(text(valueCell));
+    if (abv !== undefined) return abv;
+  }
+  return undefined;
+}
+
+function loadAbv(url: string): Promise<number | undefined> {
+  const cached = abvByUrl.get(url);
+  if (cached) return cached;
+  if (typeof fetch !== 'function') return Promise.resolve(undefined);
+
+  const promise = fetch(url, { credentials: 'include' })
+    .then(async (res) => {
+      if (!res.ok) return undefined;
+      const html = await res.text();
+      return parseProductAbv(new DOMParser().parseFromString(html, 'text/html'));
+    })
+    .catch(() => undefined);
+  abvByUrl.set(url, promise);
+  return promise;
+}
+
 export const beerfreak: SiteAdapter = {
   id: 'beerfreak',
   hostMatch: (url) => url.hostname === 'beerfreak.org' || url.hostname.endsWith('.beerfreak.org'),
@@ -93,8 +131,22 @@ export const beerfreak: SiteAdapter = {
       const brewery = parsed.brewery;
       const name = parsed.name || cleanName(rawTitle, brewery);
       if (!name) continue;
+      if (product?.url) detailUrls.set(el, product.url);
       cards.push({ el, brewery, name });
     }
     return cards;
+  },
+
+  async loadCardDetails(cards) {
+    const limited = cards
+      .filter((card) => card.abv === undefined && detailUrls.has(card.el))
+      .slice(0, MAX_DETAIL_FETCHES_PER_PASS);
+
+    await Promise.all(limited.map(async (card) => {
+      const url = detailUrls.get(card.el);
+      if (!url) return;
+      const abv = await loadAbv(url);
+      if (abv !== undefined) card.abv = abv;
+    }));
   },
 };

--- a/extension/src/sites/conformance.test.ts
+++ b/extension/src/sites/conformance.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { ADAPTERS } from './registry';
@@ -28,7 +28,14 @@ const sendMatch = (cards: RawBeer[]): Promise<MatchResult[]> =>
     })),
   );
 
-beforeEach(() => { document.body.innerHTML = ''; });
+beforeEach(() => {
+  document.body.innerHTML = '';
+  vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: false, text: async () => '' } as Response);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe.each(ADAPTERS.map((a) => [a.id, a] as const))('adapter contract: %s', (id, adapter) => {
   it('has a fixture at tests/fixtures/<id>.html', () => {

--- a/extension/src/sites/types.ts
+++ b/extension/src/sites/types.ts
@@ -19,6 +19,11 @@ export interface SiteAdapter {
   /** Optional: resolve once the (client-rendered) grid has painted cards. */
   waitForGrid?(root: ParentNode): Promise<void>;
   /**
+   * Optional bounded detail hydration for fields that are absent from listing cards.
+   * Called only for uncached cards before they are sent to /match.
+   */
+  loadCardDetails?(cards: Card[]): Promise<void>;
+  /**
    * Optional perf scope for the re-render check — narrows where cards are
    * re-parsed. Does NOT enable re-render (that is always on). Omit it freely.
    */


### PR DESCRIPTION
## Summary

BeerFreak matches now include ABV when the product detail page exposes `Міцність`, so same-name releases can be disambiguated by strength instead of matching on brewery and name alone.

The detail lookup is bounded and cached: only uncached listing misses are hydrated before `/match`, and missing or malformed strength values stay omitted.

Closes #179.

## Test Plan

- `npm run typecheck`
- `npm test`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
