### PR TITLE
fix(route): bound TSP solver + cap N + interrupted-progress on shutdown

### DIFF
--- a/docs/superpowers/plans/2026-06-24-route-robustness.md
+++ b/docs/superpowers/plans/2026-06-24-route-robustness.md
@@ -1,0 +1,743 @@
+# /route Robustness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `/route` un-hangable (cap N at 70 + bound the TSP solver with a heuristic fallback) and stop deploys from leaving frozen progress messages (a shutdown sweep that marks in-flight `/route` and `/refresh` progress messages as interrupted).
+
+**Architecture:** Bug 1 lives in the pure `domain/router.ts` (a size-dispatching `solveTour` replaces the unbounded exact Held-Karp) plus a tiny clamp in the `route.ts` command. Bug 2 adds a process-wide registry (`bot/active-progress.ts`) that the two fire-and-forget commands register with and that the graceful-shutdown path sweeps.
+
+**Tech Stack:** TypeScript, Telegraf, Vitest.
+
+---
+
+## File Structure
+
+**Create:**
+- `src/bot/active-progress.ts` — registry of in-flight progress messages + shutdown sweep.
+- `src/bot/active-progress.test.ts` — registry unit tests.
+
+**Modify:**
+- `src/domain/router.ts` — add `solveTour` (Held-Karp ≤12, else nearest-neighbour + 2-opt); route the 3 `openTsp` call sites through it.
+- `src/domain/router.test.ts` — add a large-`|S|` no-blowup test.
+- `src/bot/commands/route.ts` — `clampRouteN` + `MAX_ROUTE_N`; track/release progress.
+- `src/bot/commands/route.test.ts` — `clampRouteN` tests.
+- `src/bot/commands/refresh.ts` — track/release progress around the detached pipeline.
+- `src/i18n/types.ts`, `src/i18n/locales/{en,uk,pl}.ts` — `common.interrupted_by_restart`.
+- `src/shutdown.ts` — optional `interruptActiveProgress` hook, called early.
+- `src/index.ts` — wire the hook with `bot.telegram` + `createTranslator`.
+- `spec.md` — `/route` section.
+
+---
+
+### Task 1: Bound the TSP solver (`solveTour`)
+
+**Files:**
+- Modify: `src/domain/router.ts`
+- Modify: `src/domain/router.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/domain/router.test.ts`, add after the existing `buildRoute` tests (after the
+`'handles partial coverage when N > union'` test):
+
+```ts
+test('does not blow up for a large selected set (heuristic path)', () => {
+  // 20 pubs, each with a distinct interesting beer, spread on a line.
+  // N=20 forces greedySetCover to pick all 20 → |S|=20 > Held-Karp cap → heuristic.
+  const many = Array.from({ length: 20 }, (_, i) => ({
+    id: i + 1,
+    lat: 0,
+    lon: i * 0.01,
+    interesting: new Set([100 + i]),
+  }));
+  const start = Date.now();
+  const r = buildRoute(many, 20, { distance: haversineMeters });
+  expect(Date.now() - start).toBeLessThan(2000); // would be minutes with exact DP
+  expect(r.pubIds.length).toBe(20);
+  expect(new Set(r.pubIds).size).toBe(20); // every pub exactly once
+  expect(Number.isFinite(r.distanceMeters)).toBe(true);
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/domain/router.test.ts`
+Expected: FAIL — exact Held-Karp on 20 nodes allocates `2^20` arrays; the test either
+times out or exhausts memory (it does **not** finish under 2 s).
+
+- [ ] **Step 3: Add the heuristic + dispatcher in `router.ts`**
+
+In `src/domain/router.ts`, add a `HELD_KARP_MAX` constant near the top (after the
+`RouteOpts` interface, before `haversineMeters`):
+
+```ts
+// Exact Held-Karp is O(2^k · k²); only use it for small selected sets. Above this
+// many pubs, fall back to a polynomial nearest-neighbour + 2-opt heuristic.
+const HELD_KARP_MAX = 12;
+```
+
+Then add these two functions immediately **after** the existing `openTsp` function (after its
+closing brace, before `createOsrmDistance`):
+
+```ts
+function nearestNeighbourTwoOpt(
+  pubs: RoutePub[],
+  opts: RouteOpts,
+): { order: RoutePub[]; distance: number } {
+  const n = pubs.length;
+  if (n <= 1) return { order: pubs, distance: 0 };
+
+  const dist: number[][] = Array.from({ length: n }, (_, i) =>
+    Array.from({ length: n }, (_, j) =>
+      i === j ? 0 : opts.distance([pubs[i].lat, pubs[i].lon], [pubs[j].lat, pubs[j].lon]),
+    ),
+  );
+  const pathLen = (ord: number[]): number => {
+    let s = 0;
+    for (let i = 0; i + 1 < ord.length; i++) s += dist[ord[i]][ord[i + 1]];
+    return s;
+  };
+
+  // Nearest-neighbour construction from node 0.
+  const visited = new Array(n).fill(false);
+  let cur = 0;
+  visited[0] = true;
+  let order = [0];
+  for (let k = 1; k < n; k++) {
+    let best = -1;
+    let bd = Infinity;
+    for (let j = 0; j < n; j++) if (!visited[j] && dist[cur][j] < bd) { bd = dist[cur][j]; best = j; }
+    order.push(best);
+    visited[best] = true;
+    cur = best;
+  }
+
+  // 2-opt on the open path; bounded number of sweeps.
+  for (let sweep = 0; sweep < n; sweep++) {
+    let improved = false;
+    for (let i = 0; i < n - 1; i++) {
+      for (let k = i + 1; k < n; k++) {
+        const cand = [...order.slice(0, i), ...order.slice(i, k + 1).reverse(), ...order.slice(k + 1)];
+        if (pathLen(cand) < pathLen(order) - 1e-9) { order = cand; improved = true; }
+      }
+    }
+    if (!improved) break;
+  }
+
+  return { order: order.map((i) => pubs[i]), distance: pathLen(order) };
+}
+
+function solveTour(pubs: RoutePub[], opts: RouteOpts): { order: RoutePub[]; distance: number } {
+  return pubs.length <= HELD_KARP_MAX ? openTsp(pubs, opts) : nearestNeighbourTwoOpt(pubs, opts);
+}
+```
+
+- [ ] **Step 4: Route the 3 `openTsp` call sites through `solveTour`**
+
+In `src/domain/router.ts`, change the three `openTsp(` calls (NOT the `function openTsp`
+definition) to `solveTour(`:
+
+(a) In `buildRoute`:
+```ts
+  const tour = openTsp(improved, opts);
+```
+→
+```ts
+  const tour = solveTour(improved, opts);
+```
+
+(b) In `localSwapForDistance`, the initial best distance:
+```ts
+  let best = selected; let bestDist = openTsp(best, opts).distance;
+```
+→
+```ts
+  let best = selected; let bestDist = solveTour(best, opts).distance;
+```
+
+(c) In `localSwapForDistance`, inside the loop:
+```ts
+        const d = openTsp(trial, opts).distance;
+```
+→
+```ts
+        const d = solveTour(trial, opts).distance;
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `npx vitest run src/domain/router.test.ts`
+Expected: PASS — the new large-set test finishes well under 2 s; the existing small-`n`
+optimality tests are unchanged (those sets are `≤ 12`, so they still use exact Held-Karp).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/domain/router.ts src/domain/router.test.ts
+git commit -m "fix(route): bound TSP solver — heuristic above 12 pubs, no exponential blowup (#193 follow-up)"
+```
+
+---
+
+### Task 2: Clamp N at the command (`MAX_ROUTE_N = 70`)
+
+**Files:**
+- Modify: `src/bot/commands/route.ts`
+- Modify: `src/bot/commands/route.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/bot/commands/route.test.ts`, add (top-level, alongside existing tests — check the
+existing import line and extend it):
+
+```ts
+import { clampRouteN, MAX_ROUTE_N } from './route';
+
+describe('clampRouteN', () => {
+  it('passes small positive N through', () => {
+    expect(clampRouteN(5)).toBe(5);
+  });
+  it('caps N at MAX_ROUTE_N', () => {
+    expect(clampRouteN(200)).toBe(MAX_ROUTE_N);
+    expect(MAX_ROUTE_N).toBe(70);
+  });
+  it('floors N to at least 1', () => {
+    expect(clampRouteN(0)).toBe(1);
+    expect(clampRouteN(-4)).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/bot/commands/route.test.ts`
+Expected: FAIL — `clampRouteN` / `MAX_ROUTE_N` are not exported yet.
+
+- [ ] **Step 3: Add `clampRouteN` and apply it**
+
+In `src/bot/commands/route.ts`, add near the top after `const PROGRESS_MIN_INTERVAL_MS = 2000;`:
+
+```ts
+export const MAX_ROUTE_N = 70;
+
+// Clamp the requested coverage to a sane range. Beyond MAX_ROUTE_N the route would
+// span dozens of pubs and the tour search gets expensive; below 1 is meaningless.
+export function clampRouteN(n: number): number {
+  return Math.min(Math.max(1, Math.floor(n)), MAX_ROUTE_N);
+}
+```
+
+Then wrap the `N` computation in the handler. Find:
+
+```ts
+  const N =
+    parseInt(arg ?? '', 10) ||
+    getFilters(db, ctx.from.id)?.default_route_n ||
+    ctx.deps.env.DEFAULT_ROUTE_N;
+```
+
+Replace with:
+
+```ts
+  const N = clampRouteN(
+    parseInt(arg ?? '', 10) ||
+      getFilters(db, ctx.from.id)?.default_route_n ||
+      ctx.deps.env.DEFAULT_ROUTE_N,
+  );
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npx vitest run src/bot/commands/route.test.ts && npm run typecheck`
+Expected: PASS — `clampRouteN` tests green; typecheck clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bot/commands/route.ts src/bot/commands/route.test.ts
+git commit -m "fix(route): clamp requested N to 1..70 (#193 follow-up)"
+```
+
+---
+
+### Task 3: Active-progress registry module
+
+**Files:**
+- Create: `src/bot/active-progress.ts`
+- Create: `src/bot/active-progress.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/bot/active-progress.test.ts`:
+
+```ts
+import { trackProgress, interruptActiveProgress } from './active-progress';
+import type { Locale } from '../i18n/types';
+
+type EditCall = { chatId: number; messageId: number; text: string };
+
+function fakeTelegram() {
+  const calls: EditCall[] = [];
+  const telegram = {
+    editMessageText: async (chatId: number, messageId: number, _inline: undefined, text: string) => {
+      calls.push({ chatId, messageId, text });
+      return true as unknown;
+    },
+  };
+  return { telegram, calls };
+}
+
+// Deterministic translator: returns the locale + key so assertions are locale-agnostic.
+const fakeTranslator = (locale: Locale) => ((key: string) => `[${locale}]${key}`) as never;
+
+describe('active-progress registry', () => {
+  it('appends the interrupt suffix to each active message and clears the map', async () => {
+    const h1 = trackProgress(111, 1, 'uk');
+    const h2 = trackProgress(222, 2, 'en');
+    h1.update('progress one');
+    h2.update('progress two');
+
+    const { telegram, calls } = fakeTelegram();
+    await interruptActiveProgress(telegram, fakeTranslator);
+
+    expect(calls).toHaveLength(2);
+    expect(calls.find((c) => c.chatId === 111)!.text).toBe('progress one\n\n[uk]common.interrupted_by_restart');
+    expect(calls.find((c) => c.chatId === 222)!.text).toBe('progress two\n\n[en]common.interrupted_by_restart');
+
+    // Map cleared: a second sweep edits nothing.
+    const second = fakeTelegram();
+    await interruptActiveProgress(second.telegram, fakeTranslator);
+    expect(second.calls).toHaveLength(0);
+
+    h1.release();
+    h2.release();
+  });
+
+  it('does not edit a released entry', async () => {
+    const h = trackProgress(333, 3, 'pl');
+    h.update('x');
+    h.release();
+    const { telegram, calls } = fakeTelegram();
+    await interruptActiveProgress(telegram, fakeTranslator);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('uses the suffix alone when there is no progress text yet', async () => {
+    const h = trackProgress(444, 4, 'en');
+    const { telegram, calls } = fakeTelegram();
+    await interruptActiveProgress(telegram, fakeTranslator);
+    expect(calls[0].text).toBe('[en]common.interrupted_by_restart');
+    h.release();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/bot/active-progress.test.ts`
+Expected: FAIL — module `./active-progress` does not exist yet.
+
+- [ ] **Step 3: Implement the module**
+
+Create `src/bot/active-progress.ts`:
+
+```ts
+import type { Telegram } from 'telegraf';
+import { createTranslator } from '../i18n';
+import type { Locale, Translator } from '../i18n/types';
+
+interface Entry {
+  chatId: number;
+  messageId: number;
+  locale: Locale;
+  lastText: string;
+}
+
+const active = new Map<string, Entry>();
+const key = (chatId: number, messageId: number): string => `${chatId}:${messageId}`;
+
+export interface ProgressHandle {
+  update(text: string): void;
+  release(): void;
+}
+
+// Register an in-flight progress message so a graceful shutdown can mark it as
+// interrupted instead of leaving it frozen forever.
+export function trackProgress(chatId: number, messageId: number, locale: Locale): ProgressHandle {
+  const k = key(chatId, messageId);
+  active.set(k, { chatId, messageId, locale, lastText: '' });
+  return {
+    update(text: string): void {
+      const e = active.get(k);
+      if (e) e.lastText = text;
+    },
+    release(): void {
+      active.delete(k);
+    },
+  };
+}
+
+// Best-effort: append an "interrupted by restart" notice to every still-active
+// progress message, then clear the registry. Called from the shutdown path.
+export async function interruptActiveProgress(
+  telegram: Pick<Telegram, 'editMessageText'>,
+  makeTranslator: (locale: Locale) => Translator = createTranslator,
+): Promise<void> {
+  const entries = [...active.values()];
+  active.clear();
+  for (const e of entries) {
+    const suffix = makeTranslator(e.locale)('common.interrupted_by_restart');
+    const text = e.lastText ? `${e.lastText}\n\n${suffix}` : suffix;
+    await telegram.editMessageText(e.chatId, e.messageId, undefined, text).catch(() => {});
+  }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npx vitest run src/bot/active-progress.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/bot/active-progress.ts src/bot/active-progress.test.ts
+git commit -m "feat(bot): active-progress registry for graceful-shutdown interrupt notices"
+```
+
+---
+
+### Task 4: i18n key `common.interrupted_by_restart`
+
+**Files:**
+- Modify: `src/i18n/types.ts`
+- Modify: `src/i18n/locales/en.ts`, `src/i18n/locales/uk.ts`, `src/i18n/locales/pl.ts`
+
+- [ ] **Step 1: Declare the key**
+
+In `src/i18n/types.ts`, find the `// app` section start:
+
+```ts
+export interface Messages {
+  // app
+  'app.no_data_in_snapshot': string;
+```
+
+Insert a `common` block right after `'app.no_data_in_snapshot': string;`:
+
+```ts
+
+  // common
+  'common.interrupted_by_restart': string;
+```
+
+- [ ] **Step 2: Add the locale strings**
+
+`src/i18n/locales/en.ts` — after `  'app.no_data_in_snapshot': 'No interesting untried beers right now.',`:
+
+```ts
+
+  // common
+  'common.interrupted_by_restart': '⚠️ Interrupted by a restart — please re-run the command.',
+```
+
+`src/i18n/locales/uk.ts` — after its `'app.no_data_in_snapshot'` line:
+
+```ts
+
+  // common
+  'common.interrupted_by_restart': '⚠️ Перервано рестартом — повтори команду.',
+```
+
+`src/i18n/locales/pl.ts` — after its `'app.no_data_in_snapshot'` line:
+
+```ts
+
+  // common
+  'common.interrupted_by_restart': '⚠️ Przerwano przez restart — uruchom polecenie ponownie.',
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS — the new key is declared once and present in all three locales.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/i18n/types.ts src/i18n/locales/en.ts src/i18n/locales/uk.ts src/i18n/locales/pl.ts
+git commit -m "i18n: add common.interrupted_by_restart"
+```
+
+---
+
+### Task 5: Wire the registry into the commands + shutdown
+
+**Files:**
+- Modify: `src/bot/commands/route.ts`
+- Modify: `src/bot/commands/refresh.ts`
+- Modify: `src/shutdown.ts`
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: Track/release in `route.ts`**
+
+In `src/bot/commands/route.ts`, add the import alongside the others (after the
+`googleMapsWalkingUrl` import):
+
+```ts
+import { trackProgress } from '../active-progress';
+```
+
+After `const locale = ctx.locale;`, add:
+
+```ts
+  const tracker = trackProgress(chatId, messageId, locale);
+```
+
+In the `notify` send callback, record the text. Find:
+
+```ts
+  const notify = makeThrottledProgress(
+    async (text) => {
+      await telegram
+        .editMessageText(chatId, messageId, undefined, text, { parse_mode: 'HTML' })
+        .catch(() => {});
+    },
+    PROGRESS_MIN_INTERVAL_MS,
+  );
+```
+
+Replace the callback body's first line so it becomes:
+
+```ts
+  const notify = makeThrottledProgress(
+    async (text) => {
+      tracker.update(text);
+      await telegram
+        .editMessageText(chatId, messageId, undefined, text, { parse_mode: 'HTML' })
+        .catch(() => {});
+    },
+    PROGRESS_MIN_INTERVAL_MS,
+  );
+```
+
+Add a `finally` to release the tracker. Find the end of the detached block:
+
+```ts
+    } catch (e) {
+      log.error({ err: e }, 'route failed');
+      await notify(t('route.failed'), { force: true });
+    }
+  })();
+```
+
+Replace with:
+
+```ts
+    } catch (e) {
+      log.error({ err: e }, 'route failed');
+      await notify(t('route.failed'), { force: true });
+    } finally {
+      tracker.release();
+    }
+  })();
+```
+
+- [ ] **Step 2: Track/release in `refresh.ts`**
+
+In `src/bot/commands/refresh.ts`, add the import (after the existing imports at the top of
+the file):
+
+```ts
+import { trackProgress } from '../active-progress';
+```
+
+After `const locale = ctx.locale;`, add:
+
+```ts
+    const tracker = trackProgress(chatId, messageId, locale);
+```
+
+In the `notify` callback, record the text. Find:
+
+```ts
+    const notify = makeThrottledProgress(
+      async (text) => {
+        await telegram
+          .editMessageText(chatId, messageId, undefined, text)
+          .catch(() => {});
+      },
+      PROGRESS_MIN_INTERVAL_MS,
+    );
+```
+
+Replace with:
+
+```ts
+    const notify = makeThrottledProgress(
+      async (text) => {
+        tracker.update(text);
+        await telegram
+          .editMessageText(chatId, messageId, undefined, text)
+          .catch(() => {});
+      },
+      PROGRESS_MIN_INTERVAL_MS,
+    );
+```
+
+Wrap the detached pipeline so the tracker is always released. Find:
+
+```ts
+    void runRefreshPipeline({
+      run: (n) => run(n, { pubSlugs }),
+      notify,
+      t,
+      log,
+      postRun: postRunClosure,
+    });
+```
+
+Replace with:
+
+```ts
+    void (async () => {
+      try {
+        await runRefreshPipeline({
+          run: (n) => run(n, { pubSlugs }),
+          notify,
+          t,
+          log,
+          postRun: postRunClosure,
+        });
+      } finally {
+        tracker.release();
+      }
+    })();
+```
+
+- [ ] **Step 3: Add the optional hook to `shutdown.ts`**
+
+In `src/shutdown.ts`, add the field to `ShutdownDeps` (after `log: pino.Logger;`):
+
+```ts
+  interruptActiveProgress?: () => Promise<void>;
+```
+
+In the `shutdown` function, call it right after the "shutdown initiated" log and before the
+cron loop. Find:
+
+```ts
+    deps.log.info({ signal }, 'shutdown initiated');
+
+    for (const job of deps.cronJobs) {
+```
+
+Replace with:
+
+```ts
+    deps.log.info({ signal }, 'shutdown initiated');
+
+    if (deps.interruptActiveProgress) {
+      try {
+        await deps.interruptActiveProgress();
+      } catch (err) {
+        deps.log.error({ err }, 'interrupt active progress failed');
+      }
+    }
+
+    for (const job of deps.cronJobs) {
+```
+
+- [ ] **Step 4: Wire it in `index.ts`**
+
+In `src/index.ts`, add imports (next to the existing `createShutdown` import and an i18n
+import):
+
+```ts
+import { interruptActiveProgress } from './bot/active-progress';
+import { createTranslator } from './i18n';
+```
+
+(If `createTranslator` is already imported, do not duplicate it.)
+
+Update the `createShutdown` call. Find:
+
+```ts
+  const shutdown = createShutdown({ bot, cronJobs, db, httpServer: apiServer, log });
+```
+
+Replace with:
+
+```ts
+  const shutdown = createShutdown({
+    bot,
+    cronJobs,
+    db,
+    httpServer: apiServer,
+    log,
+    interruptActiveProgress: () => interruptActiveProgress(bot.telegram, createTranslator),
+  });
+```
+
+- [ ] **Step 5: Typecheck + targeted tests**
+
+Run: `npm run typecheck && npx vitest run src/bot/active-progress.test.ts src/bot/commands/route.test.ts src/shutdown.test.ts`
+Expected: PASS — typecheck clean (route/refresh now reference `trackProgress`; shutdown has
+the optional field; index wires it); existing shutdown tests still green (the new field is
+optional).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/bot/commands/route.ts src/bot/commands/refresh.ts src/shutdown.ts src/index.ts
+git commit -m "feat(bot): mark in-flight /route & /refresh progress as interrupted on shutdown"
+```
+
+---
+
+### Task 6: Spec update + full verification
+
+**Files:**
+- Modify: `spec.md`
+
+- [ ] **Step 1: Update `spec.md`**
+
+In `spec.md`, in the `/route` section (the paragraph describing "Під капотом
+(`domain/router.ts`)" and the `open-TSP on |S| ≤ ~8` line), update the tour description to
+state that the requested `N` is clamped to `≤ 70`, and the tour is solved exactly
+(Held-Karp) for `≤ 12` pubs and with a nearest-neighbour + 2-opt heuristic above that.
+Match the surrounding Ukrainian prose. Also add a short note (near the fire-and-forget
+description) that in-flight `/route` and `/refresh` progress messages are marked
+"⚠️ перервано рестартом" on graceful shutdown instead of being left frozen.
+
+- [ ] **Step 2: Full test + build**
+
+Run: `npm test && npm run build`
+Expected: PASS (all suites green; build clean).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add spec.md
+git commit -m "docs(spec): /route N cap, heuristic TSP, interrupted-progress on shutdown"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Cap N=70 at command → Task 2 (`clampRouteN`/`MAX_ROUTE_N`). ✅
+- `solveTour`: Held-Karp ≤12 else NN+2-opt; `buildRoute` + `localSwapForDistance` use it → Task 1. ✅
+- Registry `trackProgress` / `interruptActiveProgress` with `{chatId, messageId, locale, lastText}` → Task 3. ✅
+- Append suffix to `lastText`; suffix-only when empty; best-effort; clear map → Task 3 (impl + tests). ✅
+- Wire into route + refresh (track/update/release) → Task 5 Steps 1-2. ✅
+- Shutdown hook called early, try/catch → Task 5 Step 3. ✅
+- `index.ts` wires `bot.telegram` + `createTranslator` → Task 5 Step 4. ✅
+- i18n `common.interrupted_by_restart` (en/uk/pl + types) → Task 4. ✅
+- spec.md update → Task 6. ✅
+- Tests: router large-set no-blowup, registry behaviour → Tasks 1 & 3. ✅
+
+**Placeholder scan:** No TBD/vague steps — every code step shows full code. ✅
+
+**Type consistency:** `solveTour`/`nearestNeighbourTwoOpt` return `{ order: RoutePub[]; distance: number }`, matching `openTsp`'s shape and `buildRoute`'s usage (`tour.order`, `tour.distance`). `ProgressHandle` (`update`/`release`) is produced by `trackProgress` and consumed identically in route/refresh. `interruptActiveProgress(telegram, makeTranslator)` signature matches the `index.ts` call site (`bot.telegram`, `createTranslator`) and the test's fakes. `Translator` type imported from `../i18n/types`. ✅

--- a/docs/superpowers/specs/2026-06-24-route-robustness-design.md
+++ b/docs/superpowers/specs/2026-06-24-route-robustness-design.md
@@ -1,0 +1,105 @@
+# Design — `/route` robustness: bound TSP + interrupted-progress registry
+
+**Date:** 2026-06-24
+**Context:** Investigation of a "stuck `/route`" report (2026-06-24). Two distinct latent
+bugs surfaced; neither was the user's actual symptom (that was orphaned progress messages
+from a deploy), but both are real and worth fixing.
+
+## Background (root causes)
+
+1. **Exponential `buildRoute` blowup.** `buildRoute → openTsp` in `src/domain/router.ts` is
+   exact Held-Karp, `O(2^|S|·n²)` time + `O(2^|S|·n)` memory, with **no cap on `|S|`** (the
+   spec assumed `|S| ≤ ~8`; nothing enforces it). `greedySetCover` selects more pubs as `N`
+   grows. Measured on prod data for a power-user (11501 tried beers → 198 distinct
+   *interesting*/untried in Warszawa): `N=100 → |S|=10` (270 ms); `N=140 → |S|=17` (1.4 s);
+   **`N≥160 → |S|≥18 →` minutes / GBs / OOM** (731 MB peak seen on a killed process).
+   Triggered only by an explicit large argument (`/route 200`) — a latent DoS.
+
+2. **Orphaned progress messages on deploy.** `/route` and `/refresh` run their heavy work
+   as a detached fire-and-forget `void (async () => {…})()` that edits a progress message.
+   A deploy (`systemctl restart` → SIGTERM) kills the in-flight background promise, so its
+   progress message **freezes forever** at whatever stage it reached (`preparing` /
+   `searching_tour` / refresh progress). The bot has a graceful-shutdown path
+   (`src/shutdown.ts`) but does nothing about these messages.
+
+## Decisions
+
+### Bug 1 — bound the TSP (cap N=70 + heuristic fallback)
+
+- **Command layer (`src/bot/commands/route.ts`):** after computing `N`, clamp it:
+  `N = Math.min(Math.max(1, N), MAX_ROUTE_N)` with `MAX_ROUTE_N = 70`. Silent — the result
+  header already shows the actual pub/beer counts; nobody crawls 70+ beers, so a clamp
+  message is unnecessary (YAGNI).
+- **Algorithm layer (`src/domain/router.ts`):** introduce `solveTour(pubs, opts)` that
+  dispatches by size:
+  - `pubs.length ≤ HELD_KARP_MAX (12)` → exact Held-Karp (the current `openTsp` logic, kept
+    — optimal for small sets).
+  - otherwise → **nearest-neighbour + 2-opt** heuristic (`O(|S|²)` per 2-opt sweep, a small
+    bounded number of sweeps) — instant for any `|S|`, near-optimal in practice.
+  - `buildRoute` and `localSwapForDistance` both call `solveTour` instead of `openTsp`
+    directly, so every TSP evaluation is bounded.
+
+  Cap N=70 alone is **not** sufficient (`|S| ≤ N`, so a pathological sparse-interesting
+  distribution could still drive `|S|` past the safe Held-Karp range); the `solveTour`
+  size guard is the actual safety net and makes a blowup impossible regardless of `N` or
+  data. The N cap is a sane product limit on top.
+
+  `HELD_KARP_MAX = 12`: at `|S|=12` exact DP is ~270 ms in the worst measured case; above
+  that the heuristic takes over before the exponential bites.
+
+### Bug 2 — interrupted-progress registry
+
+- **New module `src/bot/active-progress.ts`** — a process-wide registry of in-flight
+  progress messages:
+  - Entry shape: `{ chatId: number; messageId: number; locale: Locale; lastText: string }`,
+    stored in a `Map` keyed `${chatId}:${messageId}`.
+  - `trackProgress(chatId, messageId, locale)` → handle `{ update(text: string): void; release(): void }`.
+    `update` stores the latest progress text (so the interrupt notice can be appended to
+    real context); `release` removes the entry.
+  - `interruptActiveProgress(telegram, makeTranslator)` → for each remaining entry, edit the
+    message to `lastText + '\n\n' + makeTranslator(locale)('common.interrupted_by_restart')`,
+    best-effort (`.catch` swallow per edit), then clear the map. `telegram` is typed
+    `Pick<Telegram, 'editMessageText'>`; `makeTranslator` is `createTranslator`.
+- **Integration in `route.ts` and `refresh.ts`:** create
+  `const tracker = trackProgress(chatId, messageId, locale)` right after `messageId`; in the
+  `notify` send callback call `tracker.update(text)` before the edit; wrap the entire
+  detached background body in `try { … } finally { tracker.release(); }` so the entry is
+  always cleared on normal completion or error (only a hard kill leaves it for the shutdown
+  sweep).
+- **`src/shutdown.ts`:** add optional `interruptActiveProgress?: () => Promise<void>` to
+  `ShutdownDeps`; in `shutdown()`, call it **early** (right after logging "shutdown
+  initiated", before stopping cron jobs and the bot — the Telegram API client stays usable
+  after `bot.stop()`, but doing it first maximises the window), wrapped in try/catch that
+  logs but never throws.
+- **`src/index.ts`:** wire
+  `interruptActiveProgress: () => interruptActiveProgress(bot.telegram, createTranslator)`.
+- **i18n:** new key `common.interrupted_by_restart`:
+  - en: `⚠️ Interrupted by a restart — please re-run the command.`
+  - uk: `⚠️ Перервано рестартом — повтори команду.`
+  - pl: `⚠️ Przerwano przez restart — uruchom polecenie ponownie.`
+
+## Out of scope / unchanged
+
+- The orphaned messages that already exist from past deploys are not retroactively fixed
+  (the bot has no record of them); this only prevents new orphans going forward.
+- No change to OSRM usage, the distance cache, or the result format.
+- The demo OSRM `/table` 100-coordinate cap is noted as a separate latent cliff (not hit
+  per-city today, max Warszawa = 43 pubs) and is left for a future change.
+
+## Testing (Vitest)
+
+- `src/domain/router.test.ts`:
+  - existing small-`n` optimality test stays (exact Held-Karp path, `|S| ≤ 12`).
+  - new: `buildRoute`/`solveTour` on ~20 pubs completes near-instantly (no exponential),
+    returns a tour that visits every selected pub exactly once with a finite distance.
+- `src/bot/active-progress.test.ts` (next to the module):
+  - `trackProgress` registers an entry; `update` changes `lastText`; `release` removes it.
+  - `interruptActiveProgress` edits every active entry with the localized suffix appended to
+    `lastText`, then clears the map; a released entry is never edited; a failing edit does
+    not abort the others.
+
+## Spec
+
+Update `spec.md` `/route` section: N is clamped to ≤70; the tour solver is exact Held-Karp
+for `≤12` pubs and a nearest-neighbour + 2-opt heuristic above that. Note the graceful
+"interrupted by restart" handling of in-flight `/route` and `/refresh` progress messages.

--- a/spec.md
+++ b/spec.md
@@ -488,17 +488,22 @@ Vintage-логіка: збіг ABV із найсвіжішим роком → «
 
 ### `/route [N]` — пішохідний маршрут
 Будує маршрут, що покриває **≥ N** непитих пив, мінімізуючи сумарну дистанцію.
-`N` ← аргумент → `user_filters.default_route_n` → `env.DEFAULT_ROUTE_N` (=5).
+`N` ← аргумент → `user_filters.default_route_n` → `env.DEFAULT_ROUTE_N` (=5);
+**клемпиться до `1..70`** (`clampRouteN`), бо більший N тягне десятки пабів.
 **Під капотом (`domain/router.ts`):**
 1. `interesting(p)` для кожного паба з останнього snapshot;
 2. жадібний **set-cover** ≥ N → `S₀`;
 3. **локальна оптимізація** заміною пабів під дистанцію;
-4. **open-TSP** на `|S| ≤ ~8` (DP за бітмасками), без фіксованих кінців.
+4. **тур** (`solveTour`): точний **open-TSP** (Held-Karp за бітмасками) для
+   `|S| ≤ 12`, інакше — поліноміальна евристика **nearest-neighbour + 2-opt**
+   (Held-Karp `O(2^|S|)` без стелі раніше вибухав на великому N).
 
 Дистанції: кеш `pub_distances` → один OSRM `/table` на пропуски → per-pair
-`/route` / **haversine** fallback. **Жорстких лімітів немає** — дистанція й
-кількість пабів завжди в хедері. **Fire-and-forget** + throttled
-`editMessageText` (обхід `handlerTimeout` 90 c).
+`/route` / **haversine** fallback. Дистанція й кількість пабів завжди в хедері.
+**Fire-and-forget** + throttled `editMessageText` (обхід `handlerTimeout` 90 c);
+прогрес-повідомлення `/route` і `/refresh`, що були в польоті при graceful
+shutdown, помічаються **«⚠️ перервано рестартом»** (реєстр `bot/active-progress.ts`),
+а не лишаються застиглими назавжди.
 У списку пив кожного паба відомий стиль показується inline після назви;
 невідомий стиль пропускається без placeholder-а.
 До результату додається inline-кнопка **🗺 Маршрут у Google Maps** —

--- a/src/bot/active-progress.test.ts
+++ b/src/bot/active-progress.test.ts
@@ -1,3 +1,4 @@
+import type { Telegram } from 'telegraf';
 import { trackProgress, interruptActiveProgress } from './active-progress';
 import type { Locale } from '../i18n/types';
 
@@ -8,9 +9,9 @@ function fakeTelegram() {
   const telegram = {
     editMessageText: async (chatId: number, messageId: number, _inline: undefined, text: string) => {
       calls.push({ chatId, messageId, text });
-      return true as unknown;
+      return true;
     },
-  };
+  } as unknown as Pick<Telegram, 'editMessageText'>;
   return { telegram, calls };
 }
 

--- a/src/bot/active-progress.test.ts
+++ b/src/bot/active-progress.test.ts
@@ -1,0 +1,59 @@
+import { trackProgress, interruptActiveProgress } from './active-progress';
+import type { Locale } from '../i18n/types';
+
+type EditCall = { chatId: number; messageId: number; text: string };
+
+function fakeTelegram() {
+  const calls: EditCall[] = [];
+  const telegram = {
+    editMessageText: async (chatId: number, messageId: number, _inline: undefined, text: string) => {
+      calls.push({ chatId, messageId, text });
+      return true as unknown;
+    },
+  };
+  return { telegram, calls };
+}
+
+// Deterministic translator: returns the locale + key so assertions are locale-agnostic.
+const fakeTranslator = (locale: Locale) => ((key: string) => `[${locale}]${key}`) as never;
+
+describe('active-progress registry', () => {
+  it('appends the interrupt suffix to each active message and clears the map', async () => {
+    const h1 = trackProgress(111, 1, 'uk');
+    const h2 = trackProgress(222, 2, 'en');
+    h1.update('progress one');
+    h2.update('progress two');
+
+    const { telegram, calls } = fakeTelegram();
+    await interruptActiveProgress(telegram, fakeTranslator);
+
+    expect(calls).toHaveLength(2);
+    expect(calls.find((c) => c.chatId === 111)!.text).toBe('progress one\n\n[uk]common.interrupted_by_restart');
+    expect(calls.find((c) => c.chatId === 222)!.text).toBe('progress two\n\n[en]common.interrupted_by_restart');
+
+    // Map cleared: a second sweep edits nothing.
+    const second = fakeTelegram();
+    await interruptActiveProgress(second.telegram, fakeTranslator);
+    expect(second.calls).toHaveLength(0);
+
+    h1.release();
+    h2.release();
+  });
+
+  it('does not edit a released entry', async () => {
+    const h = trackProgress(333, 3, 'pl');
+    h.update('x');
+    h.release();
+    const { telegram, calls } = fakeTelegram();
+    await interruptActiveProgress(telegram, fakeTranslator);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('uses the suffix alone when there is no progress text yet', async () => {
+    const h = trackProgress(444, 4, 'en');
+    const { telegram, calls } = fakeTelegram();
+    await interruptActiveProgress(telegram, fakeTranslator);
+    expect(calls[0].text).toBe('[en]common.interrupted_by_restart');
+    h.release();
+  });
+});

--- a/src/bot/active-progress.ts
+++ b/src/bot/active-progress.ts
@@ -1,0 +1,49 @@
+import type { Telegram } from 'telegraf';
+import { createTranslator } from '../i18n';
+import type { Locale, Translator } from '../i18n/types';
+
+interface Entry {
+  chatId: number;
+  messageId: number;
+  locale: Locale;
+  lastText: string;
+}
+
+const active = new Map<string, Entry>();
+const key = (chatId: number, messageId: number): string => `${chatId}:${messageId}`;
+
+export interface ProgressHandle {
+  update(text: string): void;
+  release(): void;
+}
+
+// Register an in-flight progress message so a graceful shutdown can mark it as
+// interrupted instead of leaving it frozen forever.
+export function trackProgress(chatId: number, messageId: number, locale: Locale): ProgressHandle {
+  const k = key(chatId, messageId);
+  active.set(k, { chatId, messageId, locale, lastText: '' });
+  return {
+    update(text: string): void {
+      const e = active.get(k);
+      if (e) e.lastText = text;
+    },
+    release(): void {
+      active.delete(k);
+    },
+  };
+}
+
+// Best-effort: append an "interrupted by restart" notice to every still-active
+// progress message, then clear the registry. Called from the shutdown path.
+export async function interruptActiveProgress(
+  telegram: Pick<Telegram, 'editMessageText'>,
+  makeTranslator: (locale: Locale) => Translator = createTranslator,
+): Promise<void> {
+  const entries = [...active.values()];
+  active.clear();
+  for (const e of entries) {
+    const suffix = makeTranslator(e.locale)('common.interrupted_by_restart');
+    const text = e.lastText ? `${e.lastText}\n\n${suffix}` : suffix;
+    await telegram.editMessageText(e.chatId, e.messageId, undefined, text).catch(() => {});
+  }
+}

--- a/src/bot/commands/refresh.ts
+++ b/src/bot/commands/refresh.ts
@@ -7,6 +7,7 @@ import type { DB } from '../../storage/db';
 import { listPubs } from '../../storage/pubs';
 import { type NewbeersDeps, type NewbeersResult, filterPubsByQuery } from './newbeers-build';
 import { getUserCity } from '../../storage/user_profiles';
+import { trackProgress } from '../active-progress';
 
 const FULL_COOLDOWN_MS = 5 * 60 * 1000;
 const SCOPED_COOLDOWN_MS = 30 * 1000;
@@ -126,9 +127,11 @@ export function createRefreshCommand(
     const locale = ctx.locale;
     const pubSlugs = scope.kind === 'scoped' ? scope.slugs : undefined;
     const pubQuery = scope.kind === 'scoped' ? scope.query : undefined;
+    const tracker = trackProgress(chatId, messageId, locale);
 
     const notify = makeThrottledProgress(
       async (text) => {
+        tracker.update(text);
         await telegram
           .editMessageText(chatId, messageId, undefined, text)
           .catch(() => {});
@@ -156,13 +159,19 @@ export function createRefreshCommand(
     // handlerTimeout (default 90s) would otherwise kill the handler and
     // raise TimeoutError into bot.catch. Captured locals above keep the
     // background promise independent of ctx's lifetime.
-    void runRefreshPipeline({
-      run: (n) => run(n, { pubSlugs }),
-      notify,
-      t,
-      log,
-      postRun: postRunClosure,
-    });
+    void (async () => {
+      try {
+        await runRefreshPipeline({
+          run: (n) => run(n, { pubSlugs }),
+          notify,
+          t,
+          log,
+          postRun: postRunClosure,
+        });
+      } finally {
+        tracker.release();
+      }
+    })();
   });
   return cmd;
 }

--- a/src/bot/commands/route.test.ts
+++ b/src/bot/commands/route.test.ts
@@ -1,4 +1,18 @@
-import { filterRouteTaps } from './route';
+import { filterRouteTaps, clampRouteN, MAX_ROUTE_N } from './route';
+
+describe('clampRouteN', () => {
+  it('passes small positive N through', () => {
+    expect(clampRouteN(5)).toBe(5);
+  });
+  it('caps N at MAX_ROUTE_N', () => {
+    expect(clampRouteN(200)).toBe(MAX_ROUTE_N);
+    expect(MAX_ROUTE_N).toBe(70);
+  });
+  it('floors N to at least 1', () => {
+    expect(clampRouteN(0)).toBe(1);
+    expect(clampRouteN(-4)).toBe(1);
+  });
+});
 
 test('route candidates always require a real Untappd match', () => {
   const taps = [

--- a/src/bot/commands/route.ts
+++ b/src/bot/commands/route.ts
@@ -31,6 +31,14 @@ import { googleMapsWalkingUrl } from '../../domain/maps';
 
 const PROGRESS_MIN_INTERVAL_MS = 2000;
 
+export const MAX_ROUTE_N = 70;
+
+// Clamp the requested coverage to a sane range. Beyond MAX_ROUTE_N the route would
+// span dozens of pubs and the tour search gets expensive; below 1 is meaningless.
+export function clampRouteN(n: number): number {
+  return Math.min(Math.max(1, Math.floor(n)), MAX_ROUTE_N);
+}
+
 export const routeCommand = new Composer<BotContext>();
 
 export function filterRouteTaps<T extends TapView>(
@@ -44,10 +52,11 @@ export function filterRouteTaps<T extends TapView>(
 routeCommand.command('route', async (ctx) => {
   const db = ctx.deps.db;
   const arg = ctx.message.text.split(' ')[1];
-  const N =
+  const N = clampRouteN(
     parseInt(arg ?? '', 10) ||
-    getFilters(db, ctx.from.id)?.default_route_n ||
-    ctx.deps.env.DEFAULT_ROUTE_N;
+      getFilters(db, ctx.from.id)?.default_route_n ||
+      ctx.deps.env.DEFAULT_ROUTE_N,
+  );
 
   const tried = triedBeerIds(db, ctx.from.id);
   const filters =

--- a/src/bot/commands/route.ts
+++ b/src/bot/commands/route.ts
@@ -28,6 +28,7 @@ import {
 } from './newbeers-format';
 import { formatRouteResult, type RoutePubFormat } from './route-format';
 import { googleMapsWalkingUrl } from '../../domain/maps';
+import { trackProgress } from '../active-progress';
 
 const PROGRESS_MIN_INTERVAL_MS = 2000;
 
@@ -113,8 +114,10 @@ routeCommand.command('route', async (ctx) => {
   const env = ctx.deps.env;
   const t = ctx.t;
   const locale = ctx.locale;
+  const tracker = trackProgress(chatId, messageId, locale);
   const notify = makeThrottledProgress(
     async (text) => {
+      tracker.update(text);
       await telegram
         .editMessageText(chatId, messageId, undefined, text, { parse_mode: 'HTML' })
         .catch(() => {});
@@ -251,6 +254,8 @@ routeCommand.command('route', async (ctx) => {
     } catch (e) {
       log.error({ err: e }, 'route failed');
       await notify(t('route.failed'), { force: true });
+    } finally {
+      tracker.release();
     }
   })();
 });

--- a/src/domain/router.test.ts
+++ b/src/domain/router.test.ts
@@ -18,6 +18,23 @@ test('handles partial coverage when N > union', () => {
   expect(r.coveredCount).toBe(5);
 });
 
+test('does not blow up for a large selected set (heuristic path)', () => {
+  // 20 pubs, each with a distinct interesting beer, spread on a line.
+  // N=20 forces greedySetCover to pick all 20 → |S|=20 > Held-Karp cap → heuristic.
+  const many = Array.from({ length: 20 }, (_, i) => ({
+    id: i + 1,
+    lat: 0,
+    lon: i * 0.01,
+    interesting: new Set([100 + i]),
+  }));
+  const start = Date.now();
+  const r = buildRoute(many, 20, { distance: haversineMeters });
+  expect(Date.now() - start).toBeLessThan(2000); // would be minutes with exact DP
+  expect(r.pubIds.length).toBe(20);
+  expect(new Set(r.pubIds).size).toBe(20); // every pub exactly once
+  expect(Number.isFinite(r.distanceMeters)).toBe(true);
+});
+
 describe('createOsrmTable', () => {
   test('builds the /table URL with lon,lat ordering and parses N×N matrix', async () => {
     let captured = '';

--- a/src/domain/router.ts
+++ b/src/domain/router.ts
@@ -15,6 +15,10 @@ export interface RouteOpts {
   distance: (a: [number, number], b: [number, number]) => number;
 }
 
+// Exact Held-Karp is O(2^k · k²); only use it for small selected sets. Above this
+// many pubs, fall back to a polynomial nearest-neighbour + 2-opt heuristic.
+const HELD_KARP_MAX = 12;
+
 export function haversineMeters(a: [number, number], b: [number, number]): number {
   const R = 6371000;
   const toRad = (x: number) => (x * Math.PI) / 180;
@@ -28,7 +32,7 @@ export function haversineMeters(a: [number, number], b: [number, number]): numbe
 export function buildRoute(pubs: RoutePub[], N: number, opts: RouteOpts): RouteResult {
   const selected = greedySetCover(pubs, N);
   const improved = localSwapForDistance(selected, pubs, N, opts);
-  const tour = openTsp(improved, opts);
+  const tour = solveTour(improved, opts);
   return {
     pubIds: tour.order.map((p) => p.id),
     coveredCount: union(improved).size,
@@ -63,7 +67,7 @@ function greedySetCover(pubs: RoutePub[], N: number): RoutePub[] {
 function localSwapForDistance(
   selected: RoutePub[], all: RoutePub[], N: number, opts: RouteOpts,
 ): RoutePub[] {
-  let best = selected; let bestDist = openTsp(best, opts).distance;
+  let best = selected; let bestDist = solveTour(best, opts).distance;
   let improved = true;
   while (improved) {
     improved = false;
@@ -72,7 +76,7 @@ function localSwapForDistance(
         if (best.some((p) => p.id === cand.id)) continue;
         const trial = [...best]; trial[i] = cand;
         if (union(trial).size < N) continue;
-        const d = openTsp(trial, opts).distance;
+        const d = solveTour(trial, opts).distance;
         if (d < bestDist) { best = trial; bestDist = d; improved = true; }
       }
     }
@@ -108,6 +112,57 @@ function openTsp(pubs: RoutePub[], opts: RouteOpts): { order: RoutePub[]; distan
   const order: number[] = []; let cur = bestEnd; let mask = full;
   while (cur !== -1) { order.unshift(cur); const p = parent[mask][cur]; mask ^= 1 << cur; cur = p; }
   return { order: order.map((i) => pubs[i]), distance: best };
+}
+
+function nearestNeighbourTwoOpt(
+  pubs: RoutePub[],
+  opts: RouteOpts,
+): { order: RoutePub[]; distance: number } {
+  const n = pubs.length;
+  if (n <= 1) return { order: pubs, distance: 0 };
+
+  const dist: number[][] = Array.from({ length: n }, (_, i) =>
+    Array.from({ length: n }, (_, j) =>
+      i === j ? 0 : opts.distance([pubs[i].lat, pubs[i].lon], [pubs[j].lat, pubs[j].lon]),
+    ),
+  );
+  const pathLen = (ord: number[]): number => {
+    let s = 0;
+    for (let i = 0; i + 1 < ord.length; i++) s += dist[ord[i]][ord[i + 1]];
+    return s;
+  };
+
+  // Nearest-neighbour construction from node 0.
+  const visited = new Array(n).fill(false);
+  let cur = 0;
+  visited[0] = true;
+  let order = [0];
+  for (let k = 1; k < n; k++) {
+    let best = -1;
+    let bd = Infinity;
+    for (let j = 0; j < n; j++) if (!visited[j] && dist[cur][j] < bd) { bd = dist[cur][j]; best = j; }
+    order.push(best);
+    visited[best] = true;
+    cur = best;
+  }
+
+  // 2-opt on the open path; bounded number of sweeps.
+  for (let sweep = 0; sweep < n; sweep++) {
+    let improved = false;
+    for (let i = 0; i < n - 1; i++) {
+      for (let k = i + 1; k < n; k++) {
+        const cand = [...order.slice(0, i), ...order.slice(i, k + 1).reverse(), ...order.slice(k + 1)];
+        if (pathLen(cand) < pathLen(order) - 1e-9) { order = cand; improved = true; }
+      }
+    }
+    if (!improved) break;
+  }
+
+  return { order: order.map((i) => pubs[i]), distance: pathLen(order) };
+}
+
+function solveTour(pubs: RoutePub[], opts: RouteOpts): { order: RoutePub[]; distance: number } {
+  return pubs.length <= HELD_KARP_MAX ? openTsp(pubs, opts) : nearestNeighbourTwoOpt(pubs, opts);
 }
 
 export function createOsrmDistance(base: string, fetchImpl: typeof fetch = fetch) {

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -4,6 +4,9 @@ export const en: Messages = {
   // app
   'app.no_data_in_snapshot': 'No interesting untried beers right now.',
 
+  // common
+  'common.interrupted_by_restart': '⚠️ Interrupted by a restart — please re-run the command.',
+
   // help / command catalog
   'help.intro': 'Bot commands:',
   'cmd.newbeers': 'top untried beers',

--- a/src/i18n/locales/pl.ts
+++ b/src/i18n/locales/pl.ts
@@ -4,6 +4,9 @@ export const pl: Messages = {
   // app
   'app.no_data_in_snapshot': 'Aktualnie brak ciekawych niespróbowanych piw.',
 
+  // common
+  'common.interrupted_by_restart': '⚠️ Przerwano przez restart — uruchom polecenie ponownie.',
+
   // help / command catalog
   'help.intro': 'Komendy bota:',
   'cmd.newbeers': 'top niepitych piw',

--- a/src/i18n/locales/uk.ts
+++ b/src/i18n/locales/uk.ts
@@ -4,6 +4,9 @@ export const uk: Messages = {
   // app
   'app.no_data_in_snapshot': 'Наразі немає цікавих непитих пив.',
 
+  // common
+  'common.interrupted_by_restart': '⚠️ Перервано рестартом — повтори команду.',
+
   // help / command catalog
   'help.intro': 'Команди бота:',
   'cmd.newbeers': 'топ непитих пив',

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -11,6 +11,9 @@ export interface Messages {
   // app
   'app.no_data_in_snapshot': string;
 
+  // common
+  'common.interrupted_by_restart': string;
+
   // help / command catalog
   'help.intro': string;
   'cmd.newbeers': string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,8 @@ import { cleanupOldSnapshots } from './jobs/cleanup-old-snapshots';
 import { dailyStatus } from './jobs/daily-status';
 import { createCircuitBreaker } from './domain/untappd-circuit';
 import { createShutdown } from './shutdown';
+import { interruptActiveProgress } from './bot/active-progress';
+import { createTranslator } from './i18n';
 
 async function main(): Promise<void> {
   const env = loadEnv(process.env);
@@ -190,7 +192,14 @@ async function main(): Promise<void> {
   // Without an explicit exit, node-cron schedules and the SQLite handle keep
   // the event loop alive — systemd then SIGKILLs us at TimeoutStopSec (90s
   // default), which risks a non-clean SQLite WAL flush.
-  const shutdown = createShutdown({ bot, cronJobs, db, httpServer: apiServer, log });
+  const shutdown = createShutdown({
+    bot,
+    cronJobs,
+    db,
+    httpServer: apiServer,
+    log,
+    interruptActiveProgress: () => interruptActiveProgress(bot.telegram, createTranslator),
+  });
   const onSignal = (signal: string) => {
     shutdown(signal).finally(() => process.exit(0));
   };

--- a/src/shutdown.ts
+++ b/src/shutdown.ts
@@ -9,6 +9,7 @@ export interface ShutdownDeps {
   db: Pick<DB, 'close'>;
   httpServer?: { close: (cb?: (err?: Error) => void) => void };
   log: pino.Logger;
+  interruptActiveProgress?: () => Promise<void>;
 }
 
 export type Shutdown = (signal: string) => Promise<void>;
@@ -19,6 +20,14 @@ export function createShutdown(deps: ShutdownDeps): Shutdown {
     if (started) return;
     started = true;
     deps.log.info({ signal }, 'shutdown initiated');
+
+    if (deps.interruptActiveProgress) {
+      try {
+        await deps.interruptActiveProgress();
+      } catch (err) {
+        deps.log.error({ err }, 'interrupt active progress failed');
+      }
+    }
 
     for (const job of deps.cronJobs) {
       try { job.stop(); } catch (err) { deps.log.error({ err }, 'cron stop failed'); }


### PR DESCRIPTION
## Summary
Follow-up to #193 — fixes two latent `/route` bugs found while debugging a "stuck route" report (the actual symptom was orphaned progress messages from a deploy; both bugs below are real and now fixed).

**Bug 1 — exponential `buildRoute` blowup.** `openTsp` is exact Held-Karp `O(2^|S|·n²)` with no cap on `|S|`. For a power-user (11501 tried beers → 198 distinct untried in Warszawa) a large arg drove `|S|` past ~17 → minutes / GBs / OOM (`/route 200`, a latent DoS).
- New `solveTour(pubs, opts)` in `domain/router.ts`: exact Held-Karp for `|S| ≤ 12`, else polynomial **nearest-neighbour + 2-opt**. `buildRoute` + `localSwapForDistance` route through it, so every TSP eval is bounded.
- `clampRouteN` clamps the requested N to `1..70` (`MAX_ROUTE_N`) at the command.

**Bug 2 — orphaned progress messages on deploy.** `/route` and `/refresh` run detached fire-and-forget work; a deploy SIGTERM kills the promise and freezes its progress message forever.
- New `bot/active-progress.ts` registry: commands `trackProgress(chatId, messageId, locale)` and `release()` in a `finally`; the graceful-shutdown path calls `interruptActiveProgress(bot.telegram, createTranslator)` which appends a localized **⚠️ interrupted by restart** notice to each still-active message.
- New i18n key `common.interrupted_by_restart` (en/uk/pl).

## Test Plan
- [x] `npm test` — 850 passed (91 files); new tests: router large-`|S|` no-blowup (visits all once, <2s), `clampRouteN`, active-progress registry (append suffix / clear / released-not-edited / suffix-only)
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] existing router optimality + shutdown tests still green

Design: `docs/superpowers/specs/2026-06-24-route-robustness-design.md`
Plan: `docs/superpowers/plans/2026-06-24-route-robustness.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)