### PR TITLE
fix(api): return existing enrich matches

### DIFF
--- a/src/api/routes/enrich.test.ts
+++ b/src/api/routes/enrich.test.ts
@@ -176,16 +176,26 @@ describe('POST /enrich/result', () => {
     expect(getBeer(db, row.id)!.rating_global).toBeCloseTo(3.98);
   });
 
-  it('skips an already-matched beer and does not overwrite it', async () => {
+  it('reports an already-matched beer without overwriting it', async () => {
     const { db, app } = setup();
     upsertBeer(db, {
       untappd_id: 111, name: 'Atak Chmielu', brewery: 'PINTA', style: null, abv: null, rating_global: 4.0,
       normalized_name: normalizeName('Atak Chmielu'), normalized_brewery: normalizeBrewery('PINTA'),
     });
-    // HTML that would otherwise match a DIFFERENT bid:
-    const html = searchHtml([{ bid: 999, name: 'Atak Chmielu', brewery: 'PINTA', rating: '2.0' }]);
-    const res = await post(app, '/enrich/result', { brewery: 'PINTA', name: 'Atak Chmielu', html });
-    expect((await res.json()).status).toBe('skipped');
+    // Algolia JSON that would otherwise match a DIFFERENT bid:
+    const res = await post(app, '/enrich/result', {
+      brewery: 'PINTA',
+      name: 'Atak Chmielu',
+      algolia: {
+        hits: [{
+          bid: 999,
+          beer_name: 'Atak Chmielu',
+          brewery_name: 'PINTA',
+          rating_score: 2.0,
+        }],
+      },
+    });
+    expect(await res.json()).toMatchObject({ status: 'matched', untappd_id: 111, rating_global: 4.0 });
 
     const row = findBeerByNormalized(db, normalizeBrewery('PINTA'), normalizeName('Atak Chmielu'))!;
     expect(getBeer(db, row.id)!.untappd_id).toBe(111);          // unchanged

--- a/src/api/routes/enrich.ts
+++ b/src/api/routes/enrich.ts
@@ -92,10 +92,11 @@ export function enrichRoute(app: Hono<ApiEnv>, deps: ApiDeps): void {
   app.post('/enrich/result', zValidator('json', ResultBody), async (c) => {
     const { brewery, name, html, algolia, pageUrl } = c.req.valid('json');
     const row = ensureBeerRow(deps.db, brewery, name);
-    // Only orphans are enrichable. Never overwrite / merge a canonical (already
-    // matched) row from client-relayed input.
+    // Only orphans need enrichment. If the row was already enriched by an earlier
+    // relay/cron, report the existing canonical match so the extension can update
+    // the page without reprocessing or overwriting it.
     if (row.untappd_id != null) {
-      return c.json({ status: 'skipped' });
+      return c.json({ status: 'matched', untappd_id: row.untappd_id, rating_global: row.rating_global });
     }
     // Reuse the full server pick pipeline; the client already fetched, so the
     // injected search adapter just returns the relayed result payload.


### PR DESCRIPTION
## Summary

Already-enriched beers no longer look like failed enrichment in the extension. When `/enrich/result` receives a relay payload for a catalog row that already has an `untappd_id`, the API now returns that existing match instead of `skipped`, so the page can update to the matched state without reprocessing or overwriting the canonical row.

This preserves the previous safety guard: client-relayed Algolia data still cannot overwrite an existing canonical Untappd id or rating.

## Validation

- `npx vitest run src/api/routes/enrich.test.ts`
- `npm run typecheck`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
