### PR TITLE
fix(extension): filter BeerRepublic twelve packs

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed BeerRepublic filtering so variety/twelve-pack products are ignored instead of being matched as individual beers.
 - Fixed BeerFreak parsing for slash/backslash collaborator titles, so brandless products and branded collabs emit the primary brewery with a clean beer name.
 - Fixed BeerFreak matching for same-name releases: when product details expose `Міцність`, the extension now sends that ABV to the matcher using bounded, cached detail-page lookups.
 - Fixed Flasker matching when product titles omit or abbreviate the brewery: trusted shop tags and product links now identify known breweries, and leading preview/sample labels are removed before matching.

--- a/extension/src/sites/beerrepublic.test.ts
+++ b/extension/src/sites/beerrepublic.test.ts
@@ -49,6 +49,7 @@ describe('beerrepublic adapter', () => {
         ${product("Firestone Walker Barrel Aged Brewer's Collective Brewery Pack", 'Firestone Walker')}
         ${product('Surprise Box Barrel Aged Beers')}
         ${product('Advent Calendar 2025 Green Edition')}
+        ${product('Winter Break Variety Twelve Pack', 'Samuel Adams')}
         ${product('Mind Haze Galaxy Bender', 'Firestone Walker')}
       </section>
     `, 'text/html');

--- a/extension/src/sites/beerrepublic.test.ts
+++ b/extension/src/sites/beerrepublic.test.ts
@@ -42,7 +42,7 @@ describe('beerrepublic adapter', () => {
     expect(beerrepublic.waitForGrid).toBeUndefined();
   });
 
-  it('ignores non-beer pack and calendar products', () => {
+  it('ignores non-beer pack, variety pack, and calendar products', () => {
     const doc = new DOMParser().parseFromString(`
       <section data-section-type="collection">
         ${product('Limited Edition Anniversary Vertical Set', 'Firestone Walker')}

--- a/extension/src/sites/non-beer.test.ts
+++ b/extension/src/sites/non-beer.test.ts
@@ -15,6 +15,9 @@ describe('isNonBeerName', () => {
     'Сертифікат 1000',
     'Gift Certificate 500',
     'Mixed Pack IPA',
+    'Variety Pack',
+    'Twelve Pack',
+    'Samuel Adams Winter Break Variety Twelve Pack',
     'Beer Club Subscription',
     'Underwood Culture tasting big set + келих',
   ])('flags packaging/voucher product %j', (name) => {
@@ -31,6 +34,8 @@ describe('isNonBeerName', () => {
     'Квас / Kvass',
     'MAGIC ROAD YES CANNONS SLOW MARKET PUSZKA 0,5 L KAUCJA',
     'Pomelo Nealko',
+    'Pack Mentality IPA',
+    'Backpack Stout',
   ])('keeps real beer %j', (name) => {
     expect(isNonBeerName(name)).toBe(false);
   });

--- a/extension/src/sites/non-beer.test.ts
+++ b/extension/src/sites/non-beer.test.ts
@@ -36,6 +36,8 @@ describe('isNonBeerName', () => {
     'Pomelo Nealko',
     'Pack Mentality IPA',
     'Backpack Stout',
+    'Variety Packaging IPA',
+    'Twelve Packard Stout',
   ])('keeps real beer %j', (name) => {
     expect(isNonBeerName(name)).toBe(false);
   });

--- a/extension/src/sites/non-beer.ts
+++ b/extension/src/sites/non-beer.ts
@@ -24,9 +24,9 @@ const NON_BEER_NAME_RE = new RegExp(
     'gift certificate',
     'mixed pack',
     'mixed case',
-    'twelve pack',
-    'variety pack',
-    'variety twelve pack',
+    'twelve pack\\b',
+    'variety pack\\b',
+    'variety twelve pack\\b',
     'subscription',   // unambiguous: no beer is named "Subscription"
     'abonnement',
     'certificate',    // EN gift voucher

--- a/extension/src/sites/non-beer.ts
+++ b/extension/src/sites/non-beer.ts
@@ -24,6 +24,9 @@ const NON_BEER_NAME_RE = new RegExp(
     'gift certificate',
     'mixed pack',
     'mixed case',
+    'twelve pack',
+    'variety pack',
+    'variety twelve pack',
     'subscription',   // unambiguous: no beer is named "Subscription"
     'abonnement',
     'certificate',    // EN gift voucher


### PR DESCRIPTION
## Summary

BeerRepublic variety and twelve-pack products are now filtered before they can be matched as individual beers. The shared non-beer detector stays conservative by adding only explicit multi-word pack phrases, with guards that keep unrelated beer names containing pack text eligible.

Fixes ysilvestrov/warsaw-beer-bot#209.

## Verification

- npm test -- src/sites/non-beer.test.ts src/sites/beerrepublic.test.ts
- npm test
- npm run typecheck
- npm run build
- git diff --check

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
