### PR TITLE
fix(extension): parse BeerFreak slash collaborators

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed BeerFreak parsing for slash/backslash collaborator titles, so brandless products and branded collabs emit the primary brewery with a clean beer name.
 - Fixed BeerFreak matching for same-name releases: when product details expose `Міцність`, the extension now sends that ABV to the matcher using bounded, cached detail-page lookups.
 - Fixed Flasker matching when product titles omit or abbreviate the brewery: trusted shop tags and product links now identify known breweries, and leading preview/sample labels are removed before matching.
 - Fixed OneMoreBeer delicatessen filtering so kvass/Kwas Chlebowy stays eligible while Kofola, kombucha, and aloe soft drinks are ignored per product.

--- a/extension/src/sites/beerfreak.test.ts
+++ b/extension/src/sites/beerfreak.test.ts
@@ -49,12 +49,17 @@ const PRODUCT_PAGE_WITH_ABV = `
   </table>
 `;
 
-function docWithProducts(products: unknown[]): Document {
+interface TestProduct {
+  id: number;
+  brand_title?: string | null;
+  title: string;
+  url?: string;
+}
+
+function docWithProducts(products: TestProduct[]): Document {
   return new DOMParser().parseFromString(`
     <div data-catalog-view-block="products">
-      ${metadataCard(1737, 'fallback title')}
-      ${metadataCard(10079, 'fallback title')}
-      ${metadataCard(10112, 'fallback title')}
+      ${products.map((product) => metadataCard(product.id, 'fallback title')).join('')}
     </div>
     <script>
       products = ${JSON.stringify(products)},
@@ -84,12 +89,44 @@ describe('beerfreak adapter', () => {
     });
   });
 
-  it('keeps collab slash names intact when metadata has no brewery', () => {
-    const collab = cards.find((c) => c.name.includes('Popihn/Brasserie Cambier'));
+  it('uses the first brewery and strips slash collaborator prefixes when metadata has no brand', () => {
+    const collab = cards.find((c) => c.name.includes('DOLCITA'));
     expect(collab).toMatchObject({
-      brewery: '',
-      name: 'Popihn/Brasserie Cambier DIPA DDH - DOLCITA',
+      brewery: 'Popihn',
+      name: 'DIPA DDH - DOLCITA',
     });
+  });
+
+  it('splits brandless BeerFreak titles into usable brewery and beer names', () => {
+    const parsed = beerfreak.parseCards(docWithProducts([
+      { id: 10412, brand_title: null, title: 'RIOAZUL Scorpion' },
+      { id: 10413, brand_title: null, title: 'La Quince Brewing Co./RIOAZUL Final Form' },
+    ]));
+
+    expect(parsed).toContainEqual(expect.objectContaining({
+      brewery: 'RIOAZUL',
+      name: 'Scorpion',
+    }));
+    expect(parsed).toContainEqual(expect.objectContaining({
+      brewery: 'La Quince Brewing Co.',
+      name: 'Final Form',
+    }));
+  });
+
+  it('strips leading slash collaborator segments after the branded brewery prefix', () => {
+    const parsed = beerfreak.parseCards(docWithProducts([
+      { id: 10457, brand_title: 'PINTA (Польща)', title: 'PINTA/Varietal Beer Company Hazy Discovery Sunnyside' },
+      { id: 10458, brand_title: 'VARVAR BREW (Україна)', title: 'VARVAR BREW\\Saugatuck Brewing Company Sugar Moon' },
+    ]));
+
+    expect(parsed).toContainEqual(expect.objectContaining({
+      brewery: 'PINTA',
+      name: 'Hazy Discovery Sunnyside',
+    }));
+    expect(parsed).toContainEqual(expect.objectContaining({
+      brewery: 'VARVAR BREW',
+      name: 'Sugar Moon',
+    }));
   });
 
   it('removes brewery suffix noise that remains after brand prefix trimming', () => {

--- a/extension/src/sites/beerfreak.ts
+++ b/extension/src/sites/beerfreak.ts
@@ -13,6 +13,8 @@ interface ProductMeta {
 
 const BREWERY_NOISE_PREFIX_RE = /^(?:brewery|brewing|browar|brouwerij|brasserie)\s+/i;
 const LEADING_BREWERY_DESCRIPTORS = new Set(['brouwerij', 'brasserie', 'browar', 'pivovar', 'birrificio', 'brauerei']);
+const COLLABORATOR_COMPANY_WORDS = new Set(['beer', 'brewing']);
+const COLLABORATOR_TERMINAL_WORDS = new Set(['brewery', 'company', 'co', 'co.']);
 const MAX_DETAIL_FETCHES_PER_PASS = 20;
 const detailUrls = new WeakMap<HTMLElement, string>();
 const abvByUrl = new Map<string, Promise<number | undefined>>();
@@ -35,11 +37,54 @@ function cleanName(rawTitle: string, brewery: string): string {
   const prefix = rawTitle.slice(0, b.length);
   if (prefix.toLowerCase() !== b.toLowerCase()) return rawTitle.trim();
 
-  return rawTitle.slice(b.length).trim().replace(BREWERY_NOISE_PREFIX_RE, '').trim() || rawTitle.trim();
+  return stripLeadingCollaborator(rawTitle.slice(b.length))
+    .replace(BREWERY_NOISE_PREFIX_RE, '')
+    .trim() || rawTitle.trim();
+}
+
+function normalizedToken(token: string): string {
+  return token.toLowerCase().replace(/[(),]/g, '');
+}
+
+function stripCollaboratorName(rawTitle: string): string {
+  const tokens = rawTitle.split(/\s+/).filter(Boolean);
+  if (tokens.length < 2) return rawTitle.trim();
+
+  const first = normalizedToken(tokens[0]);
+  if (LEADING_BREWERY_DESCRIPTORS.has(first) && tokens.length >= 3) {
+    return tokens.slice(2).join(' ');
+  }
+
+  for (let i = 0; i < tokens.length - 1; i += 1) {
+    const token = normalizedToken(tokens[i]);
+    const next = normalizedToken(tokens[i + 1] ?? '');
+    if (COLLABORATOR_COMPANY_WORDS.has(token) && COLLABORATOR_TERMINAL_WORDS.has(next)) {
+      return tokens.slice(i + 2).join(' ');
+    }
+    if (COLLABORATOR_TERMINAL_WORDS.has(token)) {
+      return tokens.slice(i + 1).join(' ');
+    }
+  }
+
+  return tokens.slice(1).join(' ');
+}
+
+function stripLeadingCollaborator(rawTitle: string): string {
+  const title = rawTitle.replace(/\s+/g, ' ').trim();
+  const match = title.match(/^[\\/]\s*(.+)$/);
+  return match ? stripCollaboratorName(match[1]) : title;
 }
 
 function splitBrandlessTitle(rawTitle: string): { brewery: string; name: string } {
   const title = rawTitle.replace(/\s+/g, ' ').trim();
+  const collaborator = title.match(/^(.+?)\s*[\\/]\s*(.+)$/);
+  if (collaborator) {
+    return {
+      brewery: collaborator[1].trim(),
+      name: stripCollaboratorName(collaborator[2].trim()) || title,
+    };
+  }
+
   const tokens = title.split(/\s+/).filter(Boolean);
   const first = tokens[0]?.toLowerCase();
 
@@ -47,6 +92,13 @@ function splitBrandlessTitle(rawTitle: string): { brewery: string; name: string 
     return {
       brewery: tokens.slice(0, -1).join(' '),
       name: tokens[tokens.length - 1],
+    };
+  }
+
+  if (tokens.length >= 2) {
+    return {
+      brewery: tokens[0],
+      name: tokens.slice(1).join(' '),
     };
   }
 
@@ -125,9 +177,11 @@ export const beerfreak: SiteAdapter = {
       if (!rawTitle) continue;
       if (isNonBeerName(rawTitle)) continue;
 
-      const parsed = product?.brand_title == null
-        ? splitBrandlessTitle(rawTitle)
-        : { brewery: cleanBrewery(product.brand_title), name: '' };
+      const parsed = product
+        ? product.brand_title == null
+          ? splitBrandlessTitle(rawTitle)
+          : { brewery: cleanBrewery(product.brand_title), name: '' }
+        : { brewery: '', name: rawTitle.trim() };
       const brewery = parsed.brewery;
       const name = parsed.name || cleanName(rawTitle, brewery);
       if (!name) continue;


### PR DESCRIPTION
## Summary

BeerFreak listings that put collaborators before the beer name now match on the primary brewery and a clean beer name instead of sending malformed brewery/name pairs. Brandless metadata titles such as `Popihn/Brasserie Cambier DIPA DDH - DOLCITA` and `RIOAZUL Scorpion` now split into usable candidates, while branded collabs such as `PINTA/Varietal Beer Company Hazy Discovery Sunnyside` strip the collaborator prefix after the brand.

Closes #206.

## Tests

- `cd extension && npm test -- src/sites/beerfreak.test.ts src/sites/conformance.test.ts`
- `cd extension && npm run typecheck`
- `cd extension && npm run build`
- `cd extension && npm test`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
