### PR TITLE
fix(matcher): strip compound nano-brewery noise tokens (#228)

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1248,7 +1248,11 @@ test-БД, §3.2 «no `await` ⇒ no race», §3.3 визначення «extern
   отже несе drunk/personal-заяви) і в `lookupBeer` Stage 2a (перед fuzzy 2b).
 - `BREWERY_NOISE` стрипить дескриптори пивоварні багатьма мовами (`browar`,
   `brewery`, `contracts`, `collab`/`collaboration`, `pivovar`, `brauerei`, `brasserie`,
-  `birrificio`, `brouwerij`, `bryggeri`, `cerveceria`, …); `cleanSearchQuery` (продакшн-будівник
+  `birrificio`, `brouwerij`, `bryggeri`, `cerveceria`, …), а також **складені**
+  «нано-пивоварня» токени (`nanobrowar`/`nanobrowary`/`nanobryggeri`) — лише як
+  єдиний склеєний токен; голе `nano` НЕ є шумом (це окреме слово/частина бренду:
+  `Nano Cinco`, `Mandrill Nano Brewing`), бо його зрізання зіпсувало б бренд (#228).
+  `cleanSearchQuery` (продакшн-будівник
   пошукового запиту; `stripBreweryNoise` збережено, але не в гарячому шляху) додатково
   колапсує `COLLAB_SEP`-роздільники ДО токенізації, тож приклеєне сміття типу `collab/`
   відсіюється і пошуковий запит enrich'у не ANDить обидві колаб-пивоварні (#117 Omnipollo).

--- a/src/domain/normalize.test.ts
+++ b/src/domain/normalize.test.ts
@@ -98,6 +98,21 @@ describe('multilingual brewery descriptors', () => {
   });
 });
 
+describe('compound nano-brewery noise tokens', () => {
+  test('strips compound "Nanobrowar"/"Nanobryggeri" descriptors (#228)', () => {
+    // "Nanobrowar" is Polish for "nano-brewery" — a single compound token that
+    // normalizeBrewery must strip so the brand survives and hits its curated alias.
+    expect(normalizeBrewery('Nanobrowar Starkraft Brewery')).toBe('starkraft');
+    expect(normalizeBrewery('Kamfjord Nanobryggeri')).toBe('kamfjord');
+  });
+
+  test('does NOT strip bare "nano" — it can be part of a brand', () => {
+    // Negative guard: bare "nano" is a separate word or brand fragment, never noise.
+    expect(normalizeBrewery('Nano Cinco')).toBe('nano cinco');
+    expect(normalizeBrewery('Mandrill Nano Brewing Co.')).toBe('mandrill nano');
+  });
+});
+
 describe('contracts noise word', () => {
   test('drops "contracts" so official-suffix collapses to the brand', () => {
     expect(normalizeBrewery('Harpagan Contracts')).toBe('harpagan');

--- a/src/domain/normalize.ts
+++ b/src/domain/normalize.ts
@@ -12,6 +12,10 @@ export const BREWERY_NOISE = new Set([
   // Scandinavian (+ definite form), Spanish (post-diacritic-strip form)
   'pivovar', 'pivovary', 'brauerei', 'brasserie', 'birrificio',
   'brouwerij', 'bryggeri', 'bryggeriet', 'cerveceria',
+  // Compound "nano-brewery" descriptors only (a single glued token). Bare "nano"
+  // is deliberately NOT noise — it's a separate word or brand fragment in
+  // "Nano Cinco"/"Mandrill Nano Brewing", which stripping would corrupt (#228).
+  'nanobrowar', 'nanobrowary', 'nanobryggeri',
 ]);
 
 // Separator for collab/bilingual brewery names. Untappd uses:


### PR DESCRIPTION
Closes #228.

## What

Add the **compound** "nano-brewery" descriptors `nanobrowar` / `nanobrowary` / `nanobryggeri` to `BREWERY_NOISE` (`src/domain/normalize.ts`). These are single glued tokens that `normalizeBrewery` couldn't strip, so brands behind a nano descriptor never reached the brewery hard-gate or their curated alias.

- `Nanobrowar Starkraft Brewery` → `starkraft` (now a curated alias key → re-armable)
- `Kamfjord Nanobryggeri` → `kamfjord`

`BREWERY_NOISE` is the single source shared by `normalizeBrewery` (gate), `cleanSearchQuery` (search query) and `stripBreweryNoise` (display) — one addition covers all three.

## What this deliberately does NOT do

Bare `nano` is **not** added — it's a separate word or brand fragment (`Nano Cinco`, `Mandrill Nano Brewing`, `Nano Brasserie`) and stripping it would corrupt the brand. Only the unambiguous compound tokens are noise. Covered by a negative-guard test.

## Tests (TDD)

- `normalizeBrewery('Nanobrowar Starkraft Brewery') === 'starkraft'`, `'Kamfjord Nanobryggeri' === 'kamfjord'`
- negative guard: `'Nano Cinco' === 'nano cinco'`, `'Mandrill Nano Brewing Co.' === 'mandrill nano'`
- Full suite: 966 passed; typecheck clean.

`spec.md` §normalization updated in the same PR.

## Post-merge ops (not in this PR)

Deploy + restart → startup `backfill-normalized-brewery` recomputes `normalized_brewery` → `npm run rearm-aliased-orphans -- --apply` re-arms the now-covered orphans (the 5 Nanobrowar Starkraft beers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)