### PR TITLE
feat(extension): add Funkyshop shop adapter

### DIFF
--- a/docs/extension-install-uk.md
+++ b/docs/extension-install-uk.md
@@ -12,6 +12,7 @@ Untappd. Працює на:
 - `hoptimaal.com` (і піддомени)
 - `flasker.com.ua` (і піддомени)
 - `piwnemosty.pl` (і піддомени)
+- `funkyshop.pl` (і піддомени)
 
 Щоб усе запрацювало, потрібні три речі: (1) завантажити свою історію пив у бота,
 (2) отримати токен доступу, (3) встановити й налаштувати розширення. Нижче — по кроках.
@@ -146,7 +147,8 @@ Untappd. Працює на:
 
 1. Зайди на підтримуваний магазин:
    `beerrepublic.eu`, `onemorebeer.pl`, `beerfreak.org`, `bierloods22.nl`,
-   `winetime.com.ua`, `hoptimaal.com`, `flasker.com.ua` або `piwnemosty.pl`.
+   `winetime.com.ua`, `hoptimaal.com`, `flasker.com.ua`, `piwnemosty.pl`
+   або `funkyshop.pl`.
 2. Розширення **автоматично** зчитує сітку пив на сторінці, надсилає її боту на звірку
    й малює **кутовий бейдж** на картках. Що означають бейджі:
 

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Added Funkyshop (funkyshop.pl) shop support. Glass/merch category pages are skipped so non-beer products are not matched.
 - Added Piwne Mosty (piwnemosty.pl) shop support. Snack and glass/merch category pages are skipped so non-beer products are not matched.
 
 ## [0.9.3] - 2026-06-28

--- a/extension/manifest.config.ts
+++ b/extension/manifest.config.ts
@@ -39,6 +39,8 @@ export default defineManifest({
         'https://*.flasker.com.ua/*',
         'https://piwnemosty.pl/*',
         'https://*.piwnemosty.pl/*',
+        'https://funkyshop.pl/*',
+        'https://*.funkyshop.pl/*',
       ],
       js: ['src/content/main.ts'],
       run_at: 'document_idle',

--- a/extension/src/manifest.test.ts
+++ b/extension/src/manifest.test.ts
@@ -39,6 +39,8 @@ describe('manifest', () => {
     expect(contentScript.matches).toContain('https://*.hoptimaal.com/*');
     expect(contentScript.matches).toContain('https://piwnemosty.pl/*');
     expect(contentScript.matches).toContain('https://*.piwnemosty.pl/*');
+    expect(contentScript.matches).toContain('https://funkyshop.pl/*');
+    expect(contentScript.matches).toContain('https://*.funkyshop.pl/*');
   });
 
   it('exposes a popup action', () => {

--- a/extension/src/sites/funkyshop.test.ts
+++ b/extension/src/sites/funkyshop.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { funkyshop } from './funkyshop';
+
+const html = readFileSync(resolve(__dirname, '../../tests/fixtures/funkyshop.html'), 'utf8');
+const nonBeerHtml = readFileSync(resolve(__dirname, '../../tests/fixtures/funkyshop.nonbeer.html'), 'utf8');
+
+function parse(source: string) {
+  const doc = new DOMParser().parseFromString(source, 'text/html');
+  return funkyshop.parseCards(doc);
+}
+
+let cards: ReturnType<typeof funkyshop.parseCards>;
+beforeAll(() => {
+  cards = parse(html);
+});
+
+describe('funkyshop adapter', () => {
+  it('matches Funkyshop hosts', () => {
+    expect(funkyshop.hostMatch(new URL('https://funkyshop.pl/pl/4-piwo-rzemieslnicze'))).toBe(true);
+    expect(funkyshop.hostMatch(new URL('https://www.funkyshop.pl/en/4-craft-beer'))).toBe(true);
+    expect(funkyshop.hostMatch(new URL('https://example.com/'))).toBe(false);
+  });
+
+  it('parses beer cards from the PrestaShop product grid', () => {
+    expect(cards.length).toBeGreaterThan(20);
+    expect(cards[0]).toMatchObject({
+      brewery: 'Ziemia Obiecana',
+      name: 'Kiełbasa Kolega (x Hop Hooligans)',
+      abv: 9.6,
+    });
+  });
+
+  it('strips package volume from names but keeps meaningful collaborators', () => {
+    expect(cards).toContainEqual(
+      expect.objectContaining({
+        brewery: 'PINTA',
+        name: 'Perfect Piece (x Other Half)',
+        abv: 6.5,
+      }),
+    );
+  });
+
+  it('drops beer sets from beer category grids', () => {
+    expect(cards.map((c) => c.name)).not.toContain('Lervig Rackhouse Barrel Aged Set');
+    expect(cards.map((c) => c.name)).not.toContain("Gelato Week '26 Set");
+  });
+
+  it('treats issue-listed glass merch categories as whole non-beer pages', () => {
+    expect(funkyshop.isNonBeerPage?.(new URL('https://funkyshop.pl/pl/17-szklomerch'))).toBe(true);
+    expect(funkyshop.isNonBeerPage?.(new URL('https://funkyshop.pl/en/17-glassmerch'))).toBe(true);
+    expect(funkyshop.isNonBeerPage?.(new URL('https://funkyshop.pl/pl/4-piwo-rzemieslnicze'))).toBe(false);
+  });
+
+  it('drops glass and merch products from the non-beer fixture', () => {
+    expect(parse(nonBeerHtml)).toEqual([]);
+  });
+});

--- a/extension/src/sites/funkyshop.ts
+++ b/extension/src/sites/funkyshop.ts
@@ -1,0 +1,54 @@
+import type { Card, SiteAdapter } from './types';
+import { isNonBeerName } from './non-beer';
+
+const CARD_SELECTOR = 'article.product-miniature';
+const NON_BEER_PAGE_RE = /\/(?:pl\/17-szklomerch|en\/17-glassmerch)(?:[/?#]|$)/i;
+const NON_BEER_TITLE_RE = /(?:\bset\b|szklank|kufel|pokal|glass|merch|rastal|sahm)/iu;
+const VOLUME_SUFFIX_RE = /\s+(?:\(?\d+\s*x\s*)?\d+(?:[.,]\d+)?\s*(?:ml|l)\)?\s*$/i;
+const ABV_RE = /(\d+(?:[.,]\d+)?)\s*%/u;
+
+function text(el: Element | null | undefined): string {
+  return el?.textContent?.replace(/\s+/g, ' ').trim() ?? '';
+}
+
+function cleanName(raw: string): string {
+  const name = raw.replace(VOLUME_SUFFIX_RE, '').trim();
+  return name || raw.trim();
+}
+
+function parseAbv(raw: string): number | undefined {
+  const match = raw.match(ABV_RE);
+  if (!match) return undefined;
+  const abv = Number(match[1].replace(',', '.'));
+  return Number.isFinite(abv) ? abv : undefined;
+}
+
+function isNonBeerTitle(rawName: string, description: string): boolean {
+  return isNonBeerName(rawName) || NON_BEER_TITLE_RE.test(rawName) || NON_BEER_TITLE_RE.test(description);
+}
+
+export const funkyshop: SiteAdapter = {
+  id: 'funkyshop',
+  hostMatch: (url) => url.hostname === 'funkyshop.pl' || url.hostname.endsWith('.funkyshop.pl'),
+  reRenderContainerSelector: '#products',
+  isNonBeerPage: (url) => NON_BEER_PAGE_RE.test(url.pathname),
+
+  parseCards(root) {
+    const cards: Card[] = [];
+
+    for (const el of Array.from(root.querySelectorAll<HTMLElement>(CARD_SELECTOR))) {
+      const rawName = text(el.querySelector('.product-title'));
+      const description = text(el.querySelector('.product-description-short'));
+      if (!rawName || isNonBeerTitle(rawName, description)) continue;
+
+      const brewery = text(el.querySelector('.manufacturer-product'));
+      const name = cleanName(rawName);
+      if (!name) continue;
+
+      const abv = parseAbv(description);
+      cards.push(abv == null ? { el, brewery, name } : { el, brewery, name, abv });
+    }
+
+    return cards;
+  },
+};

--- a/extension/src/sites/registry.test.ts
+++ b/extension/src/sites/registry.test.ts
@@ -8,6 +8,7 @@ import { winetime } from './winetime';
 import { hoptimaal } from './hoptimaal';
 import { flasker } from './flasker';
 import { piwnemosty } from './piwnemosty';
+import { funkyshop } from './funkyshop';
 
 describe('pickAdapter', () => {
   it('selects beerrepublic for beerrepublic.eu', () => {
@@ -46,6 +47,11 @@ describe('pickAdapter', () => {
     expect(pickAdapter(new URL('https://www.piwnemosty.pl/pol_m_PIWO-KRAFTOWE-100.html'))).toBe(piwnemosty);
   });
 
+  it('selects funkyshop for funkyshop.pl', () => {
+    expect(pickAdapter(new URL('https://funkyshop.pl/pl/4-piwo-rzemieslnicze'))).toBe(funkyshop);
+    expect(pickAdapter(new URL('https://www.funkyshop.pl/en/4-craft-beer'))).toBe(funkyshop);
+  });
+
   it('returns null for an unknown host', () => {
     expect(pickAdapter(new URL('https://example.com/'))).toBeNull();
   });
@@ -53,8 +59,8 @@ describe('pickAdapter', () => {
 
 describe('adapter ids', () => {
   it('every adapter has a unique non-empty id', () => {
-    const ids = [beerrepublic, onemorebeer, beerfreak, bierloods22, winetime, hoptimaal, flasker, piwnemosty].map((a) => a.id);
-    expect(ids).toEqual(['beerrepublic', 'onemorebeer', 'beerfreak', 'bierloods22', 'winetime', 'hoptimaal', 'flasker', 'piwnemosty']);
+    const ids = [beerrepublic, onemorebeer, beerfreak, bierloods22, winetime, hoptimaal, flasker, piwnemosty, funkyshop].map((a) => a.id);
+    expect(ids).toEqual(['beerrepublic', 'onemorebeer', 'beerfreak', 'bierloods22', 'winetime', 'hoptimaal', 'flasker', 'piwnemosty', 'funkyshop']);
     expect(new Set(ids).size).toBe(ids.length);
     for (const id of ids) expect(id.length).toBeGreaterThan(0);
   });

--- a/extension/src/sites/registry.ts
+++ b/extension/src/sites/registry.ts
@@ -7,8 +7,9 @@ import { winetime } from './winetime';
 import { hoptimaal } from './hoptimaal';
 import { flasker } from './flasker';
 import { piwnemosty } from './piwnemosty';
+import { funkyshop } from './funkyshop';
 
-export const ADAPTERS: SiteAdapter[] = [beerrepublic, onemorebeer, beerfreak, bierloods22, winetime, hoptimaal, flasker, piwnemosty];
+export const ADAPTERS: SiteAdapter[] = [beerrepublic, onemorebeer, beerfreak, bierloods22, winetime, hoptimaal, flasker, piwnemosty, funkyshop];
 
 export function pickAdapter(url: URL): SiteAdapter | null {
   return ADAPTERS.find((a) => a.hostMatch(url)) ?? null;

--- a/extension/tests/fixtures/funkyshop.html
+++ b/extension/tests/fixtures/funkyshop.html
@@ -1,0 +1,6176 @@
+<!DOCTYPE html><html lang="pl" class="default off-canvas"><head>
+    
+      
+  <meta charset="utf-8">
+
+
+  <meta http-equiv="x-ua-compatible" content="ie=edge">
+
+
+	<meta property="og:url" content="https://funkyshop.pl/pl/4-piwo-rzemieslnicze">
+	<meta property="og:title" content="Piwo rzemieślnicze – ciemne, pils, IPA, APA, owocowe">
+	<meta property="og:description" content="Nasza oferta obejmuje różnorodne piwa rzemieślnicze. Zapewniamy m.in. piwa jasne i ciemne, z owocowymi nutami oraz kwaśne i goryczkowe. Więcej na stronie.">
+	<meta property="og:type" content="website">
+	<meta property="og:image" content="https://funkyshop.plhttps://funkyshop.pl/img/logo-1743421189.jpg">
+  <meta property="fb:app_id" content="2358507497629256">
+
+
+
+  <title>Piwo rzemieślnicze – ciemne, pils, IPA, APA, owocowe</title>
+  <meta name="description" content="Nasza oferta obejmuje różnorodne piwa rzemieślnicze. Zapewniamy m.in. piwa jasne i ciemne, z owocowymi nutami oraz kwaśne i goryczkowe. Więcej na stronie.">
+    
+            
+          
+        <link rel="canonical" href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze">
+    
+                  <link rel="alternate" href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze" hreflang="pl">
+                  <link rel="alternate" href="https://funkyshop.pl/en/4-craft-beer" hreflang="en-us">
+        
+
+
+
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+
+
+  <link rel="icon" type="image/vnd.microsoft.icon" href="https://funkyshop.pl/img/favicon.ico?1768995451">
+  <link rel="shortcut icon" type="image/x-icon" href="https://funkyshop.pl/img/favicon.ico?1768995451">
+
+
+  
+
+    <link rel="stylesheet" href="https://funkyshop.pl/themes/leo_clark/assets/cache/theme-7d467f1506.css" type="text/css" media="all">
+
+
+
+    
+
+
+  
+
+  <script src="https://connect.facebook.net/pl_PL/bundle/sdk.js/" async="" crossorigin="anonymous"></script><script id="facebook-jssdk" src="https://connect.facebook.net/pl_PL/sdk.js#xfbml=1&amp;version=v5.0"></script><script async="" src="https://scripts.clarity.ms/0.8.66/clarity.js"></script><script type="text/javascript" async="" charset="utf-8" src="https://www.gstatic.com/recaptcha/releases/TnA7HacJFoBWt9hnlunBlYfK/recaptcha__en.js" crossorigin="anonymous" integrity="sha384-r0+0DCYB9Tdq4Rpy9IvL6ouvcnluWOWNg9jAIO3yJA2C6v7nklWcHe/NE5zIDHbA"></script><script async="" src="https://www.clarity.ms/tag/x0m7ny811l"></script><script type="text/javascript">
+        var LEO_COOKIE_THEME = "LEO_CLARK_PANEL_CONFIG";
+        var add_cart_error = "Podczas przetwarzania \u017c\u0105dania wyst\u0105pi\u0142 b\u0142\u0105d. Prosz\u0119 spr\u00f3buj ponownie";
+        var ajaxsearch = "1";
+        var appagebuilderToken = "b866420ae8aaf943d02267723ab32727";
+        var buttonwishlist_title_add = "Dodaj do listy \u017cycze\u0144";
+        var buttonwishlist_title_remove = "Usu\u0144 z listy \u017cycze\u0144";
+        var cancel_rating_txt = "Anuluj ocen\u0119";
+        var disable_review_form_txt = "Nie istnieje kryterium oceny tego produktu lub tego j\u0119zyka";
+        var dpdshipping_csrf = "b866420ae8aaf943d02267723ab32727";
+        var dpdshipping_id_cart = 0;
+        var dpdshipping_id_pudo_carrier = "400";
+        var dpdshipping_id_pudo_cod_carrier = false;
+        var dpdshipping_iframe_cod_url = "\/\/pudofinder.dpd.com.pl\/widget?key=1ae3418e27627ab52bebdcc1a958fa04&direct_delivery_cod=1&query=";
+        var dpdshipping_iframe_url = "\/\/pudofinder.dpd.com.pl\/widget?key=1ae3418e27627ab52bebdcc1a958fa04&query=";
+        var dpdshipping_pickup_get_address_ajax_url = "https:\/\/funkyshop.pl\/pl\/module\/dpdshipping\/PickupGetAddressAjax";
+        var dpdshipping_pickup_is_point_with_cod_ajax_url = "https:\/\/funkyshop.pl\/pl\/module\/dpdshipping\/PickupIsCodPointAjax";
+        var dpdshipping_pickup_save_point_ajax_url = "https:\/\/funkyshop.pl\/pl\/module\/dpdshipping\/PickupSavePointAjax";
+        var dpdshipping_token = "bea04497872c76c08b76009b3e64ecd9366ac36c";
+        var enable_dropdown_defaultcart = 1;
+        var enable_flycart_effect = 1;
+        var enable_notification = 1;
+        var height_cart_item = "115";
+        var isLogged = false;
+        var leo_push = 0;
+        var leo_search_url = "https:\/\/funkyshop.pl\/pl\/wyszukiwarka";
+        var leo_token = "b866420ae8aaf943d02267723ab32727";
+        var leoproductsearch_static_token = "b866420ae8aaf943d02267723ab32727";
+        var leoproductsearch_token = "74f973185b85b6419d9aadd1a0b68fe9";
+        var lf_is_gen_rtl = false;
+        var lps_show_product_img = "1";
+        var lps_show_product_price = true;
+        var lql_ajax_url = "https:\/\/funkyshop.pl\/pl\/module\/leoquicklogin\/leocustomer";
+        var lql_is_gen_rtl = false;
+        var lql_module_dir = "\/modules\/leoquicklogin\/";
+        var lql_myaccount_url = "https:\/\/funkyshop.pl\/pl\/moje-konto";
+        var lql_redirect = "";
+        var number_cartitem_display = 3;
+        var numpro_display = "100";
+        var pm_ca_show = "1";
+        var pm_cookie_delay_time = 0;
+        var pm_cookie_gv2 = "1";
+        var pm_cookie_label = {"Check all":"Zaznacz wszystkie","Settings":"Ustawienia","Accept all":"Zaakceptuj wszystkie","Submit selected":"Zaakceptuj wybrane i zapisz","Accept required":"Zatwierd\u017a tylko wymagane"};
+        var pm_cookie_link = "https:\/\/funkyshop.pl\/pl\/module\/pmcookie\/cookie?ajax=1";
+        var pm_cookie_link_conf = "https:\/\/funkyshop.pl\/pl\/module\/pmcookie\/settings?conf=1";
+        var pm_cookie_only_required = 0;
+        var pm_cookie_opacity = 0.5;
+        var pm_cookie_reload = 0;
+        var pm_cookie_required = ["1"];
+        var pm_cookie_settings = false;
+        var pm_cookie_show_on_scroll = 0;
+        var pm_sr_show = "0";
+        var pm_ss_show = "1";
+        var pmgoogleanalytycs4pro_ajax_link = "https:\/\/funkyshop.pl\/pl\/module\/pmgoogleanalytycs4pro\/ajax";
+        var pmgoogleanalytycs4pro_controller = "category";
+        var pmgoogleanalytycs4pro_secure_key = "bee687996f5a96ce53916f82abc43992";
+        var prestashop = {"cart":{"products":[],"totals":{"total":{"type":"total","label":"Razem","amount":0,"value":"0,00\u00a0z\u0142"},"total_including_tax":{"type":"total","label":"Suma (brutto)","amount":0,"value":"0,00\u00a0z\u0142"},"total_excluding_tax":{"type":"total","label":"Suma (netto)","amount":0,"value":"0,00\u00a0z\u0142"}},"subtotals":{"products":{"type":"products","label":"Produkty","amount":0,"value":"0,00\u00a0z\u0142"},"discounts":null,"shipping":{"type":"shipping","label":"Pakowanie","amount":0,"value":""},"tax":{"type":"tax","label":"VAT (wliczony)","amount":0,"value":"0,00\u00a0z\u0142"}},"products_count":0,"summary_string":"0 sztuk","vouchers":{"allowed":1,"added":[]},"discounts":[],"minimalPurchase":1,"minimalPurchaseRequired":"Minimalny zakup na kwot\u0119 1,00\u00a0z\u0142 (netto) jest wymagany aby zatwierdzi\u0107 Twoje zam\u00f3wienie, obecna warto\u015b\u0107 koszyka to 0,00\u00a0z\u0142 (netto)."},"currency":{"id":1,"name":"Z\u0142oty polski","iso_code":"PLN","iso_code_num":"985","sign":"z\u0142"},"customer":{"lastname":null,"firstname":null,"email":null,"birthday":null,"newsletter":null,"newsletter_date_add":null,"optin":null,"website":null,"company":null,"siret":null,"ape":null,"is_logged":false,"gender":{"type":null,"name":null},"addresses":[]},"language":{"name":"Polski (Polish)","iso_code":"pl","locale":"pl-PL","language_code":"pl","is_rtl":"0","date_format_lite":"Y-m-d","date_format_full":"Y-m-d H:i:s","id":1},"page":{"title":"","canonical":"https:\/\/funkyshop.pl\/pl\/4-piwo-rzemieslnicze","meta":{"title":"Piwo rzemie\u015blnicze \u2013 ciemne, pils, IPA, APA, owocowe","description":"Nasza oferta obejmuje r\u00f3\u017cnorodne piwa rzemie\u015blnicze. Zapewniamy m.in. piwa jasne i ciemne, z owocowymi nutami oraz kwa\u015bne i goryczkowe. Wi\u0119cej na stronie.","keywords":"","robots":"index"},"page_name":"category","body_classes":{"lang-pl":true,"lang-rtl":false,"country-PL":true,"currency-PLN":true,"layout-left-column":true,"page-category":true,"tax-display-enabled":true,"category-id-4":true,"category-Piwo Rzemie\u015blnicze":true,"category-id-parent-2":true,"category-depth-level-2":true},"admin_notifications":[]},"shop":{"name":"Funky Shop","logo":"https:\/\/funkyshop.pl\/img\/logo-1743421189.jpg","stores_icon":"https:\/\/funkyshop.pl\/img\/logo_stores.png","favicon":"https:\/\/funkyshop.pl\/img\/favicon.ico"},"urls":{"base_url":"https:\/\/funkyshop.pl\/","current_url":"https:\/\/funkyshop.pl\/pl\/4-piwo-rzemieslnicze","shop_domain_url":"https:\/\/funkyshop.pl","img_ps_url":"https:\/\/funkyshop.pl\/img\/","img_cat_url":"https:\/\/funkyshop.pl\/img\/c\/","img_lang_url":"https:\/\/funkyshop.pl\/img\/l\/","img_prod_url":"https:\/\/funkyshop.pl\/img\/p\/","img_manu_url":"https:\/\/funkyshop.pl\/img\/m\/","img_sup_url":"https:\/\/funkyshop.pl\/img\/su\/","img_ship_url":"https:\/\/funkyshop.pl\/img\/s\/","img_store_url":"https:\/\/funkyshop.pl\/img\/st\/","img_col_url":"https:\/\/funkyshop.pl\/img\/co\/","img_url":"https:\/\/funkyshop.pl\/themes\/leo_clark\/assets\/img\/","css_url":"https:\/\/funkyshop.pl\/themes\/leo_clark\/assets\/css\/","js_url":"https:\/\/funkyshop.pl\/themes\/leo_clark\/assets\/js\/","pic_url":"https:\/\/funkyshop.pl\/upload\/","pages":{"address":"https:\/\/funkyshop.pl\/pl\/adres","addresses":"https:\/\/funkyshop.pl\/pl\/adresy","authentication":"https:\/\/funkyshop.pl\/pl\/logowanie","cart":"https:\/\/funkyshop.pl\/pl\/koszyk","category":"https:\/\/funkyshop.pl\/pl\/index.php?controller=category","cms":"https:\/\/funkyshop.pl\/pl\/index.php?controller=cms","contact":"https:\/\/funkyshop.pl\/pl\/kontakt","discount":"https:\/\/funkyshop.pl\/pl\/rabaty","guest_tracking":"https:\/\/funkyshop.pl\/pl\/sledzenie-zamowien-gosci","history":"https:\/\/funkyshop.pl\/pl\/historia-zamowien","identity":"https:\/\/funkyshop.pl\/pl\/dane-osobiste","index":"https:\/\/funkyshop.pl\/pl\/","my_account":"https:\/\/funkyshop.pl\/pl\/moje-konto","order_confirmation":"https:\/\/funkyshop.pl\/pl\/potwierdzenie-zamowienia","order_detail":"https:\/\/funkyshop.pl\/pl\/index.php?controller=order-detail","order_follow":"https:\/\/funkyshop.pl\/pl\/sledzenie-zamowienia","order":"https:\/\/funkyshop.pl\/pl\/zamowienie","order_return":"https:\/\/funkyshop.pl\/pl\/index.php?controller=order-return","order_slip":"https:\/\/funkyshop.pl\/pl\/potwierdzenie-zwrotu","pagenotfound":"https:\/\/funkyshop.pl\/pl\/nie-znaleziono-strony","password":"https:\/\/funkyshop.pl\/pl\/odzyskiwanie-hasla","pdf_invoice":"https:\/\/funkyshop.pl\/pl\/index.php?controller=pdf-invoice","pdf_order_return":"https:\/\/funkyshop.pl\/pl\/index.php?controller=pdf-order-return","pdf_order_slip":"https:\/\/funkyshop.pl\/pl\/index.php?controller=pdf-order-slip","prices_drop":"https:\/\/funkyshop.pl\/pl\/promocje","product":"https:\/\/funkyshop.pl\/pl\/index.php?controller=product","search":"https:\/\/funkyshop.pl\/pl\/szukaj","sitemap":"https:\/\/funkyshop.pl\/pl\/mapa-strony","stores":"https:\/\/funkyshop.pl\/pl\/nasze-sklepy","supplier":"https:\/\/funkyshop.pl\/pl\/dostawcy","register":"https:\/\/funkyshop.pl\/pl\/logowanie?create_account=1","order_login":"https:\/\/funkyshop.pl\/pl\/zamowienie?login=1"},"alternative_langs":{"pl":"https:\/\/funkyshop.pl\/pl\/4-piwo-rzemieslnicze","en-us":"https:\/\/funkyshop.pl\/en\/4-craft-beer"},"theme_assets":"\/themes\/leo_clark\/assets\/","actions":{"logout":"https:\/\/funkyshop.pl\/pl\/?mylogout="},"no_picture_image":{"bySize":{"small_default":{"url":"https:\/\/funkyshop.pl\/img\/p\/pl-default-small_default.jpg","width":98,"height":98},"cart_default":{"url":"https:\/\/funkyshop.pl\/img\/p\/pl-default-cart_default.jpg","width":125,"height":125},"medium_default":{"url":"https:\/\/funkyshop.pl\/img\/p\/pl-default-medium_default.jpg","width":400,"height":400},"home_default":{"url":"https:\/\/funkyshop.pl\/img\/p\/pl-default-home_default.jpg","width":500,"height":500},"large_default":{"url":"https:\/\/funkyshop.pl\/img\/p\/pl-default-large_default.jpg","width":1000,"height":1000}},"small":{"url":"https:\/\/funkyshop.pl\/img\/p\/pl-default-small_default.jpg","width":98,"height":98},"medium":{"url":"https:\/\/funkyshop.pl\/img\/p\/pl-default-medium_default.jpg","width":400,"height":400},"large":{"url":"https:\/\/funkyshop.pl\/img\/p\/pl-default-large_default.jpg","width":1000,"height":1000},"legend":""}},"configuration":{"display_taxes_label":true,"display_prices_tax_incl":true,"is_catalog":false,"show_prices":true,"opt_in":{"partner":false},"quantity_discount":{"type":"discount","label":"Rabat Jednostkowy"},"voucher_enabled":1,"return_enabled":1},"field_required":[],"breadcrumb":{"links":[{"title":"G\u0142\u00f3wna","url":"https:\/\/funkyshop.pl\/pl\/"},{"title":"Piwo Rzemie\u015blnicze","url":"https:\/\/funkyshop.pl\/pl\/4-piwo-rzemieslnicze"}],"count":2},"link":{"protocol_link":"https:\/\/","protocol_content":"https:\/\/"},"time":1782821786,"static_token":"b866420ae8aaf943d02267723ab32727","token":"74f973185b85b6419d9aadd1a0b68fe9","debug":false};
+        var psemailsubscription_subscription = "https:\/\/funkyshop.pl\/pl\/module\/ps_emailsubscription\/subscription";
+        var psr_icon_color = "#F19D76";
+        var recaptcha = {"newsletter":"1","contact":"1","resetpw":"1","login":"1","register":"1"};
+        var recaptchatoken = "6LfV7hsrAAAAAFM2myNNgqZuypFI573dG2Jvvvju";
+        var review_error = "Podczas przetwarzania \u017c\u0105dania wyst\u0105pi\u0142 b\u0142\u0105d. Prosz\u0119 spr\u00f3buj ponownie";
+        var show_popup = 0;
+        var text_no_product = "Brak produkt\u00f3w";
+        var text_results_count = "results";
+        var type_dropdown_defaultcart = "dropdown";
+        var type_flycart_effect = "fade";
+        var width_cart_item = "265";
+        var wishlist_add = "Produkt zosta\u0142 pomy\u015blnie dodany do Twojej listy \u017cycze\u0144\t";
+        var wishlist_cancel_txt = "Anuluj";
+        var wishlist_confirm_del_txt = "Usun\u0105\u0107 wybrany element?";
+        var wishlist_del_default_txt = "Nie mo\u017cna usun\u0105\u0107 domy\u015blnej listy \u017cycze\u0144";
+        var wishlist_email_txt = "E-mail";
+        var wishlist_loggin_required = "Musisz by\u0107 zalogowany, aby zarz\u0105dza\u0107 swoj\u0105 list\u0105 \u017cycze\u0144\t";
+        var wishlist_ok_txt = "Ok";
+        var wishlist_quantity_required = "Musisz poda\u0107 ilo\u015b\u0107";
+        var wishlist_remove = "Produkt zosta\u0142 pomy\u015blnie usuni\u0119ty z Twojej listy \u017cycze\u0144";
+        var wishlist_reset_txt = "Resetuj";
+        var wishlist_send_txt = "Wy\u015blij";
+        var wishlist_send_wishlist_txt = "Wy\u015blij list\u0119 \u017cycze\u0144";
+        var wishlist_url = "https:\/\/funkyshop.pl\/pl\/module\/leofeature\/mywishlist";
+        var wishlist_viewwishlist = "Zobacz swoj\u0105 list\u0119 \u017cycze\u0144";
+      </script>
+<script type="text/javascript">
+	var choosefile_text = "Wybierz plik";
+	var turnoff_popup_text = "Nie pokazuj więcej tego wyskakującego okienka";
+	
+	var size_item_quickview = 82;
+	var style_scroll_quickview = 'vertical';
+	
+	var size_item_page = 113;
+	var style_scroll_page = 'horizontal';
+	
+	var size_item_quickview_attr = 101;	
+	var style_scroll_quickview_attr = 'vertical';
+	
+	var size_item_popup = 160;
+	var style_scroll_popup = 'vertical';
+</script>  <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazy/1.7.10/jquery.lazy.min.js"></script>
+  <script async="" src="https://access.eye-able.com/configs/funkyshop.pl.js"></script>
+
+  
+    <script type="text/javascript">
+        (function(c,l,a,r,i,t,y){
+            c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+            t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+            y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+        })(window, document, "clarity", "script", "x0m7ny811l");
+    </script>
+  
+  
+
+
+
+  
+<script>
+    var x13pricehistory_ajax_url = 'https://funkyshop.pl/pl/module/x13pricehistory/ajax';
+    var x13pricehistory_ajax_token = 'b866420ae8aaf943d02267723ab32727';
+</script>
+
+<!-- START > PM Google Analytycs 4.0 1.6.x and 1.7.x Module -->
+<script async="" data-keepinline="true" src="https://www.googletagmanager.com/gtag/js?id=G-ZKT34BH6DS"></script>
+
+
+<script>
+	window.dataLayer = window.dataLayer || [];
+	function gtag(){dataLayer.push(arguments);}
+	gtag('js', new Date());
+
+	gtag('config', 'G-ZKT34BH6DS', {'send_page_view': true});
+	gtag('set', {currency: 'PLN'});
+	gtag('set', {country: 'PL'});
+	</script>
+
+
+<!-- END > PM Google Analytycs 4.0 1.6.x and 1.7.x Module -->
+<style>
+  :root {
+    --x13gpsr-color-link: #24b9d7;
+    --x13gpsr-color-tab: #24b9d7;
+  }
+</style><script type="text/javascript">
+    var bant_extra_price_url = 'https://funkyshop.pl/pl/module/bantrecyclingdeposit/price';
+    var bant_er_id = '3279';
+    var bant_er_legacy_mode = 'false';
+</script>
+<!-- emarketing start -->
+
+
+
+
+<!-- emarketing end --><!-- @file modules\appagebuilder\views\templates\hook\header -->
+
+<script>
+	/**
+	 * List functions will run when document.ready()
+	 */
+	var ap_list_functions = [];
+	/**
+	 * List functions will run when window.load()
+	 */
+	var ap_list_functions_loaded = [];
+
+	/**
+	 * List functions will run when document.ready() for theme
+	 */
+
+	var products_list_functions = [];
+</script>
+
+
+<script type="text/javascript">
+	var leoOption = {
+		category_qty:1,
+		product_list_image:0,
+		product_one_img:1,
+		productCdown: 1,
+		productColor: 0,
+		homeWidth: 500,
+		homeheight: 500,
+	}
+
+	ap_list_functions.push(function(){
+		if (typeof $.LeoCustomAjax !== "undefined" && $.isFunction($.LeoCustomAjax)) {
+			var leoCustomAjax = new $.LeoCustomAjax();
+			leoCustomAjax.processAjax();
+		}
+	});
+</script>
+<script type="text/javascript">
+	
+	var FancyboxI18nClose = "Zamknij";
+	var FancyboxI18nNext = "Następny";
+	var FancyboxI18nPrev = "Poprzedni";
+	var current_link = "http://funkyshop.pl/pl/";		
+	var currentURL = window.location;
+	currentURL = String(currentURL);
+	currentURL = currentURL.replace("https://","").replace("http://","").replace("www.","").replace( /#\w*/, "" );
+	current_link = current_link.replace("https://","").replace("http://","").replace("www.","");
+	var text_warning_select_txt = "Wybierz pozycje do usunięcia";
+	var text_confirm_remove_txt = "Na pewno chcesz usunąć pozycje?";
+	var close_bt_txt = "Zamknij";
+	var list_menu = [];
+	var list_menu_tmp = {};
+	var list_tab = [];
+	var isHomeMenu = 0;
+	
+</script><script>
+    window.dataLayer = window.dataLayer || [];
+
+    function gtag() {
+        window.dataLayer.push(arguments);
+    }
+        gtag('consent', 'default', {
+        'functionality_storage': 'denied',
+        'analytics_storage': 'denied',
+        'ad_personalization': 'denied',
+        'ad_storage': 'denied',
+        'ad_user_data': 'denied',
+        'personalization_storage': 'denied',
+        'security_storage': 'denied',
+        'wait_for_update': 1000
+    });
+    gtag('set', 'url_passthrough', false);
+    gtag('set', 'ads_data_redaction', true);
+</script>
+
+
+
+
+
+    
+  <script async="" src="https://access.eye-able.com/configs/funkyshop.pl/default.js"></script><script async="" src="https://access.eye-able.com/access/eyeAbleAccess.js"></script><style type="text/css">.fancybox-margin{margin-right:0px;}</style><style type="text/css" data-fbcssmodules="css:fb.css.base css:fb.css.dialog css:fb.css.iframewidget">.fb_hidden{position:absolute;top:-10000px;z-index:10001}.fb_reposition{overflow:hidden;position:relative}.fb_invisible{display:none}.fb_reset{background:none;border:0px;border-spacing:0;color:#000;cursor:auto;direction:ltr;font-family:lucida grande,tahoma,verdana,arial,sans-serif;font-size:11px;font-style:normal;font-variant:normal;font-weight:400;letter-spacing:normal;line-height:1;margin:0;overflow:visible;padding:0;text-align:left;text-decoration:none;text-indent:0;text-shadow:none;text-transform:none;visibility:visible;white-space:normal;word-spacing:normal}.fb_reset>div{overflow:hidden}@keyframes fb_transform{0%{opacity:0;transform:scale(.95)}to{opacity:1;transform:scale(1)}}.fb_animate{animation:fb_transform .3s forwards}
+
+.fb_dialog{background:#525252b3;position:absolute;top:-10000px;z-index:10001}.fb_dialog_advanced{border-radius:8px;padding:10px}.fb_dialog_content{background:#fff;color:#373737}.fb_dialog_close_icon{background:url(https://connect.facebook.net/rsrc.php/v4/yq/r/IE9JII6Z1Ys.png) no-repeat scroll 0 0 transparent;cursor:pointer;display:block;height:15px;position:absolute;right:18px;top:17px;width:15px}.fb_dialog_mobile .fb_dialog_close_icon{left:5px;right:auto;top:5px}.fb_dialog_padding{background-color:transparent;position:absolute;width:1px;z-index:-1}.fb_dialog_close_icon:hover{background:url(https://connect.facebook.net/rsrc.php/v4/yq/r/IE9JII6Z1Ys.png) no-repeat scroll 0 -15px transparent}.fb_dialog_close_icon:active{background:url(https://connect.facebook.net/rsrc.php/v4/yq/r/IE9JII6Z1Ys.png) no-repeat scroll 0 -30px transparent}.fb_dialog_iframe{line-height:0}.fb_dialog_content .dialog_title{background:#6d84b4;border:1px solid #365899;color:#fff;font-size:14px;font-weight:700;margin:0}.fb_dialog_content .dialog_title>span{background:url(https://connect.facebook.net/rsrc.php/v4/yd/r/Cou7n-nqK52.gif) no-repeat 5px 50%;float:left;padding:5px 0 7px 26px}body.fb_hidden{height:100%;left:0;margin:0;overflow:visible;position:absolute;top:-10000px;transform:none;width:100%}.fb_dialog.fb_dialog_mobile.loading{background:url(https://connect.facebook.net/rsrc.php/v4/ya/r/3rhSv5V8j3o.gif) #fff no-repeat 50% 50%;min-height:100%;min-width:100%;overflow:hidden;position:absolute;top:0;z-index:10001}.fb_dialog.fb_dialog_mobile.loading.centered{background:none;height:auto;min-height:initial;min-width:initial;width:auto}.fb_dialog.fb_dialog_mobile.loading.centered #fb_dialog_loader_spinner{width:100%}.fb_dialog.fb_dialog_mobile.loading.centered .fb_dialog_content{background:none}.loading.centered #fb_dialog_loader_close{clear:both;color:#fff;display:block;font-size:18px;padding-top:20px}#fb-root #fb_dialog_ipad_overlay{background:#0006;inset:0;min-height:100%;position:absolute;width:100%;z-index:10000}#fb-root #fb_dialog_ipad_overlay.hidden{display:none}.fb_dialog.fb_dialog_mobile.loading iframe{visibility:hidden}.fb_dialog_mobile .fb_dialog_iframe{position:sticky;top:0}.fb_dialog_content .dialog_header{background:linear-gradient(from(#738aba),to(#2c4987));border-bottom:1px solid;border-color:#043b87;box-shadow:#fff 0 1px 1px -1px inset;color:#fff;font:700 14px Helvetica,sans-serif;text-overflow:ellipsis;text-shadow:rgba(0,30,84,.296875) 0px -1px 0px;vertical-align:middle;white-space:nowrap}.fb_dialog_content .dialog_header table{height:43px;width:100%}.fb_dialog_content .dialog_header td.header_left{font-size:12px;padding-left:5px;vertical-align:middle;width:60px}.fb_dialog_content .dialog_header td.header_right{font-size:12px;padding-right:5px;vertical-align:middle;width:60px}.fb_dialog_content .touchable_button{background:linear-gradient(from(#4267B2),to(#2a4887));background-clip:padding-box;border:1px solid #29487d;border-radius:3px;display:inline-block;line-height:18px;margin-top:3px;max-width:85px;padding:4px 12px;position:relative}.fb_dialog_content .dialog_header .touchable_button input{background:none;border:none;color:#fff;font:700 12px Helvetica,sans-serif;margin:2px -12px;padding:2px 6px 3px;text-shadow:rgba(0,30,84,.296875) 0px -1px 0px}.fb_dialog_content .dialog_header .header_center{color:#fff;font-size:16px;font-weight:700;line-height:18px;text-align:center;vertical-align:middle}.fb_dialog_content .dialog_content{background:url(https://connect.facebook.net/rsrc.php/v4/y9/r/jKEcVPZFk-2.gif) no-repeat 50% 50%;border:1px solid #4A4A4A;border-bottom:0;border-top:0;height:150px}.fb_dialog_content .dialog_footer{background:#f5f6f7;border:1px solid #4A4A4A;border-top-color:#ccc;height:40px}#fb_dialog_loader_close{float:left}.fb_dialog.fb_dialog_mobile .fb_dialog_close_icon{visibility:hidden}#fb_dialog_loader_spinner{animation:rotateSpinner 1.2s linear infinite;background-color:transparent;background-image:url(https://connect.facebook.net/rsrc.php/v4/y2/r/onuUJj0tCqE.png);background-position:50% 50%;background-repeat:no-repeat;height:24px;width:24px}@keyframes rotateSpinner{0%{transform:rotate(0)}to{transform:rotate(360deg)}}
+
+.fb_iframe_widget{display:inline-block;position:relative}.fb_iframe_widget span{display:inline-block;position:relative;text-align:justify}.fb_iframe_widget iframe{position:absolute}.fb_iframe_widget_fluid_desktop,.fb_iframe_widget_fluid_desktop span,.fb_iframe_widget_fluid_desktop iframe{max-width:100%}.fb_iframe_widget_fluid_desktop iframe{min-width:220px;position:relative}.fb_iframe_widget_lift{z-index:1}.fb_iframe_widget_fluid{display:inline}.fb_iframe_widget_fluid span{width:100%}
+</style></head>
+
+  <body id="category" class="lang-pl country-pl currency-pln layout-left-column page-category tax-display-enabled category-id-4 category-piwo-rzemieslnicze category-id-parent-2 category-depth-level-2 fullwidth" style="overflow: hidden;">
+
+    
+          <!-- Load Facebook SDK for JavaScript -->
+<!-- Load Facebook SDK for JavaScript -->
+
+    <!-- PM Google Analytycs 4 Pro - EVENTS CODE FOOTER -->
+<script type="text/javascript">
+
+	
+		console.log('Fired up event GA4: view_item_list > Category products list page');
+		gtag('event', 'view_item_list', {
+			items: [
+								{
+					item_id: '5849',
+					item_name: 'Kiełbasa Kolega (x Hop Hooligans) 500ml',
+					coupon: '',
+					discount: 0,
+					index: 0,
+					item_list_name: 'Piwo Rzemieślnicze',
+					item_list_id: 'category',
+					affiliation: '',
+					item_brand: 'Ziemia Obiecana',
+					item_category: 'Piwo Rzemieślnicze',
+																									item_variant: '',
+					price: 30,
+					currency: 'PLN',
+					quantity: 1
+				},
+								{
+					item_id: '5848',
+					item_name: 'Bubu 500ml',
+					coupon: '',
+					discount: 0,
+					index: 1,
+					item_list_name: 'Piwo Rzemieślnicze',
+					item_list_id: 'category',
+					affiliation: '',
+					item_brand: 'Ziemia Obiecana',
+					item_category: 'Piwo Rzemieślnicze',
+																									item_variant: '',
+					price: 19.5,
+					currency: 'PLN',
+					quantity: 1
+				},
+								{
+					item_id: '5846',
+					item_name: 'Młot 2026 500ml',
+					coupon: '',
+					discount: -0,
+					index: 2,
+					item_list_name: 'Piwo Rzemieślnicze',
+					item_list_id: 'category',
+					affiliation: '',
+					item_brand: 'Ziemia Obiecana',
+					item_category: 'Piwo Rzemieślnicze',
+																									item_variant: '',
+					price: 19,
+					currency: 'PLN',
+					quantity: 1
+				},
+								{
+					item_id: '5847',
+					item_name: 'Uparcie I Skrycie 500ml',
+					coupon: '',
+					discount: 0,
+					index: 3,
+					item_list_name: 'Piwo Rzemieślnicze',
+					item_list_id: 'category',
+					affiliation: '',
+					item_brand: 'Ziemia Obiecana',
+					item_category: 'Piwo Rzemieślnicze',
+																									item_variant: '',
+					price: 18,
+					currency: 'PLN',
+					quantity: 1
+				},
+								{
+					item_id: '5845',
+					item_name: 'Libacja Na Skwerku 2026 500ml',
+					coupon: '',
+					discount: 0,
+					index: 4,
+					item_list_name: 'Piwo Rzemieślnicze',
+					item_list_id: 'category',
+					affiliation: '',
+					item_brand: 'Ziemia Obiecana',
+					item_category: 'Piwo Rzemieślnicze',
+																									item_variant: '',
+					price: 19.5,
+					currency: 'PLN',
+					quantity: 1
+				},
+								{
+					item_id: '5840',
+					item_name: 'Nightfall 500ml',
+					coupon: '',
+					discount: 0,
+					index: 5,
+					item_list_name: 'Piwo Rzemieślnicze',
+					item_list_id: 'category',
+					affiliation: '',
+					item_brand: 'Moon Lark',
+					item_category: 'Piwo Rzemieślnicze',
+																									item_variant: '',
+					price: 12.5,
+					currency: 'PLN',
+					quantity: 1
+				},
+								{
+					item_id: '5841',
+					item_name: 'Peak. 500ml',
+					coupon: '',
+					discount: 0,
+					index: 6,
+					item_list_name: 'Piwo Rzemieślnicze',
+					item_list_id: 'category',
+					affiliation: '',
+					item_brand: 'Moon Lark',
+					item_category: 'Piwo Rzemieślnicze',
+																									item_variant: '',
+					price: 17,
+					currency: 'PLN',
+					quantity: 1
+				},
+								{
+					item_id: '5842',
+					item_name: 'Gravity. 500ml',
+					coupon: '',
+					discount: 0,
+					index: 7,
+					item_list_name: 'Piwo Rzemieślnicze',
+					item_list_id: 'category',
+					affiliation: '',
+					item_brand: 'Moon Lark',
+					item_category: 'Piwo Rzemieślnicze',
+																									item_variant: '',
+					price: 18,
+					currency: 'PLN',
+					quantity: 1
+				},
+								{
+					item_id: '5844',
+					item_name: 'Marine. 500ml',
+					coupon: '',
+					discount: 0,
+					index: 8,
+					item_list_name: 'Piwo Rzemieślnicze',
+					item_list_id: 'category',
+					affiliation: '',
+					item_brand: 'Moon Lark',
+					item_category: 'Piwo Rzemieślnicze',
+																									item_variant: '',
+					price: 17,
+					currency: 'PLN',
+					quantity: 1
+				},
+								{
+					item_id: '2931',
+					item_name: 'Shelter. 500ml',
+					coupon: '',
+					discount: 0,
+					index: 9,
+					item_list_name: 'Piwo Rzemieślnicze',
+					item_list_id: 'category',
+					affiliation: '',
+					item_brand: 'Moon Lark',
+					item_category: 'Piwo Rzemieślnicze',
+																									item_variant: '',
+					price: 12,
+					currency: 'PLN',
+					quantity: 1
+				},
+								{
+					item_id: '3000',
+					item_name: 'Bench. 500ml',
+					coupon: '',
+					discount: 0,
+					index: 10,
+					item_list_name: 'Piwo Rzemieślnicze',
+					item_list_id: 'category',
+					affiliation: '',
+					item_brand: 'Moon Lark',
+					item_category: 'Piwo Rzemieślnicze',
+																									item_variant: '',
+					price: 12.5,
+					currency: 'PLN',
+					quantity: 1
+				},
+								{
+					item_id: '2634',
+					item_name: 'Prime 500ml',
+					coupon: '',
+					discount: 0,
+					index: 11,
+					item_list_name: 'Piwo Rzemieślnicze',
+					item_list_id: 'category',
+					affiliation: '',
+					item_brand: 'Moon Lark',
+					item_category: 'Piwo Rzemieślnicze',
+																									item_variant: '',
+					price: 16,
+					currency: 'PLN',
+					quantity: 1
+				},
+								{
+					item_id: '2930',
+					item_name: 'Raise 500ml',
+					coupon: '',
+					discount: 0,
+					index: 12,
+					item_list_name: 'Piwo Rzemieślnicze',
+					item_list_id: 'category',
+					affiliation: '',
+					item_brand: 'Moon Lark',
+					item_category: 'Piwo Rzemieślnicze',
+																									item_variant: '',
+					price: 12,
+					currency: 'PLN',
+					quantity: 1
+				},
+								{
+					item_id: '4943',
+					item_name: 'Affection (2026) 330ml',
+					coupon: '',
+					discount: 0,
+					index: 13,
+					item_list_name: 'Piwo Rzemieślnicze',
+					item_list_id: 'category',
+					affiliation: '',
+					item_brand: 'Pinta Barrel Brewing',
+					item_category: 'Piwo Rzemieślnicze',
+																									item_variant: '',
+					price: 52,
+					currency: 'PLN',
+					quantity: 1
+				},
+								{
+					item_id: '3868',
+					item_name: 'Liberty (2026) 330ml',
+					coupon: '',
+					discount: 0,
+					index: 14,
+					item_list_name: 'Piwo Rzemieślnicze',
+					item_list_id: 'category',
+					affiliation: '',
+					item_brand: 'Pinta Barrel Brewing',
+					item_category: 'Piwo Rzemieślnicze',
+																									item_variant: '',
+					price: 52,
+					currency: 'PLN',
+					quantity: 1
+				},
+								{
+					item_id: '5836',
+					item_name: 'Hazy Discovery Setubal 500ml',
+					coupon: '',
+					discount: 0,
+					index: 15,
+					item_list_name: 'Piwo Rzemieślnicze',
+					item_list_id: 'category',
+					affiliation: '',
+					item_brand: 'PINTA',
+					item_category: 'Piwo Rzemieślnicze',
+																									item_variant: '',
+					price: 19.5,
+					currency: 'PLN',
+					quantity: 1
+				},
+								{
+					item_id: '5837',
+					item_name: 'Perfect Piece (x Other Half) 500ml',
+					coupon: '',
+					discount: 0,
+					index: 16,
+					item_list_name: 'Piwo Rzemieślnicze',
+					item_list_id: 'category',
+					affiliation: '',
+					item_brand: 'PINTA',
+					item_category: 'Piwo Rzemieślnicze',
+																									item_variant: '',
+					price: 21.5,
+					currency: 'PLN',
+					quantity: 1
+				},
+								{
+					item_id: '5838',
+					item_name: 'XIV 330ml',
+					coupon: '',
+					discount: 0,
+					index: 17,
+					item_list_name: 'Piwo Rzemieślnicze',
+					item_list_id: 'category',
+					affiliation: '',
+					item_brand: 'Artezan',
+					item_category: 'Piwo Rzemieślnicze',
+																									item_variant: '',
+					price: 52,
+					currency: 'PLN',
+					quantity: 1
+				},
+								{
+					item_id: '5839',
+					item_name: 'Samiec Alfa Bananas &amp; Chocolate Foster 330ml',
+					coupon: '',
+					discount: 0,
+					index: 18,
+					item_list_name: 'Piwo Rzemieślnicze',
+					item_list_id: 'category',
+					affiliation: '',
+					item_brand: 'Artezan',
+					item_category: 'Piwo Rzemieślnicze',
+																									item_variant: '',
+					price: 52,
+					currency: 'PLN',
+					quantity: 1
+				},
+								{
+					item_id: '5747',
+					item_name: 'Hazy Discovery Sunnyside 500ml',
+					coupon: '',
+					discount: -0,
+					index: 19,
+					item_list_name: 'Piwo Rzemieślnicze',
+					item_list_id: 'category',
+					affiliation: '',
+					item_brand: 'PINTA',
+					item_category: 'Piwo Rzemieślnicze',
+																									item_variant: '',
+					price: 19,
+					currency: 'PLN',
+					quantity: 1
+				},
+								{
+					item_id: '5746',
+					item_name: 'Hazy Discovery Groningen 500ml',
+					coupon: '',
+					discount: -0,
+					index: 20,
+					item_list_name: 'Piwo Rzemieślnicze',
+					item_list_id: 'category',
+					affiliation: '',
+					item_brand: 'PINTA',
+					item_category: 'Piwo Rzemieślnicze',
+																									item_variant: '',
+					price: 19,
+					currency: 'PLN',
+					quantity: 1
+				},
+								{
+					item_id: '5810',
+					item_name: 'Gelato XTREME: It Floats! (x White Dog) 500ml',
+					coupon: '',
+					discount: 0,
+					index: 21,
+					item_list_name: 'Piwo Rzemieślnicze',
+					item_list_id: 'category',
+					affiliation: '',
+					item_brand: 'Funky Fluid',
+					item_category: 'Piwo Rzemieślnicze',
+																									item_variant: '',
+					price: 30,
+					currency: 'PLN',
+					quantity: 1
+				},
+								{
+					item_id: '5835',
+					item_name: 'Lervig Rackhouse Barrel Aged Set 4x375ml',
+					coupon: '',
+					discount: 18,
+					index: 22,
+					item_list_name: 'Piwo Rzemieślnicze',
+					item_list_id: 'category',
+					affiliation: '',
+					item_brand: 'LERVIG',
+					item_category: 'Piwo Rzemieślnicze',
+																									item_variant: '',
+					price: 342,
+					currency: 'PLN',
+					quantity: 1
+				},
+								{
+					item_id: '5811',
+					item_name: 'Gelato Week \&#039;26 Set (4 puszki 500ml)',
+					coupon: '',
+					discount: 5,
+					index: 23,
+					item_list_name: 'Piwo Rzemieślnicze',
+					item_list_id: 'category',
+					affiliation: '',
+					item_brand: 'Funky Fluid',
+					item_category: 'Piwo Rzemieślnicze',
+																									item_variant: '',
+					price: 95,
+					currency: 'PLN',
+					quantity: 1
+				},
+							],
+			item_list_name: 'Piwo Rzemieślnicze',
+			item_list_id: 'category'
+		});
+
+
+	
+	
+</script>
+<!-- PM Google Analytycs 4 Pro - EVENTS CODE FOOTER -->
+
+    
+
+    <main id="page">
+      
+              
+      <header id="header">
+        <div class="header-container">
+          
+            
+  <div class="header-banner">
+          <div class="container">
+              <div class="inner"><!--
+* 2007-2018 PrestaShop
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+* @author    PrestaShop SA <contact@prestashop.com>
+* @copyright 2007-2018 PrestaShop SA
+* @license   http://addons.prestashop.com/en/content/12-terms-and-conditions-of-use
+* International Registered Trademark & Property of PrestaShop SA
+-->
+<link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet" type="text/css" media="all">
+<link href="https://fonts.googleapis.com/css?family=Hind" rel="stylesheet" type="text/css" media="all">
+<link href="https://fonts.googleapis.com/css?family=Maven+Pro" rel="stylesheet" type="text/css" media="all">
+<link href="https://fonts.googleapis.com/css?family=Noto+Serif" rel="stylesheet" type="text/css" media="all">
+<link href="https://fonts.googleapis.com/css?family=Bitter" rel="stylesheet" type="text/css" media="all">
+<link href="https://fonts.googleapis.com/css?family=Forum" rel="stylesheet" type="text/css" media="all">
+
+<div id="psagechecker_block" class="preload">
+    <div id="psagechecker-lightbox" class="lightbox">
+        <div class="lightbox-content">
+            <div style="height:100%">
+                                <div class="age_verify_text_content">
+                    <div class="age_verify" style="font-family: Roboto !important;">
+                        <p>Dostęp do tej witryny nie jest udzielany osobom niepełnoletnim.</p>
+                    </div>
+                    <div class="blockAgeVerify">
+                        <div class="custom_msg_age_verify">
+                            <p>Aby uzyskać dostęp do sklepu potwierdź, że jesteś osobą pełnoletnią.</p>
+                        </div>
+                                                    <div class="age_verify_buttons">
+                                <button id="deny_button" class="btn btn_deny">Nie mam 18 lat</button>
+                                <button id="confirm_button" class="btn btn_confirm">Mam 18 lat, wchodzę</button>
+                            </div>
+                                            </div>
+                </div>
+                <div class="deny_msg_age_verify psagechecker-hide">
+                    <p>Przepraszamy, nie skończyłeś 18 lat, więc nie możesz uzyskać dostępu do naszej strony internetowej.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div id="overlay" class=""></div>
+</div>
+<style>
+
+    #psagechecker-lightbox{
+        background-color: #d7d7d7 !important;
+    }
+    #psagechecker-lightbox, #psagechecker-lightbox *{
+        font-family: Roboto !important;
+    }
+
+    .btn_deny{
+        background-color: #686868 !important;
+        color: #ffffff !important;
+    }
+    .btn_confirm{
+        background-color: #ec008c !important;
+        color: #ffffff !important;
+    }
+    #psagechecker_block .lightbox{
+        width : 500px ;
+        height : 400px !important;
+    }
+    #psagechecker_block #overlay {
+        background-color: rgba(0,0,0,0.7);
+        height: 100%;
+        left: 0;
+        position: fixed;
+        top: 0;
+        width: 100%;
+        z-index: 9999;
+    }
+</style>
+
+<script>
+var display_popup = "1";
+var age_required = "18";
+</script>
+
+</div>
+          </div>
+        </div>
+
+
+
+  <nav class="header-nav">
+    <div class="topnav">
+              <div class="inner"></div>
+          </div>
+    <div class="bottomnav">
+              <div class="inner"><!-- @file modules\appagebuilder\views\templates\hook\ApRow -->
+<div class="wrapper" style="background: repeat-x bottom">
+
+<div class="container">
+    <div class="row box-navh1 ApRow  has-bg bg-fullwidth-container" style="margin-top: 25px;margin-bottom: 50px;">
+                                            <!-- @file modules\appagebuilder\views\templates\hook\ApColumn -->
+<div class="col-xl-3 col-lg-12 col-md-12 col-sm-12 col-xs-12 col-sp-12 search-column ApColumn ">
+                    <!-- @file modules\appagebuilder\views\templates\hook\ApModule -->
+
+
+<!-- Block search module -->
+<div id="leo_search_block_top" class="block exclusive search-by-category">
+			<form method="get" action="https://funkyshop.pl/pl/index.php?controller=productsearch" id="leosearchtopbox" data-label-suggestion="Sugestia" data-search-for="Szukaj dla" data-in-category="w kategorii" data-products-for="Produkty dla" data-label-products="Produkty" data-view-all="Zobacz wszystkie">
+		<input type="hidden" name="fc" value="module">
+		<input type="hidden" name="module" value="leoproductsearch">
+		<input type="hidden" name="controller" value="productsearch">
+		<input type="hidden" name="txt_not_found" value="Nie znaleziono">
+                <input type="hidden" name="leoproductsearch_static_token" value="b866420ae8aaf943d02267723ab32727">
+		    			<div class="block_content clearfix leoproductsearch-content">
+					
+				<div class="list-cate-wrapper">
+					<input id="leosearchtop-cate-id" name="cate" value="" type="hidden">
+					<a href="javascript:void(0)" id="dropdownListCateTop" class="select-title" rel="nofollow" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+						<span>Wszystkie kategorie</span>
+						<i class="material-icons pull-xs-right">keyboard_arrow_down</i>
+					</a>
+					<div class="list-cate dropdown-menu" aria-labelledby="dropdownListCateTop">
+						<a href="#" data-cate-id="" data-cate-name="Wszystkie kategorie" class="cate-item active">Wszystkie kategorie</a>				
+						<a href="#" data-cate-id="2" data-cate-name="Funky Shop" class="cate-item cate-level-1">Funky Shop</a>
+						
+  <a href="#" data-cate-id="3" data-cate-name="Piwo Bezalkoholowe" class="cate-item cate-level-2">--Piwo Bezalkoholowe</a>
+  <a href="#" data-cate-id="14" data-cate-name="0%" class="cate-item cate-level-3">---0%</a>
+  <a href="#" data-cate-id="15" data-cate-name="Ponad 0,0%" class="cate-item cate-level-3">---Ponad 0,0%</a>
+  <a href="#" data-cate-id="4" data-cate-name="Piwo Rzemieślnicze" class="cate-item cate-level-2">--Piwo Rzemieślnicze</a>
+  <a href="#" data-cate-id="5" data-cate-name="Mocno chmielone" class="cate-item cate-level-3">---Mocno chmielone</a>
+  <a href="#" data-cate-id="6" data-cate-name="Ciemne" class="cate-item cate-level-3">---Ciemne</a>
+  <a href="#" data-cate-id="7" data-cate-name="Kwaśne/dzikie" class="cate-item cate-level-3">---Kwaśne/dzikie</a>
+  <a href="#" data-cate-id="9" data-cate-name="Owocowe" class="cate-item cate-level-3">---Owocowe</a>
+  <a href="#" data-cate-id="10" data-cate-name="Klasyczne" class="cate-item cate-level-3">---Klasyczne</a>
+  <a href="#" data-cate-id="11" data-cate-name="Vintage" class="cate-item cate-level-3">---Vintage</a>
+  <a href="#" data-cate-id="12" data-cate-name="Barrel aged" class="cate-item cate-level-3">---Barrel aged</a>
+  <a href="#" data-cate-id="19" data-cate-name="Cydr" class="cate-item cate-level-3">---Cydr</a>
+  <a href="#" data-cate-id="16" data-cate-name="Zestawy" class="cate-item cate-level-2">--Zestawy</a>
+  <a href="#" data-cate-id="17" data-cate-name="Szkło/Merch" class="cate-item cate-level-2">--Szkło/Merch</a>
+  <a href="#" data-cate-id="21" data-cate-name="Promo" class="cate-item cate-level-2">--Promo</a>
+  <a href="#" data-cate-id="23" data-cate-name="Browar miesiąca" class="cate-item cate-level-2">--Browar miesiąca</a>
+  
+					</div>
+				</div>
+						<div class="leoproductsearch-result">
+				<div class="leoproductsearch-loading cssload-speeding-wheel"></div>
+				<input class="search_query form-control grey ac_input" type="text" id="leo_search_query_top" name="search_query" data-content="" value="" placeholder="Szukaj" autocomplete="off">
+				<div class="ac_results lps_results"></div>
+			</div>
+			<button type="submit" id="leo_search_top_button" class="btn btn-default button button-small"><span><i class="material-icons search">search</i></span></button> 
+		</div>
+	</form>
+</div>
+<script type="text/javascript">
+	var blocksearch_type = 'top';
+</script>
+<!-- /Block search module -->
+
+    </div><!-- @file modules\appagebuilder\views\templates\hook\ApColumn -->
+<div class="col-xl-6 col-lg-12 col-md-12 col-sm-12 col-xs-12 col-sp-12 col-logo ApColumn ">
+                    <!-- @file modules\appagebuilder\views\templates\hook\ApGenCode -->
+
+	<div class="h-logo">    <a href="https://funkyshop.pl/">        <img class="img-fluid" src="https://funkyshop.pl/img/logo-1743421189.jpg" alt="Craft Beer Online">    </a></div>
+
+    </div><!-- @file modules\appagebuilder\views\templates\hook\ApColumn -->
+<div class="col-xl-3 col-lg-12 col-md-12 col-sm-12 col-xs-12 col-sp-12 right-icons ApColumn ">
+                    <!-- @file modules\appagebuilder\views\templates\hook\ApModule -->
+<!-- Block languages module -->
+	<!-- /Block languages module -->
+
+
+
+
+
+
+
+
+
+
+
+<div id="leo_block_top" class="popup-over e-scale float-md-right">
+    <a href="javascript:void(0)" data-toggle="dropdown" class="popup-title">
+    	<i class="material-icons">language</i>
+    	<span>Język</span>
+    </a>	    
+	<div class="popup-content">
+		<div class="row">
+			<div class="col-xs-12">
+				<div class="language-selector">
+					<span>Język:</span>
+					<ul class="link">
+										          	<li class="current">
+				            	<a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze" class="dropdown-item">
+				            		<img src="/img/l/1.jpg" alt="Polski" width="16" height="11">
+				            	</a>
+				          	</li>
+				        				          	<li>
+				            	<a href="https://funkyshop.pl/en/4-craft-beer" class="dropdown-item">
+				            		<img src="/img/l/3.jpg" alt="Angielski" width="16" height="11">
+				            	</a>
+				          	</li>
+				        					</ul>
+				</div>
+				<div class="currency-selector">
+					<span>Waluta:</span>
+					<ul class="link">
+										        	<li>
+				          		<a title="Euro" rel="nofollow" href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?SubmitCurrency=1&amp;id_currency=2" class="dropdown-item">EUR</a>
+				        	</li>
+				      					        	<li class="current">
+				          		<a title="Złoty polski" rel="nofollow" href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?SubmitCurrency=1&amp;id_currency=1" class="dropdown-item">PLN</a>
+				        	</li>
+				      						</ul>
+				</div>
+			</div>
+		</div>
+	</div>
+</div><!-- @file modules\appagebuilder\views\templates\hook\ApModule -->
+<div class="userinfo-selector dropdown js-dropdown popup-over">
+  <a href="javascript:void(0)" data-toggle="dropdown" class="popup-title" title="Konto">
+    <i class="material-icons">account_circle</i>
+    <span class="hidden-md-down">Moje konto</span>
+  </a>
+  <ul class="popup-content dropdown-menu user-info">
+          <li>
+        <a class="signin leo-quicklogin" data-enable-sociallogin="enable" data-type="popup" data-layout="login" href="javascript:void(0)" title="Zaloguj się na swoje konto klienta" rel="nofollow">
+          <i class="fa fa-lock"></i>
+          <span>Zaloguj się</span>
+        </a>
+      </li>
+            <li>
+        <a class="signup leo-quickregister" data-enable-sociallogin="enable" data-type="popup" data-layout="register" href="javascript:void(0)" title="Zaloguj się na swoje konto klienta" rel="nofollow">
+          <i class="fa fa-lock"></i>
+          <span>Zarejestruj się</span>
+        </a>
+      </li>
+    
+          </ul>
+</div><!-- @file modules\appagebuilder\views\templates\hook\ApGenCode -->
+
+	          <a class="ap-btn-wishlist" href="//funkyshop.pl/pl/module/leofeature/mywishlist" title="Lista życzeń">        <i class="fa fa-heart"></i>    <span class="ap-total-wishlist ap-total">0</span>      </a>    
+<!-- @file modules\appagebuilder\views\templates\hook\ApModule -->
+<div id="cart-block">
+  <div class="cart-preview inactive leo-blockcart show-leo-loading" data-refresh-url="//funkyshop.pl/pl/module/ps_shoppingcart/ajax">
+    <div class="header">
+              <i class="fa fa-shopping-cart"></i>
+        <span class="cart-products-count">0</span>
+        <span class="cart-total">0,00&nbsp;zł</span>
+              
+            <span class="current-weight" style="display: none;">0</span>
+
+      <custom class="cart-total-value" style="display: none;">0</custom>
+    </div>
+  <div class="cssload-piano" style="display: none;"><div class="cssload-rect1"></div><div class="cssload-rect2"></div><div class="cssload-rect3"></div></div></div>
+</div><!-- @file modules\appagebuilder\views\templates\hook\ApGenCode -->
+
+	<div class="custom-text-header" data-refresh-url="//dev.funkyshop.pl/pl/module/ps_shoppingcart/ajax">
+    <p class="free-shiping">
+        Do darmowej<br>paczki<br>w Polsce<br>brakuje:
+                                                        <custom class="convRate" style="display:none;">1</custom>
+            <span class="to-free-shiping">229.00</span>
+            <span class="header-sign">&nbsp;zł</span>
+            </p>
+                            <span class="max-package" style="display: none;">24</span>
+<span class="current-package-size" style="display: none;">Small</span>
+<span class="current-in-cart" style="display: none;">0</span>
+   <!-- <p class="one-package-weight">
+                    Paczka<br>pełna w
+                <span class="free-package">
+                                   0
+        </span><span class="header-sign">&nbsp;
+                        %</span>
+        </span>
+    </p> -->
+    <p class="current-package">
+                    Obecny<br>
+            rozmiar<br>
+            paczki
+        :
+        <span class="current-package-size">
+                                                Mała
+                                    </span>
+    </p>
+</div>
+
+
+    </div>            </div>
+</div>
+</div>
+        
+	<script>
+		ap_list_functions.push(function(){
+			$.stellar({horizontalScrolling:false}); 
+		});
+	</script>
+    
+    </div>
+          </div>
+  </nav>
+
+
+
+  <div class="header-top">
+          <div class="inner"><!-- @file modules\appagebuilder\views\templates\hook\ApRow -->
+<div class="wrapper">
+
+<div class="container">
+    <div class="row box-top ApRow  has-bg bg-boxed" style="background: no-repeat;" data-bg_data=" no-repeat">
+                                            <!-- @file modules\appagebuilder\views\templates\hook\ApColumn -->
+<div class="col-xl-12 col-lg-12 col-md-12 col-sm-12 col-xs-12 col-sp-12 col-menu ApColumn ">
+                    <!-- @file modules\appagebuilder\views\templates\hook\ApSlideShow -->
+<div id="memgamenu-form_9184166521380958" class="ApMegamenu">
+			                        <nav data-megamenu-id="9184166521380958" class="leo-megamenu cavas_menu navbar navbar-default enable-canvas " role="navigation">
+                            <!-- Brand and toggle get grouped for better mobile display -->
+                            <div class="navbar-header">
+                                    <button type="button" class="navbar-toggler hidden-lg-up" data-toggle="collapse" data-target=".megamenu-off-canvas-9184166521380958">
+                                            <span class="sr-only">Przełącz nawigację</span>
+                                            ☰
+                                            <!--
+                                            <span class="icon-bar"></span>
+                                            <span class="icon-bar"></span>
+                                            <span class="icon-bar"></span>
+                                            -->
+                                    </button>
+                            </div>
+                            <!-- Collect the nav links, forms, and other content for toggling -->
+                                                        <div class="leo-top-menu collapse navbar-toggleable-md megamenu-off-canvas megamenu-off-canvas-9184166521380958"><ul class="nav navbar-nav megamenu horizontal"><li data-menu-type="category" class="nav-item parent dropdown active">
+    <a class="nav-link dropdown-toggle has-category" data-toggle="dropdown" href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze" target="_self">
+
+                    
+                    <span class="menu-title">Piwo rzemieślnicze</span>
+                                        
+            </a>
+        <b class="caret"></b>
+            <div class="dropdown-sub dropdown-menu" style="width:600px">
+            <div class="dropdown-menu-inner">
+                                    <div class="row">
+                                                    <div class="mega-col col-md-4">
+                                <div class="mega-col-inner">
+                                    <div class="leo-widget" data-id_widget="1613641002">
+    <div class="widget-links">
+		<div class="widget-inner">	
+		<div id="tabs1118693385" class="panel-group">
+			<ul class="nav-links">
+				  
+					<li><a href="https://funkyshop.pl/pl/2-funky-shop">wszystkie produkty</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/brand/2-funky-fluid">Funky Fluid</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/nowe-produkty">Nowości</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/index.php?controller=pricesdrop">Promocje</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/16-zestawy">Zestawy</a></li>
+							</ul>
+		</div>
+	</div>
+    </div>
+</div>                                </div>
+                            </div>
+                                                    <div class="mega-col col-md-4">
+                                <div class="mega-col-inner">
+                                    <div class="leo-widget" data-id_widget="1613641017">
+    <div class="widget-links">
+		<div class="widget-inner">	
+		<div id="tabs427826493" class="panel-group">
+			<ul class="nav-links">
+				  
+					<li><a href="https://funkyshop.pl/pl/5-mocno-chmielone">Mocno chmielone</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/6-ciemne">Ciemne</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/7-kwasnedzikie">Kwaśne/dzikie</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/9-owocowe">Owocowe</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/10-klasyczne">Klasyczne</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/11-vintage">Vintage/barrel aged</a></li>
+							</ul>
+		</div>
+	</div>
+    </div>
+</div>                                </div>
+                            </div>
+                                                    <div class="mega-col col-md-4">
+                                <div class="mega-col-inner">
+                                    <div class="leo-widget" data-id_widget="1613641028">
+    <div class="widget-links">
+		<div class="widget-inner">	
+		<div id="tabs494219662" class="panel-group">
+			<ul class="nav-links">
+				  
+					<li><a href="https://funkyshop.pl/pl/2-oferta?q=Kraj+pochodzenia-Polska">Polska</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/2-oferta?q=Kraj+pochodzenia-Anglia">Anglia</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/2-piwa-rzemieslnicze?q=Kraj+pochodzenia-Belgia">Belgia</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/2-oferta?q=Kraj+pochodzenia-Szwecja">Szwecja</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/2-oferta?q=Kraj+pochodzenia-USA">USA</a></li>
+							</ul>
+		</div>
+	</div>
+    </div>
+</div>                                </div>
+                            </div>
+                                            </div>
+                            </div>
+        </div>
+    </li><li data-menu-type="category" class="nav-item parent dropdown">
+    <a class="nav-link dropdown-toggle has-category" data-toggle="dropdown" href="https://funkyshop.pl/pl/3-piwo-bezalkoholowe" target="_self">
+                    
+                    <span class="menu-title">Piwo bezalkoholowe</span>
+                                	
+	    </a>
+    <b class="caret"></b>
+    <div class="dropdown-menu level1">
+    <div class="dropdown-menu-inner">
+        <div class="row">
+            <div class="col-sm-12 mega-col" data-colwidth="12" data-type="menu">
+                <div class="inner">
+                    <ul>
+                                                    <li data-menu-type="category" class="nav-item   ">
+            <a class="nav-link" href="https://funkyshop.pl/pl/14-zero-procent">
+            
+                            <span class="menu-title">0%</span>
+                                    
+                    </a>
+
+    </li>
+            
+                                                    <li data-menu-type="category" class="nav-item   ">
+            <a class="nav-link" href="https://funkyshop.pl/pl/15-ponad-00">
+            
+                            <span class="menu-title">Ponad 0,0%</span>
+                                    
+                    </a>
+
+    </li>
+            
+                                            </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+</li>    <li data-menu-type="category" class="nav-item  ">
+        <a class="nav-link has-category" href="https://funkyshop.pl/pl/18-cydry-miody-wina" target="_self">
+                            
+                            <span class="menu-title">Cydry/wina/miody pitne</span>
+                                                        </a>
+    </li>
+    <li data-menu-type="category" class="nav-item  ">
+        <a class="nav-link has-category" href="https://funkyshop.pl/pl/17-szklomerch" target="_self">
+                            
+                            <span class="menu-title">Szkło / Merch</span>
+                                                        </a>
+    </li>
+    <li data-menu-type="category" class="nav-item pink ">
+        <a class="nav-link has-category" href="https://funkyshop.pl/pl/23-browar-miesiaca" target="_self">
+                            
+                            <span class="menu-title">Browar miesiąca</span>
+                                                        </a>
+    </li>
+    <li data-menu-type="controller" class="nav-item  ">
+        <a class="nav-link has-category" href="https://funkyshop.pl/pl/kontakt" target="_self">
+                            
+                            <span class="menu-title">Kontakt</span>
+                                                        </a>
+    </li>
+</ul></div>
+            </nav>
+            <script type="text/javascript">
+            // <![CDATA[				
+                            // var type="horizontal";
+                            // checkActiveLink();
+                            // checkTarget();
+                            list_menu_tmp.id = '9184166521380958';
+                            list_menu_tmp.type = 'horizontal';
+            // ]]>
+            
+                                						
+                                    // offCanvas();
+                                    // var show_cavas = 1;
+                                    // console.log('testaaa');
+                                    // console.log(show_cavas);
+                                    list_menu_tmp.show_cavas =1;
+
+                    
+                                        
+                    list_menu_tmp.list_tab = list_tab;
+                    list_menu.push(list_menu_tmp);
+                    list_menu_tmp = {};	
+                    list_tab = {};
+                    
+            </script>
+    
+	</div>
+
+    </div>            </div>
+</div>
+</div>
+        
+	<script>
+		ap_list_functions.push(function(){
+			$.stellar({horizontalScrolling:false}); 
+		});
+	</script>
+    
+    </div>
+          </div>
+  
+          
+        </div>
+      </header>
+      
+        
+<aside id="notifications">
+  <div class="container">
+    
+    
+    
+      </div>
+</aside>
+      
+      <section id="wrapper">
+       
+              <div class="container">
+                
+                      
+          <div class="row">
+            
+              <div id="left-column" class="sidebar col-xs-12 col-sm-12 col-md-4 col-lg-3">
+                                  
+
+<div class="block-categories block block-highlighted hidden-sm-down">
+  <p class="title_block"><a href="https://funkyshop.pl/pl/2-funky-shop">Funky Shop</a></p>
+  <div class="block_content">
+    <ul class="category-top-menu">
+      <li>
+  <ul class="category-sub-menu"><li data-depth="0"><a href="https://funkyshop.pl/pl/3-piwo-bezalkoholowe">Piwo Bezalkoholowe</a><div class="navbar-toggler collapse-icons" data-toggle="collapse" data-target="#exCollapsingNavbar3"><i class="fa fa-caret-right add"></i><i class="fa fa-caret-down remove"></i></div><div class="collapse" id="exCollapsingNavbar3">
+  <ul class="category-sub-menu"><li data-depth="1"><a class="category-sub-link" href="https://funkyshop.pl/pl/14-zero-procent">0%</a></li><li data-depth="1"><a class="category-sub-link" href="https://funkyshop.pl/pl/15-ponad-00">Ponad 0,0%</a></li></ul></div></li><li data-depth="0"><a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze">Piwo Rzemieślnicze</a><div class="navbar-toggler collapse-icons" data-toggle="collapse" data-target="#exCollapsingNavbar4"><i class="fa fa-caret-right add"></i><i class="fa fa-caret-down remove"></i></div><div class="collapse" id="exCollapsingNavbar4">
+  <ul class="category-sub-menu"><li data-depth="1"><a class="category-sub-link" href="https://funkyshop.pl/pl/5-mocno-chmielone">Mocno chmielone</a></li><li data-depth="1"><a class="category-sub-link" href="https://funkyshop.pl/pl/6-ciemne">Ciemne</a></li><li data-depth="1"><a class="category-sub-link" href="https://funkyshop.pl/pl/7-kwasnedzikie">Kwaśne/dzikie</a></li><li data-depth="1"><a class="category-sub-link" href="https://funkyshop.pl/pl/9-owocowe">Owocowe</a></li><li data-depth="1"><a class="category-sub-link" href="https://funkyshop.pl/pl/10-klasyczne">Klasyczne</a></li><li data-depth="1"><a class="category-sub-link" href="https://funkyshop.pl/pl/11-vintage">Vintage</a></li><li data-depth="1"><a class="category-sub-link" href="https://funkyshop.pl/pl/12-barrel-aged">Barrel aged</a></li><li data-depth="1"><a class="category-sub-link" href="https://funkyshop.pl/pl/19-cydr">Cydr</a></li></ul></div></li><li data-depth="0"><a href="https://funkyshop.pl/pl/16-zestawy">Zestawy</a></li><li data-depth="0"><a href="https://funkyshop.pl/pl/17-szklomerch">Szkło/Merch</a></li><li data-depth="0"><a href="https://funkyshop.pl/pl/21-promo">Promo</a></li><li data-depth="0"><a href="https://funkyshop.pl/pl/23-browar-miesiaca">Browar miesiąca</a></li></ul></li>
+    </ul>
+  </div>
+</div>
+<div id="search_filters_wrapper" class="hidden-sm-down">
+  <div id="search_filter_controls" class="hidden-md-up">
+      <span id="_mobile_search_filters_clear_all"></span>
+      <button class="btn btn-secondary ok">
+        <i class="material-icons rtl-no-flip"></i>
+        OK
+      </button>
+  </div>
+    <div id="search_filters">
+    
+      <p class="text-uppercase h6 hidden-sm-down">Filtruj według</p>
+    
+
+    
+          
+
+          <section class="facet clearfix">
+        <p class="h6 facet-title hidden-sm-down">Marka</p>
+                                                                                                                                                                                                                                                                                                                                                                                                
+        <div class="title hidden-md-up" data-target="#facet_12655" data-toggle="collapse">
+          <p class="h6 facet-title">Marka</p>
+          <span class="navbar-toggler collapse-icons">
+            <i class="material-icons add"></i>
+            <i class="material-icons remove"></i>
+          </span>
+        </div>
+
+                  
+            <ul id="facet_12655" class="collapse">
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_12655_0">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_12655_0" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-Artezan" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-Artezan" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Artezan
+                                              <span class="magnitude">(2)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_12655_1">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_12655_1" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-Cztery+%C5%9Aciany" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-Cztery+%C5%9Aciany" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Cztery Ściany
+                                              <span class="magnitude">(2)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_12655_2">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_12655_2" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-Funky+Fluid" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-Funky+Fluid" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Funky Fluid
+                                              <span class="magnitude">(138)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_12655_3">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_12655_3" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-Goose+Island" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-Goose+Island" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Goose Island
+                                              <span class="magnitude">(1)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_12655_4">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_12655_4" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-Gwarek" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-Gwarek" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Gwarek
+                                              <span class="magnitude">(1)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_12655_5">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_12655_5" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-Magic+Road" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-Magic+Road" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Magic Road
+                                              <span class="magnitude">(35)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_12655_6">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_12655_6" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-Moksa" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-Moksa" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Moksa
+                                              <span class="magnitude">(1)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_12655_7">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_12655_7" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-Monsters" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-Monsters" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Monsters
+                                              <span class="magnitude">(10)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_12655_8">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_12655_8" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-Moon+Lark" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-Moon+Lark" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Moon Lark
+                                              <span class="magnitude">(6)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_12655_9">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_12655_9" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-NEPO" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-NEPO" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      NEPO
+                                              <span class="magnitude">(16)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_12655_10">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_12655_10" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-Odilon" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-Odilon" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Odilon
+                                              <span class="magnitude">(1)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_12655_11">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_12655_11" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-PINTA" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-PINTA" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      PINTA
+                                              <span class="magnitude">(18)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_12655_12">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_12655_12" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-Pinta+Barrel+Brewing" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-Pinta+Barrel+Brewing" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Pinta Barrel Brewing
+                                              <span class="magnitude">(6)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_12655_13">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_12655_13" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-Pohjala" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-Pohjala" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Pohjala
+                                              <span class="magnitude">(1)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_12655_14">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_12655_14" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-Przetw%C3%B3rnia+Chmielu" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-Przetw%C3%B3rnia+Chmielu" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Przetwórnia Chmielu
+                                              <span class="magnitude">(13)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_12655_15">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_12655_15" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-Stu+Most%C3%B3w" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-Stu+Most%C3%B3w" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Stu Mostów
+                                              <span class="magnitude">(10)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_12655_16">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_12655_16" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-Symbiose" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-Symbiose" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Symbiose
+                                              <span class="magnitude">(1)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_12655_17">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_12655_17" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-Tankbusters" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-Tankbusters" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Tankbusters
+                                              <span class="magnitude">(3)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_12655_18">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_12655_18" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-Trzech+Kumpli" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-Trzech+Kumpli" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Trzech Kumpli
+                                              <span class="magnitude">(1)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_12655_19">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_12655_19" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-Ziemia+Obiecana" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Marka-Ziemia+Obiecana" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Ziemia Obiecana
+                                              <span class="magnitude">(8)</span>
+                                          </a>
+                  </label>
+                </li>
+                          </ul>
+          
+
+              </section>
+          <section class="facet clearfix">
+        <p class="h6 facet-title hidden-sm-down">Kraj pochodzenia</p>
+                                                                                                                  
+        <div class="title hidden-md-up" data-target="#facet_6314" data-toggle="collapse">
+          <p class="h6 facet-title">Kraj pochodzenia</p>
+          <span class="navbar-toggler collapse-icons">
+            <i class="material-icons add"></i>
+            <i class="material-icons remove"></i>
+          </span>
+        </div>
+
+                  
+            <ul id="facet_6314" class="collapse">
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_6314_0">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_6314_0" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Kraj+pochodzenia-Belgia" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Kraj+pochodzenia-Belgia" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Belgia
+                                              <span class="magnitude">(1)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_6314_1">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_6314_1" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Kraj+pochodzenia-Estonia" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Kraj+pochodzenia-Estonia" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Estonia
+                                              <span class="magnitude">(1)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_6314_2">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_6314_2" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Kraj+pochodzenia-Holandia" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Kraj+pochodzenia-Holandia" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Holandia
+                                              <span class="magnitude">(1)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_6314_3">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_6314_3" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Kraj+pochodzenia-Polska" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Kraj+pochodzenia-Polska" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Polska
+                                              <span class="magnitude">(269)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_6314_4">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_6314_4" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Kraj+pochodzenia-USA" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Kraj+pochodzenia-USA" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      USA
+                                              <span class="magnitude">(2)</span>
+                                          </a>
+                  </label>
+                </li>
+                          </ul>
+          
+
+              </section>
+          <section class="facet clearfix">
+        <p class="h6 facet-title hidden-sm-down">Kategorie</p>
+                                                                                                                                    
+        <div class="title hidden-md-up" data-target="#facet_45128" data-toggle="collapse">
+          <p class="h6 facet-title">Kategorie</p>
+          <span class="navbar-toggler collapse-icons">
+            <i class="material-icons add"></i>
+            <i class="material-icons remove"></i>
+          </span>
+        </div>
+
+                  
+            <ul id="facet_45128" class="collapse">
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_45128_0">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_45128_0" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Kategorie-Barrel+aged" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Kategorie-Barrel+aged" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Barrel aged
+                                              <span class="magnitude">(25)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_45128_1">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_45128_1" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Kategorie-Ciemne" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Kategorie-Ciemne" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Ciemne
+                                              <span class="magnitude">(28)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_45128_2">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_45128_2" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Kategorie-Klasyczne" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Kategorie-Klasyczne" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Klasyczne
+                                              <span class="magnitude">(35)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_45128_3">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_45128_3" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Kategorie-Kwa%C5%9Bne%5C/dzikie" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Kategorie-Kwa%C5%9Bne%5C/dzikie" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Kwaśne/dzikie
+                                              <span class="magnitude">(106)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_45128_4">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_45128_4" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Kategorie-Mocno+chmielone" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Kategorie-Mocno+chmielone" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Mocno chmielone
+                                              <span class="magnitude">(117)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_45128_5">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_45128_5" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Kategorie-Owocowe" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Kategorie-Owocowe" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Owocowe
+                                              <span class="magnitude">(97)</span>
+                                          </a>
+                  </label>
+                </li>
+                          </ul>
+          
+
+              </section>
+          <section class="facet clearfix">
+        <p class="h6 facet-title hidden-sm-down">Styl</p>
+                                                                                                                                                                                                                                                                                    
+        <div class="title hidden-md-up" data-target="#facet_78559" data-toggle="collapse">
+          <p class="h6 facet-title">Styl</p>
+          <span class="navbar-toggler collapse-icons">
+            <i class="material-icons add"></i>
+            <i class="material-icons remove"></i>
+          </span>
+        </div>
+
+                  
+            <ul id="facet_78559" class="collapse">
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_78559_0">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_78559_0" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Styl-Barley+Wine+%5C/+Old+Ale+%5C/+Strong+Ale" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Styl-Barley+Wine+%5C/+Old+Ale+%5C/+Strong+Ale" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Barley Wine / Old Ale / Strong Ale
+                                              <span class="magnitude">(2)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_78559_1">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_78559_1" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Styl-Bitter+%5C/+Brown+Ale+%5C/+Red+Ale" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Styl-Bitter+%5C/+Brown+Ale+%5C/+Red+Ale" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Bitter / Brown Ale / Red Ale
+                                              <span class="magnitude">(1)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_78559_2">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_78559_2" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Styl-Fruit+Beer" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Styl-Fruit+Beer" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Fruit Beer
+                                              <span class="magnitude">(1)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_78559_3">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_78559_3" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Styl-Imperial+Stout+%5C/+Porter" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Styl-Imperial+Stout+%5C/+Porter" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Imperial Stout / Porter
+                                              <span class="magnitude">(28)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_78559_4">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_78559_4" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Styl-IPA+%5C/+DIPA+%5C/+APA" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Styl-IPA+%5C/+DIPA+%5C/+APA" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      IPA / DIPA / APA
+                                              <span class="magnitude">(113)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_78559_5">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_78559_5" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Styl-Lager+%5C/+Pilsner" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Styl-Lager+%5C/+Pilsner" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Lager / Pilsner
+                                              <span class="magnitude">(12)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_78559_6">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_78559_6" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Styl-Lambic" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Styl-Lambic" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Lambic
+                                              <span class="magnitude">(2)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_78559_7">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_78559_7" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Styl-Non%5C-ABV+%5C/+Low%5C-ABV" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Styl-Non%5C-ABV+%5C/+Low%5C-ABV" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Non-ABV / Low-ABV
+                                              <span class="magnitude">(12)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_78559_8">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_78559_8" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Styl-Pastry+Sour+%5C/+Fruited+Sour" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Styl-Pastry+Sour+%5C/+Fruited+Sour" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Pastry Sour / Fruited Sour
+                                              <span class="magnitude">(90)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_78559_9">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_78559_9" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Styl-Quadrupel+%5C/+Tripel+%5C/+Dubbel+" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Styl-Quadrupel+%5C/+Tripel+%5C/+Dubbel+" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Quadrupel / Tripel / Dubbel 
+                                              <span class="magnitude">(1)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_78559_10">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_78559_10" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Styl-Smoked+Beer" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Styl-Smoked+Beer" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Smoked Beer
+                                              <span class="magnitude">(5)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_78559_11">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_78559_11" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Styl-Stout+%5C/+Porter" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Styl-Stout+%5C/+Porter" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Stout / Porter
+                                              <span class="magnitude">(6)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_78559_12">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_78559_12" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Styl-Wild+Ale+%5C/+Sour+Ale+%5C/+Saison" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Styl-Wild+Ale+%5C/+Sour+Ale+%5C/+Saison" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Wild Ale / Sour Ale / Saison
+                                              <span class="magnitude">(13)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_78559_13">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_78559_13" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Styl-Witbier+%5C/+Weizen+%5C/+Wheat" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Styl-Witbier+%5C/+Weizen+%5C/+Wheat" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Witbier / Weizen / Wheat
+                                              <span class="magnitude">(4)</span>
+                                          </a>
+                  </label>
+                </li>
+                          </ul>
+          
+
+              </section>
+          <section class="facet clearfix">
+        <p class="h6 facet-title hidden-sm-down">Pojemność</p>
+                                                                              
+        <div class="title hidden-md-up" data-target="#facet_68343" data-toggle="collapse">
+          <p class="h6 facet-title">Pojemność</p>
+          <span class="navbar-toggler collapse-icons">
+            <i class="material-icons add"></i>
+            <i class="material-icons remove"></i>
+          </span>
+        </div>
+
+                  
+            <ul id="facet_68343" class="collapse">
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_68343_0">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_68343_0" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Pojemno%C5%9B%C4%87-250%5C-375+ml" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Pojemno%C5%9B%C4%87-250%5C-375+ml" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      250-375 ml
+                                              <span class="magnitude">(31)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_68343_1">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_68343_1" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Pojemno%C5%9B%C4%87-400%5C-500+ml" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Pojemno%C5%9B%C4%87-400%5C-500+ml" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      400-500 ml
+                                              <span class="magnitude">(239)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_68343_2">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_68343_2" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Pojemno%C5%9B%C4%87-650%2B+ml" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Pojemno%C5%9B%C4%87-650%2B+ml" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      650+ ml
+                                              <span class="magnitude">(4)</span>
+                                          </a>
+                  </label>
+                </li>
+                          </ul>
+          
+
+              </section>
+          <section class="facet clearfix">
+        <p class="h6 facet-title hidden-sm-down">Dostępność</p>
+                                                                              
+        <div class="title hidden-md-up" data-target="#facet_4620" data-toggle="collapse">
+          <p class="h6 facet-title">Dostępność</p>
+          <span class="navbar-toggler collapse-icons">
+            <i class="material-icons add"></i>
+            <i class="material-icons remove"></i>
+          </span>
+        </div>
+
+                  
+            <ul id="facet_4620" class="collapse">
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_4620_0">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_4620_0" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Dost%C4%99pno%C5%9B%C4%87-Dost%C4%99pny" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Dost%C4%99pno%C5%9B%C4%87-Dost%C4%99pny" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Dostępny
+                                              <span class="magnitude">(246)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_4620_1">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_4620_1" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Dost%C4%99pno%C5%9B%C4%87-Niedost%C4%99pny" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Dost%C4%99pno%C5%9B%C4%87-Niedost%C4%99pny" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Niedostępny
+                                              <span class="magnitude">(28)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_4620_2">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_4620_2" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Dost%C4%99pno%C5%9B%C4%87-W+magazynie" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Dost%C4%99pno%C5%9B%C4%87-W+magazynie" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      W magazynie
+                                              <span class="magnitude">(246)</span>
+                                          </a>
+                  </label>
+                </li>
+                          </ul>
+          
+
+              </section>
+          <section class="facet clearfix">
+        <p class="h6 facet-title hidden-sm-down">Cena</p>
+                                          
+        <div class="title hidden-md-up" data-target="#facet_42558" data-toggle="collapse">
+          <p class="h6 facet-title">Cena</p>
+          <span class="navbar-toggler collapse-icons">
+            <i class="material-icons add"></i>
+            <i class="material-icons remove"></i>
+          </span>
+        </div>
+
+                  
+                          <ul id="facet_42558" class="faceted-slider collapse" data-slider-min="9" data-slider-max="430" data-slider-id="42558" data-slider-values="null" data-slider-unit="zł" data-slider-label="Cena" data-slider-specifications="{&quot;symbol&quot;:[&quot;,&quot;,&quot;\u00a0&quot;,&quot;;&quot;,&quot;%&quot;,&quot;-&quot;,&quot;+&quot;,&quot;E&quot;,&quot;\u00d7&quot;,&quot;\u2030&quot;,&quot;\u221e&quot;,&quot;NaN&quot;],&quot;currencyCode&quot;:&quot;PLN&quot;,&quot;currencySymbol&quot;:&quot;z\u0142&quot;,&quot;numberSymbols&quot;:[&quot;,&quot;,&quot;\u00a0&quot;,&quot;;&quot;,&quot;%&quot;,&quot;-&quot;,&quot;+&quot;,&quot;E&quot;,&quot;\u00d7&quot;,&quot;\u2030&quot;,&quot;\u221e&quot;,&quot;NaN&quot;],&quot;positivePattern&quot;:&quot;#,##0.00\u00a0\u00a4&quot;,&quot;negativePattern&quot;:&quot;-#,##0.00\u00a0\u00a4&quot;,&quot;maxFractionDigits&quot;:2,&quot;minFractionDigits&quot;:2,&quot;groupingUsed&quot;:true,&quot;primaryGroupSize&quot;:3,&quot;secondaryGroupSize&quot;:3}" data-slider-encoded-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze">
+                <li>
+                  <p id="facet_label_42558">9,00&nbsp;zł - 430,00&nbsp;zł</p>
+
+                  <div id="slider-range_42558" class="ui-slider ui-slider-horizontal ui-widget ui-widget-content ui-corner-all" aria-disabled="false"><div class="ui-slider-range ui-widget-header ui-corner-all" style="left: 0%; width: 100%;"></div><a class="ui-slider-handle ui-state-default ui-corner-all" href="#" style="left: 0%;" aria-label="Ustaw zakres cen"></a><a class="ui-slider-handle ui-state-default ui-corner-all" href="#" style="left: 100%;" aria-label="Ustaw zakres cen"></a></div>
+                </li>
+              </ul>
+                      
+              </section>
+          <section class="facet clearfix">
+        <p class="h6 facet-title hidden-sm-down">Typ opakowania</p>
+                                                            
+        <div class="title hidden-md-up" data-target="#facet_16343" data-toggle="collapse">
+          <p class="h6 facet-title">Typ opakowania</p>
+          <span class="navbar-toggler collapse-icons">
+            <i class="material-icons add"></i>
+            <i class="material-icons remove"></i>
+          </span>
+        </div>
+
+                  
+            <ul id="facet_16343" class="collapse">
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_16343_0">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_16343_0" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Typ+opakowania-butelka" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Typ+opakowania-butelka" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      butelka
+                                              <span class="magnitude">(45)</span>
+                                          </a>
+                  </label>
+                </li>
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_16343_1">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_16343_1" data-search-url="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Typ+opakowania-puszka" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?q=Typ+opakowania-puszka" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      puszka
+                                              <span class="magnitude">(229)</span>
+                                          </a>
+                  </label>
+                </li>
+                          </ul>
+          
+
+              </section>
+      </div>
+
+</div>
+
+                              </div>
+            
+
+            
+  <div id="content-wrapper" class="left-column col-xs-12 col-sm-12 col-md-8 col-lg-9">
+    
+    
+  <section id="main">
+
+    
+  <div class="block-category">    
+              <div id="category-description" class="text-muted"><h1>Piwo Rzemieślnicze</h1></div>
+      </div>
+  
+
+    <section id="products">
+      
+        <div>
+          
+            
+<div id="js-product-list-top" class="products-selection">
+  <div class="row">
+    <div class="col-lg-6 col-md-3 hidden-sm-down total-products">     
+      
+        <div class="display">
+          <div id="grid" class="leo_grid selected"><a rel="nofollow" href="#" title="Siatka"><i class="fa fa-th"></i></a></div>
+          <div id="list" class="leo_list "><a rel="nofollow" href="#" title="Lista"><i class="fa fa-list-ul"></i></a></div>
+        </div>
+      
+            	<p>Liczba produktów w Twoim koszyku: 174</p>
+          </div>
+    <div class="col-lg-6 col-md-9">
+      <div class="row sort-by-row">
+        
+          <span class="col-sm-3 col-md-3 hidden-sm-down sort-by">Sortuj według:</span>
+<div class="col-sm-9 col-xs-8 col-sp-12  col-md-9 products-sort-order dropdown">
+  <button class="btn-unstyle select-title" rel="nofollow" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <i class="material-icons float-xs-right"></i>
+  </button>
+  <div class="dropdown-menu">
+          <a rel="nofollow" href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?order=product.sales.desc" class="select-list js-search-link">
+        Sprzedaż, od najwyższej do najniższej
+      </a>
+          <a rel="nofollow" href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?order=product.position.asc" class="select-list js-search-link">
+        Trafność
+      </a>
+          <a rel="nofollow" href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?order=product.name.asc" class="select-list js-search-link">
+        Nazwa, A do Z
+      </a>
+          <a rel="nofollow" href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?order=product.name.desc" class="select-list js-search-link">
+        Nazwa, Z do A
+      </a>
+          <a rel="nofollow" href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?order=product.price.asc" class="select-list js-search-link">
+        Cena, rosnąco
+      </a>
+          <a rel="nofollow" href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?order=product.price.desc" class="select-list js-search-link">
+        Cena, malejąco
+      </a>
+          <a rel="nofollow" href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?order=product.date_add.asc" class="select-list js-search-link">
+        Najstarsze produkty
+      </a>
+          <a rel="nofollow" href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?order=product.date_add.desc" class="select-list js-search-link">
+        Najnowsze produkty
+      </a>
+      </div>
+</div>
+        
+
+                  <div class="col-sm-4 col-xs-4 col-sp-12 hidden-md-up filter-button">
+            <button id="search_filter_toggler" class="btn btn-outline">
+              Filtr
+            </button>
+          </div>
+              </div>
+    </div>
+    <div class="col-sm-12 hidden-md-up text-sm-center showing">
+      Pokazano 1-24 z 174 pozycji
+    </div>
+  </div>
+</div>
+          
+        </div>
+
+        
+          <div id="" class="hidden-sm-down">
+            <section id="js-active-search-filters" class="hide">
+  
+    <p class="h6 hidden-xs-up">Aktywne filtry</p>
+  
+
+  </section>
+
+          </div>
+        
+
+        <div>
+          
+            <div id="js-product-list">
+  <div class="products">  
+        
+
+    
+                    
+
+
+<!-- Products list -->
+
+
+<div class="product_list grid  plist-default3 ">
+    <div class="row">
+                    
+            
+            
+                                       
+            <div class="ajax_block_product col-sp-12 col-xs-6 col-sm-6 col-md-6 col-lg-4 col-xl-4
+                 first-in-line                                 first-item-of-tablet-line                 first-item-of-mobile-line                                ">
+                
+                                                                                                <article class="product-miniature js-product-miniature" data-id-product="5849" data-id-product-attribute="0" itemscope="" itemtype="http://schema.org/Product">
+  <div class="thumbnail-container">
+    <div class="product-image">
+
+
+        			    	<a href="https://funkyshop.pl/pl/piwo-rzemieslnicze/5849-kielbasa-kolega-x-hop-hooligans-500ml.html" class="thumbnail product-thumbnail">
+				  <img class="img-fluid" src="https://funkyshop.pl/10821-home_default/kielbasa-kolega-x-hop-hooligans-500ml.jpg" alt="Kiełbasa Kolega (x Hop Hooligans) 500ml" data-full-size-image-url="https://funkyshop.pl/10821-large_default/kielbasa-kolega-x-hop-hooligans-500ml.jpg">
+				  					<span class="product-additional" data-idproduct="5849"></span>
+				  				</a>
+
+		      
+
+
+<div class="functional-buttons clearfix">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="quickview no-variants hidden-sm-down">
+<a href="#" class="quick-view" data-link-action="quickview" title="Quick view">
+	<span class="leo-quickview-bt-loading cssload-speeding-wheel"></span>
+	<span class="leo-quickview-bt-content">
+		<i class="material-icons search"></i>
+		<span>Quick view</span>
+	</span>
+</a>
+</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="wishlist">
+			<a class="leo-wishlist-button btn-product btn-primary btn" href="javascript:void(0)" data-id-wishlist="" data-id-product="5849" data-id-product-attribute="0" title="Dodaj do listy życzeń">
+			<span class="leo-wishlist-bt-loading cssload-speeding-wheel"></span>
+			<span class="leo-wishlist-bt-content">
+				<i class="icon-btn-product icon-wishlist material-icons"></i>
+				<span class="name-btn-product">Dodaj do listy życzeń</span>
+			</span>
+		</a>
+	</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+</div></div>
+    <div class="product-meta">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+  <p class="h3 product-title" itemprop="name"><a href="https://funkyshop.pl/pl/piwo-rzemieslnicze/5849-kielbasa-kolega-x-hop-hooligans-500ml.html">Kiełbasa Kolega (x Hop Hooligans) 500ml</a></p>
+
+<a class="manufacturer-product" href="https://funkyshop.pl/pl/brand/62-ziemia-obiecana">
+    Ziemia Obiecana
+</a>
+
+  <div class="product-description-short" itemprop="description"> Classic Imperial Stout, 9.6% </div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+      <div class="product-price-and-shipping ">
+      
+      
+      
+      <span class="sr-only">Cena</span>
+      <span class="price" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+        <span itemprop="priceCurrency" content="PLN"></span><span itemprop="price" content="30">30,00&nbsp;zł</span>
+      </span>
+
+      
+
+      
+    </div>
+  
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="button-container cart">
+	<form action="https://funkyshop.pl/pl/koszyk" method="post">
+		<input type="hidden" name="token" value="b866420ae8aaf943d02267723ab32727">
+		<input type="hidden" value="18" class="quantity_product quantity_product_5849" name="quantity_product">
+		<input type="hidden" value="1" class="minimal_quantity minimal_quantity_5849" name="minimal_quantity">
+		<input type="hidden" value="0" class="id_product_attribute id_product_attribute_5849" name="id_product_attribute">
+		<input type="hidden" value="5849" class="id_product" name="id_product">
+		<input type="hidden" name="id_customization" value="" class="product_customization_id">
+			
+		<input type="hidden" class="input-group form-control qty qty_product qty_product_5849" name="qty" value="1" data-min="1">
+		  <button class="btn btn-product add-to-cart leo-bt-cart leo-bt-cart_5849 leo-enable" data-button-action="add-to-cart" type="submit">
+			<span class="leo-loading cssload-speeding-wheel"></span>
+			<span class="leo-bt-cart-content">
+				<i class="icon-btn-product icon-cart material-icons shopping-cart"></i>
+				<span class="name-btn-product">Dodaj do koszyka</span>
+			</span>
+		  </button>
+	</form>
+</div>
+
+</div>
+  </div>
+</article>
+
+                                                            
+            </div>
+                    
+            
+            
+                                       
+            <div class="ajax_block_product col-sp-12 col-xs-6 col-sm-6 col-md-6 col-lg-4 col-xl-4
+                                                 last-item-of-tablet-line
+                                 last-item-of-mobile-line
+                                                ">
+                
+                                                                                                <article class="product-miniature js-product-miniature" data-id-product="5848" data-id-product-attribute="0" itemscope="" itemtype="http://schema.org/Product">
+  <div class="thumbnail-container">
+    <div class="product-image">
+
+
+        			    	<a href="https://funkyshop.pl/pl/piwo-rzemieslnicze/5848-bubu-500ml.html" class="thumbnail product-thumbnail">
+				  <img class="img-fluid" src="https://funkyshop.pl/10820-home_default/bubu-500ml.jpg" alt="Bubu 500ml" data-full-size-image-url="https://funkyshop.pl/10820-large_default/bubu-500ml.jpg">
+				  					<span class="product-additional" data-idproduct="5848"></span>
+				  				</a>
+
+		      
+
+
+<div class="functional-buttons clearfix">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="quickview no-variants hidden-sm-down">
+<a href="#" class="quick-view" data-link-action="quickview" title="Quick view">
+	<span class="leo-quickview-bt-loading cssload-speeding-wheel"></span>
+	<span class="leo-quickview-bt-content">
+		<i class="material-icons search"></i>
+		<span>Quick view</span>
+	</span>
+</a>
+</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="wishlist">
+			<a class="leo-wishlist-button btn-product btn-primary btn" href="javascript:void(0)" data-id-wishlist="" data-id-product="5848" data-id-product-attribute="0" title="Dodaj do listy życzeń">
+			<span class="leo-wishlist-bt-loading cssload-speeding-wheel"></span>
+			<span class="leo-wishlist-bt-content">
+				<i class="icon-btn-product icon-wishlist material-icons"></i>
+				<span class="name-btn-product">Dodaj do listy życzeń</span>
+			</span>
+		</a>
+	</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+</div></div>
+    <div class="product-meta">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+  <p class="h3 product-title" itemprop="name"><a href="https://funkyshop.pl/pl/piwo-rzemieslnicze/5848-bubu-500ml.html">Bubu 500ml</a></p>
+
+<a class="manufacturer-product" href="https://funkyshop.pl/pl/brand/62-ziemia-obiecana">
+    Ziemia Obiecana
+</a>
+
+  <div class="product-description-short" itemprop="description"> Lychee/Mango/Vanilla Triple Fruited Sour, 4.8% </div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+      <div class="product-price-and-shipping ">
+      
+      
+      
+      <span class="sr-only">Cena</span>
+      <span class="price" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+        <span itemprop="priceCurrency" content="PLN"></span><span itemprop="price" content="19.5">19,50&nbsp;zł</span>
+      </span>
+
+      
+
+      
+    </div>
+  
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="button-container cart">
+	<form action="https://funkyshop.pl/pl/koszyk" method="post">
+		<input type="hidden" name="token" value="b866420ae8aaf943d02267723ab32727">
+		<input type="hidden" value="19" class="quantity_product quantity_product_5848" name="quantity_product">
+		<input type="hidden" value="1" class="minimal_quantity minimal_quantity_5848" name="minimal_quantity">
+		<input type="hidden" value="0" class="id_product_attribute id_product_attribute_5848" name="id_product_attribute">
+		<input type="hidden" value="5848" class="id_product" name="id_product">
+		<input type="hidden" name="id_customization" value="" class="product_customization_id">
+			
+		<input type="hidden" class="input-group form-control qty qty_product qty_product_5848" name="qty" value="1" data-min="1">
+		  <button class="btn btn-product add-to-cart leo-bt-cart leo-bt-cart_5848 leo-enable" data-button-action="add-to-cart" type="submit">
+			<span class="leo-loading cssload-speeding-wheel"></span>
+			<span class="leo-bt-cart-content">
+				<i class="icon-btn-product icon-cart material-icons shopping-cart"></i>
+				<span class="name-btn-product">Dodaj do koszyka</span>
+			</span>
+		  </button>
+	</form>
+</div>
+
+</div>
+  </div>
+</article>
+
+                                                            
+            </div>
+                    
+            
+            
+                                       
+            <div class="ajax_block_product col-sp-12 col-xs-6 col-sm-6 col-md-6 col-lg-4 col-xl-4
+                 last-in-line
+                                                 first-item-of-tablet-line                 first-item-of-mobile-line                                ">
+                
+                                                                                                <article class="product-miniature js-product-miniature" data-id-product="5846" data-id-product-attribute="0" itemscope="" itemtype="http://schema.org/Product">
+  <div class="thumbnail-container">
+    <div class="product-image">
+
+
+        			    	<a href="https://funkyshop.pl/pl/piwo-rzemieslnicze/5846-mlot-2026-500ml.html" class="thumbnail product-thumbnail">
+				  <img class="img-fluid" src="https://funkyshop.pl/10818-home_default/mlot-2026-500ml.jpg" alt="Młot 2026 500ml" data-full-size-image-url="https://funkyshop.pl/10818-large_default/mlot-2026-500ml.jpg">
+				  					<span class="product-additional" data-idproduct="5846"></span>
+				  				</a>
+
+		      
+
+
+<div class="functional-buttons clearfix">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="quickview no-variants hidden-sm-down">
+<a href="#" class="quick-view" data-link-action="quickview" title="Quick view">
+	<span class="leo-quickview-bt-loading cssload-speeding-wheel"></span>
+	<span class="leo-quickview-bt-content">
+		<i class="material-icons search"></i>
+		<span>Quick view</span>
+	</span>
+</a>
+</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="wishlist">
+			<a class="leo-wishlist-button btn-product btn-primary btn" href="javascript:void(0)" data-id-wishlist="" data-id-product="5846" data-id-product-attribute="0" title="Dodaj do listy życzeń">
+			<span class="leo-wishlist-bt-loading cssload-speeding-wheel"></span>
+			<span class="leo-wishlist-bt-content">
+				<i class="icon-btn-product icon-wishlist material-icons"></i>
+				<span class="name-btn-product">Dodaj do listy życzeń</span>
+			</span>
+		</a>
+	</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+</div></div>
+    <div class="product-meta">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+  <p class="h3 product-title" itemprop="name"><a href="https://funkyshop.pl/pl/piwo-rzemieslnicze/5846-mlot-2026-500ml.html">Młot 2026 500ml</a></p>
+
+<a class="manufacturer-product" href="https://funkyshop.pl/pl/brand/62-ziemia-obiecana">
+    Ziemia Obiecana
+</a>
+
+  <div class="product-description-short" itemprop="description"> Citra/Nugget West Coast IPA, 7% </div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+      <div class="product-price-and-shipping ">
+      
+      
+      
+      <span class="sr-only">Cena</span>
+      <span class="price" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+        <span itemprop="priceCurrency" content="PLN"></span><span itemprop="price" content="19">19,00&nbsp;zł</span>
+      </span>
+
+      
+
+      
+    </div>
+  
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="button-container cart">
+	<form action="https://funkyshop.pl/pl/koszyk" method="post">
+		<input type="hidden" name="token" value="b866420ae8aaf943d02267723ab32727">
+		<input type="hidden" value="18" class="quantity_product quantity_product_5846" name="quantity_product">
+		<input type="hidden" value="1" class="minimal_quantity minimal_quantity_5846" name="minimal_quantity">
+		<input type="hidden" value="0" class="id_product_attribute id_product_attribute_5846" name="id_product_attribute">
+		<input type="hidden" value="5846" class="id_product" name="id_product">
+		<input type="hidden" name="id_customization" value="" class="product_customization_id">
+			
+		<input type="hidden" class="input-group form-control qty qty_product qty_product_5846" name="qty" value="1" data-min="1">
+		  <button class="btn btn-product add-to-cart leo-bt-cart leo-bt-cart_5846 leo-enable" data-button-action="add-to-cart" type="submit">
+			<span class="leo-loading cssload-speeding-wheel"></span>
+			<span class="leo-bt-cart-content">
+				<i class="icon-btn-product icon-cart material-icons shopping-cart"></i>
+				<span class="name-btn-product">Dodaj do koszyka</span>
+			</span>
+		  </button>
+	</form>
+</div>
+
+</div>
+  </div>
+</article>
+
+                                                            
+            </div>
+                    
+            
+            
+                                       
+            <div class="ajax_block_product col-sp-12 col-xs-6 col-sm-6 col-md-6 col-lg-4 col-xl-4
+                 first-in-line                                 last-item-of-tablet-line
+                                 last-item-of-mobile-line
+                                                ">
+                
+                                                                                                <article class="product-miniature js-product-miniature" data-id-product="5847" data-id-product-attribute="0" itemscope="" itemtype="http://schema.org/Product">
+  <div class="thumbnail-container">
+    <div class="product-image">
+
+
+        			    	<a href="https://funkyshop.pl/pl/piwo-rzemieslnicze/5847-uparcie-i-skrycie-500ml.html" class="thumbnail product-thumbnail">
+				  <img class="img-fluid" src="https://funkyshop.pl/10819-home_default/uparcie-i-skrycie-500ml.jpg" alt="Uparcie I Skrycie 500ml" data-full-size-image-url="https://funkyshop.pl/10819-large_default/uparcie-i-skrycie-500ml.jpg">
+				  					<span class="product-additional" data-idproduct="5847"></span>
+				  				</a>
+
+		      
+
+
+<div class="functional-buttons clearfix">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="quickview no-variants hidden-sm-down">
+<a href="#" class="quick-view" data-link-action="quickview" title="Quick view">
+	<span class="leo-quickview-bt-loading cssload-speeding-wheel"></span>
+	<span class="leo-quickview-bt-content">
+		<i class="material-icons search"></i>
+		<span>Quick view</span>
+	</span>
+</a>
+</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="wishlist">
+			<a class="leo-wishlist-button btn-product btn-primary btn" href="javascript:void(0)" data-id-wishlist="" data-id-product="5847" data-id-product-attribute="0" title="Dodaj do listy życzeń">
+			<span class="leo-wishlist-bt-loading cssload-speeding-wheel"></span>
+			<span class="leo-wishlist-bt-content">
+				<i class="icon-btn-product icon-wishlist material-icons"></i>
+				<span class="name-btn-product">Dodaj do listy życzeń</span>
+			</span>
+		</a>
+	</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+</div></div>
+    <div class="product-meta">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+  <p class="h3 product-title" itemprop="name"><a href="https://funkyshop.pl/pl/piwo-rzemieslnicze/5847-uparcie-i-skrycie-500ml.html">Uparcie I Skrycie 500ml</a></p>
+
+<a class="manufacturer-product" href="https://funkyshop.pl/pl/brand/62-ziemia-obiecana">
+    Ziemia Obiecana
+</a>
+
+  <div class="product-description-short" itemprop="description"> Dolcita/Nelson Sauvin Oatcream Hazy Pale Ale, 4.8% </div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+      <div class="product-price-and-shipping ">
+      
+      
+      
+      <span class="sr-only">Cena</span>
+      <span class="price" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+        <span itemprop="priceCurrency" content="PLN"></span><span itemprop="price" content="18">18,00&nbsp;zł</span>
+      </span>
+
+      
+
+      
+    </div>
+  
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="button-container cart">
+	<form action="https://funkyshop.pl/pl/koszyk" method="post">
+		<input type="hidden" name="token" value="b866420ae8aaf943d02267723ab32727">
+		<input type="hidden" value="19" class="quantity_product quantity_product_5847" name="quantity_product">
+		<input type="hidden" value="1" class="minimal_quantity minimal_quantity_5847" name="minimal_quantity">
+		<input type="hidden" value="0" class="id_product_attribute id_product_attribute_5847" name="id_product_attribute">
+		<input type="hidden" value="5847" class="id_product" name="id_product">
+		<input type="hidden" name="id_customization" value="" class="product_customization_id">
+			
+		<input type="hidden" class="input-group form-control qty qty_product qty_product_5847" name="qty" value="1" data-min="1">
+		  <button class="btn btn-product add-to-cart leo-bt-cart leo-bt-cart_5847 leo-enable" data-button-action="add-to-cart" type="submit">
+			<span class="leo-loading cssload-speeding-wheel"></span>
+			<span class="leo-bt-cart-content">
+				<i class="icon-btn-product icon-cart material-icons shopping-cart"></i>
+				<span class="name-btn-product">Dodaj do koszyka</span>
+			</span>
+		  </button>
+	</form>
+</div>
+
+</div>
+  </div>
+</article>
+
+                                                            
+            </div>
+                    
+            
+            
+                                       
+            <div class="ajax_block_product col-sp-12 col-xs-6 col-sm-6 col-md-6 col-lg-4 col-xl-4
+                                                 first-item-of-tablet-line                 first-item-of-mobile-line                                ">
+                
+                                                                                                <article class="product-miniature js-product-miniature" data-id-product="5845" data-id-product-attribute="0" itemscope="" itemtype="http://schema.org/Product">
+  <div class="thumbnail-container">
+    <div class="product-image">
+
+
+        			    	<a href="https://funkyshop.pl/pl/piwo-rzemieslnicze/5845-libacja-na-skwerku-2026-500ml.html" class="thumbnail product-thumbnail">
+				  <img class="img-fluid" src="https://funkyshop.pl/10817-home_default/libacja-na-skwerku-2026-500ml.jpg" alt="Libacja Na Skwerku 2026 500ml" data-full-size-image-url="https://funkyshop.pl/10817-large_default/libacja-na-skwerku-2026-500ml.jpg">
+				  					<span class="product-additional" data-idproduct="5845"></span>
+				  				</a>
+
+		      
+
+
+<div class="functional-buttons clearfix">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="quickview no-variants hidden-sm-down">
+<a href="#" class="quick-view" data-link-action="quickview" title="Quick view">
+	<span class="leo-quickview-bt-loading cssload-speeding-wheel"></span>
+	<span class="leo-quickview-bt-content">
+		<i class="material-icons search"></i>
+		<span>Quick view</span>
+	</span>
+</a>
+</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="wishlist">
+			<a class="leo-wishlist-button btn-product btn-primary btn" href="javascript:void(0)" data-id-wishlist="" data-id-product="5845" data-id-product-attribute="0" title="Dodaj do listy życzeń">
+			<span class="leo-wishlist-bt-loading cssload-speeding-wheel"></span>
+			<span class="leo-wishlist-bt-content">
+				<i class="icon-btn-product icon-wishlist material-icons"></i>
+				<span class="name-btn-product">Dodaj do listy życzeń</span>
+			</span>
+		</a>
+	</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+</div></div>
+    <div class="product-meta">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+  <p class="h3 product-title" itemprop="name"><a href="https://funkyshop.pl/pl/piwo-rzemieslnicze/5845-libacja-na-skwerku-2026-500ml.html">Libacja Na Skwerku 2026 500ml</a></p>
+
+<a class="manufacturer-product" href="https://funkyshop.pl/pl/brand/62-ziemia-obiecana">
+    Ziemia Obiecana
+</a>
+
+  <div class="product-description-short" itemprop="description"> Sabro/Citra Double Hazy IPA, 7.2% </div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+      <div class="product-price-and-shipping ">
+      
+      
+      
+      <span class="sr-only">Cena</span>
+      <span class="price" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+        <span itemprop="priceCurrency" content="PLN"></span><span itemprop="price" content="19.5">19,50&nbsp;zł</span>
+      </span>
+
+      
+
+      
+    </div>
+  
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="button-container cart">
+	<form action="https://funkyshop.pl/pl/koszyk" method="post">
+		<input type="hidden" name="token" value="b866420ae8aaf943d02267723ab32727">
+		<input type="hidden" value="12" class="quantity_product quantity_product_5845" name="quantity_product">
+		<input type="hidden" value="1" class="minimal_quantity minimal_quantity_5845" name="minimal_quantity">
+		<input type="hidden" value="0" class="id_product_attribute id_product_attribute_5845" name="id_product_attribute">
+		<input type="hidden" value="5845" class="id_product" name="id_product">
+		<input type="hidden" name="id_customization" value="" class="product_customization_id">
+			
+		<input type="hidden" class="input-group form-control qty qty_product qty_product_5845" name="qty" value="1" data-min="1">
+		  <button class="btn btn-product add-to-cart leo-bt-cart leo-bt-cart_5845 leo-enable" data-button-action="add-to-cart" type="submit">
+			<span class="leo-loading cssload-speeding-wheel"></span>
+			<span class="leo-bt-cart-content">
+				<i class="icon-btn-product icon-cart material-icons shopping-cart"></i>
+				<span class="name-btn-product">Dodaj do koszyka</span>
+			</span>
+		  </button>
+	</form>
+</div>
+
+</div>
+  </div>
+</article>
+
+                                                            
+            </div>
+                    
+            
+            
+                                       
+            <div class="ajax_block_product col-sp-12 col-xs-6 col-sm-6 col-md-6 col-lg-4 col-xl-4
+                 last-in-line
+                                                 last-item-of-tablet-line
+                                 last-item-of-mobile-line
+                                                ">
+                
+                                                                                                <article class="product-miniature js-product-miniature" data-id-product="5840" data-id-product-attribute="0" itemscope="" itemtype="http://schema.org/Product">
+  <div class="thumbnail-container">
+    <div class="product-image">
+
+
+        			    	<a href="https://funkyshop.pl/pl/funky-shop/5840-nightfall-500ml.html" class="thumbnail product-thumbnail">
+				  <img class="img-fluid" src="https://funkyshop.pl/10812-home_default/nightfall-500ml.jpg" alt="Nightfall 500ml" data-full-size-image-url="https://funkyshop.pl/10812-large_default/nightfall-500ml.jpg">
+				  					<span class="product-additional" data-idproduct="5840"></span>
+				  				</a>
+
+		      
+
+
+<div class="functional-buttons clearfix">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="quickview no-variants hidden-sm-down">
+<a href="#" class="quick-view" data-link-action="quickview" title="Quick view">
+	<span class="leo-quickview-bt-loading cssload-speeding-wheel"></span>
+	<span class="leo-quickview-bt-content">
+		<i class="material-icons search"></i>
+		<span>Quick view</span>
+	</span>
+</a>
+</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="wishlist">
+			<a class="leo-wishlist-button btn-product btn-primary btn" href="javascript:void(0)" data-id-wishlist="" data-id-product="5840" data-id-product-attribute="0" title="Dodaj do listy życzeń">
+			<span class="leo-wishlist-bt-loading cssload-speeding-wheel"></span>
+			<span class="leo-wishlist-bt-content">
+				<i class="icon-btn-product icon-wishlist material-icons"></i>
+				<span class="name-btn-product">Dodaj do listy życzeń</span>
+			</span>
+		</a>
+	</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+</div></div>
+    <div class="product-meta">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+  <p class="h3 product-title" itemprop="name"><a href="https://funkyshop.pl/pl/funky-shop/5840-nightfall-500ml.html">Nightfall 500ml</a></p>
+
+<a class="manufacturer-product" href="https://funkyshop.pl/pl/brand/198-moon-lark">
+    Moon Lark
+</a>
+
+  <div class="product-description-short" itemprop="description"> Schwarzbier, 5% </div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+      <div class="product-price-and-shipping ">
+      
+      
+      
+      <span class="sr-only">Cena</span>
+      <span class="price" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+        <span itemprop="priceCurrency" content="PLN"></span><span itemprop="price" content="12.5">12,50&nbsp;zł</span>
+      </span>
+
+      			<div class="extra-return-services image-only">
+				<label>
+					<img src="/modules/bantrecyclingdeposit/uploads/bant_er_696e046eeb64f.jpg" alt="Miniatura dodatkowego produktu" class="extra-return--image">
+				</label>
+		</div>
+	
+
+      
+    </div>
+  
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="button-container cart">
+	<form action="https://funkyshop.pl/pl/koszyk" method="post">
+		<input type="hidden" name="token" value="b866420ae8aaf943d02267723ab32727">
+		<input type="hidden" value="10" class="quantity_product quantity_product_5840" name="quantity_product">
+		<input type="hidden" value="1" class="minimal_quantity minimal_quantity_5840" name="minimal_quantity">
+		<input type="hidden" value="0" class="id_product_attribute id_product_attribute_5840" name="id_product_attribute">
+		<input type="hidden" value="5840" class="id_product" name="id_product">
+		<input type="hidden" name="id_customization" value="" class="product_customization_id">
+			
+		<input type="hidden" class="input-group form-control qty qty_product qty_product_5840" name="qty" value="1" data-min="1">
+		  <button class="btn btn-product add-to-cart leo-bt-cart leo-bt-cart_5840 leo-enable" data-button-action="add-to-cart" type="submit">
+			<span class="leo-loading cssload-speeding-wheel"></span>
+			<span class="leo-bt-cart-content">
+				<i class="icon-btn-product icon-cart material-icons shopping-cart"></i>
+				<span class="name-btn-product">Dodaj do koszyka</span>
+			</span>
+		  </button>
+	</form>
+</div>
+
+</div>
+  </div>
+</article>
+
+                                                            
+            </div>
+                    
+            
+            
+                                       
+            <div class="ajax_block_product col-sp-12 col-xs-6 col-sm-6 col-md-6 col-lg-4 col-xl-4
+                 first-in-line                                 first-item-of-tablet-line                 first-item-of-mobile-line                                ">
+                
+                                                                                                <article class="product-miniature js-product-miniature" data-id-product="5841" data-id-product-attribute="0" itemscope="" itemtype="http://schema.org/Product">
+  <div class="thumbnail-container">
+    <div class="product-image">
+
+
+        			    	<a href="https://funkyshop.pl/pl/piwo-rzemieslnicze/5841-peak-500ml.html" class="thumbnail product-thumbnail">
+				  <img class="img-fluid" src="https://funkyshop.pl/10815-home_default/peak-500ml.jpg" alt="Peak. 500ml" data-full-size-image-url="https://funkyshop.pl/10815-large_default/peak-500ml.jpg">
+				  					<span class="product-additional" data-idproduct="5841"></span>
+				  				</a>
+
+		      
+
+
+<div class="functional-buttons clearfix">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="quickview no-variants hidden-sm-down">
+<a href="#" class="quick-view" data-link-action="quickview" title="Quick view">
+	<span class="leo-quickview-bt-loading cssload-speeding-wheel"></span>
+	<span class="leo-quickview-bt-content">
+		<i class="material-icons search"></i>
+		<span>Quick view</span>
+	</span>
+</a>
+</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="wishlist">
+			<a class="leo-wishlist-button btn-product btn-primary btn" href="javascript:void(0)" data-id-wishlist="" data-id-product="5841" data-id-product-attribute="0" title="Dodaj do listy życzeń">
+			<span class="leo-wishlist-bt-loading cssload-speeding-wheel"></span>
+			<span class="leo-wishlist-bt-content">
+				<i class="icon-btn-product icon-wishlist material-icons"></i>
+				<span class="name-btn-product">Dodaj do listy życzeń</span>
+			</span>
+		</a>
+	</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+</div></div>
+    <div class="product-meta">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+  <p class="h3 product-title" itemprop="name"><a href="https://funkyshop.pl/pl/piwo-rzemieslnicze/5841-peak-500ml.html">Peak. 500ml</a></p>
+
+<a class="manufacturer-product" href="https://funkyshop.pl/pl/brand/198-moon-lark">
+    Moon Lark
+</a>
+
+  <div class="product-description-short" itemprop="description"> Cryo Sabro/Talus/Dolcita Hazy IPA, 5.9% </div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+      <div class="product-price-and-shipping ">
+      
+      
+      
+      <span class="sr-only">Cena</span>
+      <span class="price" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+        <span itemprop="priceCurrency" content="PLN"></span><span itemprop="price" content="17">17,00&nbsp;zł</span>
+      </span>
+
+      
+
+      
+    </div>
+  
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="button-container cart">
+	<form action="https://funkyshop.pl/pl/koszyk" method="post">
+		<input type="hidden" name="token" value="b866420ae8aaf943d02267723ab32727">
+		<input type="hidden" value="35" class="quantity_product quantity_product_5841" name="quantity_product">
+		<input type="hidden" value="1" class="minimal_quantity minimal_quantity_5841" name="minimal_quantity">
+		<input type="hidden" value="0" class="id_product_attribute id_product_attribute_5841" name="id_product_attribute">
+		<input type="hidden" value="5841" class="id_product" name="id_product">
+		<input type="hidden" name="id_customization" value="" class="product_customization_id">
+			
+		<input type="hidden" class="input-group form-control qty qty_product qty_product_5841" name="qty" value="1" data-min="1">
+		  <button class="btn btn-product add-to-cart leo-bt-cart leo-bt-cart_5841 leo-enable" data-button-action="add-to-cart" type="submit">
+			<span class="leo-loading cssload-speeding-wheel"></span>
+			<span class="leo-bt-cart-content">
+				<i class="icon-btn-product icon-cart material-icons shopping-cart"></i>
+				<span class="name-btn-product">Dodaj do koszyka</span>
+			</span>
+		  </button>
+	</form>
+</div>
+
+</div>
+  </div>
+</article>
+
+                                                            
+            </div>
+                    
+            
+            
+                                       
+            <div class="ajax_block_product col-sp-12 col-xs-6 col-sm-6 col-md-6 col-lg-4 col-xl-4
+                                                 last-item-of-tablet-line
+                                 last-item-of-mobile-line
+                                                ">
+                
+                                                                                                <article class="product-miniature js-product-miniature" data-id-product="5842" data-id-product-attribute="0" itemscope="" itemtype="http://schema.org/Product">
+  <div class="thumbnail-container">
+    <div class="product-image">
+
+
+        			    	<a href="https://funkyshop.pl/pl/piwo-rzemieslnicze/5842-gravity-500ml.html" class="thumbnail product-thumbnail">
+				  <img class="img-fluid" src="https://funkyshop.pl/10816-home_default/gravity-500ml.jpg" alt="Gravity. 500ml" data-full-size-image-url="https://funkyshop.pl/10816-large_default/gravity-500ml.jpg">
+				  					<span class="product-additional" data-idproduct="5842"></span>
+				  				</a>
+
+		      
+
+
+<div class="functional-buttons clearfix">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="quickview no-variants hidden-sm-down">
+<a href="#" class="quick-view" data-link-action="quickview" title="Quick view">
+	<span class="leo-quickview-bt-loading cssload-speeding-wheel"></span>
+	<span class="leo-quickview-bt-content">
+		<i class="material-icons search"></i>
+		<span>Quick view</span>
+	</span>
+</a>
+</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="wishlist">
+			<a class="leo-wishlist-button btn-product btn-primary btn" href="javascript:void(0)" data-id-wishlist="" data-id-product="5842" data-id-product-attribute="0" title="Dodaj do listy życzeń">
+			<span class="leo-wishlist-bt-loading cssload-speeding-wheel"></span>
+			<span class="leo-wishlist-bt-content">
+				<i class="icon-btn-product icon-wishlist material-icons"></i>
+				<span class="name-btn-product">Dodaj do listy życzeń</span>
+			</span>
+		</a>
+	</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+</div></div>
+    <div class="product-meta">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+  <p class="h3 product-title" itemprop="name"><a href="https://funkyshop.pl/pl/piwo-rzemieslnicze/5842-gravity-500ml.html">Gravity. 500ml</a></p>
+
+<a class="manufacturer-product" href="https://funkyshop.pl/pl/brand/198-moon-lark">
+    Moon Lark
+</a>
+
+  <div class="product-description-short" itemprop="description"> Nectaron/Sabro/Krush/Dolcita/Citra Double Hazy IPA, 7.7% </div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+      <div class="product-price-and-shipping ">
+      
+      
+      
+      <span class="sr-only">Cena</span>
+      <span class="price" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+        <span itemprop="priceCurrency" content="PLN"></span><span itemprop="price" content="18">18,00&nbsp;zł</span>
+      </span>
+
+      
+
+      
+    </div>
+  
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="button-container cart">
+	<form action="https://funkyshop.pl/pl/koszyk" method="post">
+		<input type="hidden" name="token" value="b866420ae8aaf943d02267723ab32727">
+		<input type="hidden" value="32" class="quantity_product quantity_product_5842" name="quantity_product">
+		<input type="hidden" value="1" class="minimal_quantity minimal_quantity_5842" name="minimal_quantity">
+		<input type="hidden" value="0" class="id_product_attribute id_product_attribute_5842" name="id_product_attribute">
+		<input type="hidden" value="5842" class="id_product" name="id_product">
+		<input type="hidden" name="id_customization" value="" class="product_customization_id">
+			
+		<input type="hidden" class="input-group form-control qty qty_product qty_product_5842" name="qty" value="1" data-min="1">
+		  <button class="btn btn-product add-to-cart leo-bt-cart leo-bt-cart_5842 leo-enable" data-button-action="add-to-cart" type="submit">
+			<span class="leo-loading cssload-speeding-wheel"></span>
+			<span class="leo-bt-cart-content">
+				<i class="icon-btn-product icon-cart material-icons shopping-cart"></i>
+				<span class="name-btn-product">Dodaj do koszyka</span>
+			</span>
+		  </button>
+	</form>
+</div>
+
+</div>
+  </div>
+</article>
+
+                                                            
+            </div>
+                    
+            
+            
+                                       
+            <div class="ajax_block_product col-sp-12 col-xs-6 col-sm-6 col-md-6 col-lg-4 col-xl-4
+                 last-in-line
+                                                 first-item-of-tablet-line                 first-item-of-mobile-line                                ">
+                
+                                                                                                <article class="product-miniature js-product-miniature" data-id-product="5844" data-id-product-attribute="0" itemscope="" itemtype="http://schema.org/Product">
+  <div class="thumbnail-container">
+    <div class="product-image">
+
+
+        			    	<a href="https://funkyshop.pl/pl/piwo-rzemieslnicze/5844-marine-500ml.html" class="thumbnail product-thumbnail">
+				  <img class="img-fluid" src="https://funkyshop.pl/10814-home_default/marine-500ml.jpg" alt="Marine. 500ml" data-full-size-image-url="https://funkyshop.pl/10814-large_default/marine-500ml.jpg">
+				  					<span class="product-additional" data-idproduct="5844"></span>
+				  				</a>
+
+		      
+
+
+<div class="functional-buttons clearfix">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="quickview no-variants hidden-sm-down">
+<a href="#" class="quick-view" data-link-action="quickview" title="Quick view">
+	<span class="leo-quickview-bt-loading cssload-speeding-wheel"></span>
+	<span class="leo-quickview-bt-content">
+		<i class="material-icons search"></i>
+		<span>Quick view</span>
+	</span>
+</a>
+</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="wishlist">
+			<a class="leo-wishlist-button btn-product btn-primary btn" href="javascript:void(0)" data-id-wishlist="" data-id-product="5844" data-id-product-attribute="0" title="Dodaj do listy życzeń">
+			<span class="leo-wishlist-bt-loading cssload-speeding-wheel"></span>
+			<span class="leo-wishlist-bt-content">
+				<i class="icon-btn-product icon-wishlist material-icons"></i>
+				<span class="name-btn-product">Dodaj do listy życzeń</span>
+			</span>
+		</a>
+	</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+</div></div>
+    <div class="product-meta">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+  <p class="h3 product-title" itemprop="name"><a href="https://funkyshop.pl/pl/piwo-rzemieslnicze/5844-marine-500ml.html">Marine. 500ml</a></p>
+
+<a class="manufacturer-product" href="https://funkyshop.pl/pl/brand/198-moon-lark">
+    Moon Lark
+</a>
+
+  <div class="product-description-short" itemprop="description"> Cryo Citra/Riwaka/Cryo Nelson Hazy IPA, 6.4% </div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+      <div class="product-price-and-shipping ">
+      
+      
+      
+      <span class="sr-only">Cena</span>
+      <span class="price" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+        <span itemprop="priceCurrency" content="PLN"></span><span itemprop="price" content="17">17,00&nbsp;zł</span>
+      </span>
+
+      			<div class="extra-return-services image-only">
+				<label>
+					<img src="/modules/bantrecyclingdeposit/uploads/bant_er_696e046eeb64f.jpg" alt="Miniatura dodatkowego produktu" class="extra-return--image">
+				</label>
+		</div>
+	
+
+      
+    </div>
+  
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="button-container cart">
+	<form action="https://funkyshop.pl/pl/koszyk" method="post">
+		<input type="hidden" name="token" value="b866420ae8aaf943d02267723ab32727">
+		<input type="hidden" value="32" class="quantity_product quantity_product_5844" name="quantity_product">
+		<input type="hidden" value="1" class="minimal_quantity minimal_quantity_5844" name="minimal_quantity">
+		<input type="hidden" value="0" class="id_product_attribute id_product_attribute_5844" name="id_product_attribute">
+		<input type="hidden" value="5844" class="id_product" name="id_product">
+		<input type="hidden" name="id_customization" value="" class="product_customization_id">
+			
+		<input type="hidden" class="input-group form-control qty qty_product qty_product_5844" name="qty" value="1" data-min="1">
+		  <button class="btn btn-product add-to-cart leo-bt-cart leo-bt-cart_5844 leo-enable" data-button-action="add-to-cart" type="submit">
+			<span class="leo-loading cssload-speeding-wheel"></span>
+			<span class="leo-bt-cart-content">
+				<i class="icon-btn-product icon-cart material-icons shopping-cart"></i>
+				<span class="name-btn-product">Dodaj do koszyka</span>
+			</span>
+		  </button>
+	</form>
+</div>
+
+</div>
+  </div>
+</article>
+
+                                                            
+            </div>
+                    
+            
+            
+                                       
+            <div class="ajax_block_product col-sp-12 col-xs-6 col-sm-6 col-md-6 col-lg-4 col-xl-4
+                 first-in-line                                 last-item-of-tablet-line
+                                 last-item-of-mobile-line
+                                                ">
+                
+                                                                                                <article class="product-miniature js-product-miniature" data-id-product="2931" data-id-product-attribute="0" itemscope="" itemtype="http://schema.org/Product">
+  <div class="thumbnail-container">
+    <div class="product-image">
+
+
+        			    	<a href="https://funkyshop.pl/pl/funky-shop/2931-shelter-500ml.html" class="thumbnail product-thumbnail">
+				  <img class="img-fluid" src="https://funkyshop.pl/5040-home_default/shelter-500ml.jpg" alt="Shelter. 500ml" data-full-size-image-url="https://funkyshop.pl/5040-large_default/shelter-500ml.jpg">
+				  					<span class="product-additional" data-idproduct="2931"></span>
+				  				</a>
+
+		      
+
+
+<div class="functional-buttons clearfix">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="quickview no-variants hidden-sm-down">
+<a href="#" class="quick-view" data-link-action="quickview" title="Quick view">
+	<span class="leo-quickview-bt-loading cssload-speeding-wheel"></span>
+	<span class="leo-quickview-bt-content">
+		<i class="material-icons search"></i>
+		<span>Quick view</span>
+	</span>
+</a>
+</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="wishlist">
+			<a class="leo-wishlist-button btn-product btn-primary btn" href="javascript:void(0)" data-id-wishlist="" data-id-product="2931" data-id-product-attribute="0" title="Dodaj do listy życzeń">
+			<span class="leo-wishlist-bt-loading cssload-speeding-wheel"></span>
+			<span class="leo-wishlist-bt-content">
+				<i class="icon-btn-product icon-wishlist material-icons"></i>
+				<span class="name-btn-product">Dodaj do listy życzeń</span>
+			</span>
+		</a>
+	</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+</div></div>
+    <div class="product-meta">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+  <p class="h3 product-title" itemprop="name"><a href="https://funkyshop.pl/pl/funky-shop/2931-shelter-500ml.html">Shelter. 500ml</a></p>
+
+<a class="manufacturer-product" href="https://funkyshop.pl/pl/brand/198-moon-lark">
+    Moon Lark
+</a>
+
+  <div class="product-description-short" itemprop="description"> German Pilsner, 5.2% </div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+      <div class="product-price-and-shipping ">
+      
+      
+      
+      <span class="sr-only">Cena</span>
+      <span class="price" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+        <span itemprop="priceCurrency" content="PLN"></span><span itemprop="price" content="12">12,00&nbsp;zł</span>
+      </span>
+
+      			<div class="extra-return-services image-only">
+				<label>
+					<img src="/modules/bantrecyclingdeposit/uploads/bant_er_696e046eeb64f.jpg" alt="Miniatura dodatkowego produktu" class="extra-return--image">
+				</label>
+		</div>
+	
+
+      
+    </div>
+  
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="button-container cart">
+	<form action="https://funkyshop.pl/pl/koszyk" method="post">
+		<input type="hidden" name="token" value="b866420ae8aaf943d02267723ab32727">
+		<input type="hidden" value="23" class="quantity_product quantity_product_2931" name="quantity_product">
+		<input type="hidden" value="1" class="minimal_quantity minimal_quantity_2931" name="minimal_quantity">
+		<input type="hidden" value="0" class="id_product_attribute id_product_attribute_2931" name="id_product_attribute">
+		<input type="hidden" value="2931" class="id_product" name="id_product">
+		<input type="hidden" name="id_customization" value="" class="product_customization_id">
+			
+		<input type="hidden" class="input-group form-control qty qty_product qty_product_2931" name="qty" value="1" data-min="1">
+		  <button class="btn btn-product add-to-cart leo-bt-cart leo-bt-cart_2931 leo-enable" data-button-action="add-to-cart" type="submit">
+			<span class="leo-loading cssload-speeding-wheel"></span>
+			<span class="leo-bt-cart-content">
+				<i class="icon-btn-product icon-cart material-icons shopping-cart"></i>
+				<span class="name-btn-product">Dodaj do koszyka</span>
+			</span>
+		  </button>
+	</form>
+</div>
+
+</div>
+  </div>
+</article>
+
+                                                            
+            </div>
+                    
+            
+            
+                                       
+            <div class="ajax_block_product col-sp-12 col-xs-6 col-sm-6 col-md-6 col-lg-4 col-xl-4
+                                                 first-item-of-tablet-line                 first-item-of-mobile-line                                ">
+                
+                                                                                                <article class="product-miniature js-product-miniature" data-id-product="3000" data-id-product-attribute="0" itemscope="" itemtype="http://schema.org/Product">
+  <div class="thumbnail-container">
+    <div class="product-image">
+
+
+        			    	<a href="https://funkyshop.pl/pl/funky-shop/3000-bench-500ml.html" class="thumbnail product-thumbnail">
+				  <img class="img-fluid" src="https://funkyshop.pl/5182-home_default/bench-500ml.jpg" alt="Bench. 500ml" data-full-size-image-url="https://funkyshop.pl/5182-large_default/bench-500ml.jpg">
+				  					<span class="product-additional" data-idproduct="3000"></span>
+				  				</a>
+
+		      
+
+
+<div class="functional-buttons clearfix">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="quickview no-variants hidden-sm-down">
+<a href="#" class="quick-view" data-link-action="quickview" title="Quick view">
+	<span class="leo-quickview-bt-loading cssload-speeding-wheel"></span>
+	<span class="leo-quickview-bt-content">
+		<i class="material-icons search"></i>
+		<span>Quick view</span>
+	</span>
+</a>
+</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="wishlist">
+			<a class="leo-wishlist-button btn-product btn-primary btn" href="javascript:void(0)" data-id-wishlist="" data-id-product="3000" data-id-product-attribute="0" title="Dodaj do listy życzeń">
+			<span class="leo-wishlist-bt-loading cssload-speeding-wheel"></span>
+			<span class="leo-wishlist-bt-content">
+				<i class="icon-btn-product icon-wishlist material-icons"></i>
+				<span class="name-btn-product">Dodaj do listy życzeń</span>
+			</span>
+		</a>
+	</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+</div></div>
+    <div class="product-meta">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+  <p class="h3 product-title" itemprop="name"><a href="https://funkyshop.pl/pl/funky-shop/3000-bench-500ml.html">Bench. 500ml</a></p>
+
+<a class="manufacturer-product" href="https://funkyshop.pl/pl/brand/198-moon-lark">
+    Moon Lark
+</a>
+
+  <div class="product-description-short" itemprop="description"> Czech Premium Lager, 5.6% </div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+      <div class="product-price-and-shipping ">
+      
+      
+      
+      <span class="sr-only">Cena</span>
+      <span class="price" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+        <span itemprop="priceCurrency" content="PLN"></span><span itemprop="price" content="12.5">12,50&nbsp;zł</span>
+      </span>
+
+      			<div class="extra-return-services image-only">
+				<label>
+					<img src="/modules/bantrecyclingdeposit/uploads/bant_er_696e046eeb64f.jpg" alt="Miniatura dodatkowego produktu" class="extra-return--image">
+				</label>
+		</div>
+	
+
+      
+    </div>
+  
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="button-container cart">
+	<form action="https://funkyshop.pl/pl/koszyk" method="post">
+		<input type="hidden" name="token" value="b866420ae8aaf943d02267723ab32727">
+		<input type="hidden" value="23" class="quantity_product quantity_product_3000" name="quantity_product">
+		<input type="hidden" value="1" class="minimal_quantity minimal_quantity_3000" name="minimal_quantity">
+		<input type="hidden" value="0" class="id_product_attribute id_product_attribute_3000" name="id_product_attribute">
+		<input type="hidden" value="3000" class="id_product" name="id_product">
+		<input type="hidden" name="id_customization" value="" class="product_customization_id">
+			
+		<input type="hidden" class="input-group form-control qty qty_product qty_product_3000" name="qty" value="1" data-min="1">
+		  <button class="btn btn-product add-to-cart leo-bt-cart leo-bt-cart_3000 leo-enable" data-button-action="add-to-cart" type="submit">
+			<span class="leo-loading cssload-speeding-wheel"></span>
+			<span class="leo-bt-cart-content">
+				<i class="icon-btn-product icon-cart material-icons shopping-cart"></i>
+				<span class="name-btn-product">Dodaj do koszyka</span>
+			</span>
+		  </button>
+	</form>
+</div>
+
+</div>
+  </div>
+</article>
+
+                                                            
+            </div>
+                    
+            
+            
+                                       
+            <div class="ajax_block_product col-sp-12 col-xs-6 col-sm-6 col-md-6 col-lg-4 col-xl-4
+                 last-in-line
+                                                 last-item-of-tablet-line
+                                 last-item-of-mobile-line
+                                                ">
+                
+                                                                                                <article class="product-miniature js-product-miniature" data-id-product="2634" data-id-product-attribute="0" itemscope="" itemtype="http://schema.org/Product">
+  <div class="thumbnail-container">
+    <div class="product-image">
+
+
+        			    	<a href="https://funkyshop.pl/pl/funky-shop/2634-prime-500ml.html" class="thumbnail product-thumbnail">
+				  <img class="img-fluid" src="https://funkyshop.pl/4457-home_default/prime-500ml.jpg" alt="Prime 500ml" data-full-size-image-url="https://funkyshop.pl/4457-large_default/prime-500ml.jpg">
+				  					<span class="product-additional" data-idproduct="2634"></span>
+				  				</a>
+
+		      
+
+
+<div class="functional-buttons clearfix">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="quickview no-variants hidden-sm-down">
+<a href="#" class="quick-view" data-link-action="quickview" title="Quick view">
+	<span class="leo-quickview-bt-loading cssload-speeding-wheel"></span>
+	<span class="leo-quickview-bt-content">
+		<i class="material-icons search"></i>
+		<span>Quick view</span>
+	</span>
+</a>
+</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="wishlist">
+			<a class="leo-wishlist-button btn-product btn-primary btn" href="javascript:void(0)" data-id-wishlist="" data-id-product="2634" data-id-product-attribute="0" title="Dodaj do listy życzeń">
+			<span class="leo-wishlist-bt-loading cssload-speeding-wheel"></span>
+			<span class="leo-wishlist-bt-content">
+				<i class="icon-btn-product icon-wishlist material-icons"></i>
+				<span class="name-btn-product">Dodaj do listy życzeń</span>
+			</span>
+		</a>
+	</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+</div></div>
+    <div class="product-meta">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+  <p class="h3 product-title" itemprop="name"><a href="https://funkyshop.pl/pl/funky-shop/2634-prime-500ml.html">Prime 500ml</a></p>
+
+<a class="manufacturer-product" href="https://funkyshop.pl/pl/brand/198-moon-lark">
+    Moon Lark
+</a>
+
+  <div class="product-description-short" itemprop="description"> Citra/El Dorado/Columbus West Coast IPA, 6.8% </div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+      <div class="product-price-and-shipping ">
+      
+      
+      
+      <span class="sr-only">Cena</span>
+      <span class="price" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+        <span itemprop="priceCurrency" content="PLN"></span><span itemprop="price" content="16">16,00&nbsp;zł</span>
+      </span>
+
+      			<div class="extra-return-services image-only">
+				<label>
+					<img src="/modules/bantrecyclingdeposit/uploads/bant_er_696e046eeb64f.jpg" alt="Miniatura dodatkowego produktu" class="extra-return--image">
+				</label>
+		</div>
+	
+
+      
+    </div>
+  
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="button-container cart">
+	<form action="https://funkyshop.pl/pl/koszyk" method="post">
+		<input type="hidden" name="token" value="b866420ae8aaf943d02267723ab32727">
+		<input type="hidden" value="23" class="quantity_product quantity_product_2634" name="quantity_product">
+		<input type="hidden" value="1" class="minimal_quantity minimal_quantity_2634" name="minimal_quantity">
+		<input type="hidden" value="0" class="id_product_attribute id_product_attribute_2634" name="id_product_attribute">
+		<input type="hidden" value="2634" class="id_product" name="id_product">
+		<input type="hidden" name="id_customization" value="" class="product_customization_id">
+			
+		<input type="hidden" class="input-group form-control qty qty_product qty_product_2634" name="qty" value="1" data-min="1">
+		  <button class="btn btn-product add-to-cart leo-bt-cart leo-bt-cart_2634 leo-enable" data-button-action="add-to-cart" type="submit">
+			<span class="leo-loading cssload-speeding-wheel"></span>
+			<span class="leo-bt-cart-content">
+				<i class="icon-btn-product icon-cart material-icons shopping-cart"></i>
+				<span class="name-btn-product">Dodaj do koszyka</span>
+			</span>
+		  </button>
+	</form>
+</div>
+
+</div>
+  </div>
+</article>
+
+                                                            
+            </div>
+                    
+            
+            
+                                       
+            <div class="ajax_block_product col-sp-12 col-xs-6 col-sm-6 col-md-6 col-lg-4 col-xl-4
+                 first-in-line                                 first-item-of-tablet-line                 first-item-of-mobile-line                                ">
+                
+                                                                                                <article class="product-miniature js-product-miniature" data-id-product="2930" data-id-product-attribute="0" itemscope="" itemtype="http://schema.org/Product">
+  <div class="thumbnail-container">
+    <div class="product-image">
+
+
+        			    	<a href="https://funkyshop.pl/pl/funky-shop/2930-raise-500ml.html" class="thumbnail product-thumbnail">
+				  <img class="img-fluid" src="https://funkyshop.pl/5038-home_default/raise-500ml.jpg" alt="Raise 500ml" data-full-size-image-url="https://funkyshop.pl/5038-large_default/raise-500ml.jpg">
+				  					<span class="product-additional" data-idproduct="2930"></span>
+				  				</a>
+
+		      
+
+
+<div class="functional-buttons clearfix">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="quickview no-variants hidden-sm-down">
+<a href="#" class="quick-view" data-link-action="quickview" title="Quick view">
+	<span class="leo-quickview-bt-loading cssload-speeding-wheel"></span>
+	<span class="leo-quickview-bt-content">
+		<i class="material-icons search"></i>
+		<span>Quick view</span>
+	</span>
+</a>
+</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="wishlist">
+			<a class="leo-wishlist-button btn-product btn-primary btn" href="javascript:void(0)" data-id-wishlist="" data-id-product="2930" data-id-product-attribute="0" title="Dodaj do listy życzeń">
+			<span class="leo-wishlist-bt-loading cssload-speeding-wheel"></span>
+			<span class="leo-wishlist-bt-content">
+				<i class="icon-btn-product icon-wishlist material-icons"></i>
+				<span class="name-btn-product">Dodaj do listy życzeń</span>
+			</span>
+		</a>
+	</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+</div></div>
+    <div class="product-meta">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+  <p class="h3 product-title" itemprop="name"><a href="https://funkyshop.pl/pl/funky-shop/2930-raise-500ml.html">Raise 500ml</a></p>
+
+<a class="manufacturer-product" href="https://funkyshop.pl/pl/brand/198-moon-lark">
+    Moon Lark
+</a>
+
+  <div class="product-description-short" itemprop="description"> Helles Lager, 4.8% </div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+      <div class="product-price-and-shipping ">
+      
+      
+      
+      <span class="sr-only">Cena</span>
+      <span class="price" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+        <span itemprop="priceCurrency" content="PLN"></span><span itemprop="price" content="12">12,00&nbsp;zł</span>
+      </span>
+
+      			<div class="extra-return-services image-only">
+				<label>
+					<img src="/modules/bantrecyclingdeposit/uploads/bant_er_696e046eeb64f.jpg" alt="Miniatura dodatkowego produktu" class="extra-return--image">
+				</label>
+		</div>
+	
+
+      
+    </div>
+  
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="button-container cart">
+	<form action="https://funkyshop.pl/pl/koszyk" method="post">
+		<input type="hidden" name="token" value="b866420ae8aaf943d02267723ab32727">
+		<input type="hidden" value="23" class="quantity_product quantity_product_2930" name="quantity_product">
+		<input type="hidden" value="1" class="minimal_quantity minimal_quantity_2930" name="minimal_quantity">
+		<input type="hidden" value="0" class="id_product_attribute id_product_attribute_2930" name="id_product_attribute">
+		<input type="hidden" value="2930" class="id_product" name="id_product">
+		<input type="hidden" name="id_customization" value="" class="product_customization_id">
+			
+		<input type="hidden" class="input-group form-control qty qty_product qty_product_2930" name="qty" value="1" data-min="1">
+		  <button class="btn btn-product add-to-cart leo-bt-cart leo-bt-cart_2930 leo-enable" data-button-action="add-to-cart" type="submit">
+			<span class="leo-loading cssload-speeding-wheel"></span>
+			<span class="leo-bt-cart-content">
+				<i class="icon-btn-product icon-cart material-icons shopping-cart"></i>
+				<span class="name-btn-product">Dodaj do koszyka</span>
+			</span>
+		  </button>
+	</form>
+</div>
+
+</div>
+  </div>
+</article>
+
+                                                            
+            </div>
+                    
+            
+            
+                                       
+            <div class="ajax_block_product col-sp-12 col-xs-6 col-sm-6 col-md-6 col-lg-4 col-xl-4
+                                                 last-item-of-tablet-line
+                                 last-item-of-mobile-line
+                                                ">
+                
+                                                                                                <article class="product-miniature js-product-miniature" data-id-product="4943" data-id-product-attribute="0" itemscope="" itemtype="http://schema.org/Product">
+  <div class="thumbnail-container">
+    <div class="product-image">
+
+
+        			    	<a href="https://funkyshop.pl/pl/nowosci/4943-affection-2026-330ml.html" class="thumbnail product-thumbnail">
+				  <img class="img-fluid" src="https://funkyshop.pl/10802-home_default/affection-2026-330ml.jpg" alt="Affection (2026) 330ml" data-full-size-image-url="https://funkyshop.pl/10802-large_default/affection-2026-330ml.jpg">
+				  					<span class="product-additional" data-idproduct="4943"></span>
+				  				</a>
+
+		      
+
+
+<div class="functional-buttons clearfix">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="quickview no-variants hidden-sm-down">
+<a href="#" class="quick-view" data-link-action="quickview" title="Quick view">
+	<span class="leo-quickview-bt-loading cssload-speeding-wheel"></span>
+	<span class="leo-quickview-bt-content">
+		<i class="material-icons search"></i>
+		<span>Quick view</span>
+	</span>
+</a>
+</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="wishlist">
+			<a class="leo-wishlist-button btn-product btn-primary btn" href="javascript:void(0)" data-id-wishlist="" data-id-product="4943" data-id-product-attribute="0" title="Dodaj do listy życzeń">
+			<span class="leo-wishlist-bt-loading cssload-speeding-wheel"></span>
+			<span class="leo-wishlist-bt-content">
+				<i class="icon-btn-product icon-wishlist material-icons"></i>
+				<span class="name-btn-product">Dodaj do listy życzeń</span>
+			</span>
+		</a>
+	</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+</div></div>
+    <div class="product-meta">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+  <p class="h3 product-title" itemprop="name"><a href="https://funkyshop.pl/pl/nowosci/4943-affection-2026-330ml.html">Affection (2026) 330ml</a></p>
+
+<a class="manufacturer-product" href="https://funkyshop.pl/pl/brand/143-pinta-barrel-brewing">
+    Pinta Barrel Brewing
+</a>
+
+  <div class="product-description-short" itemprop="description"> Bourbon BA Imp Stout w. coconut, cocoa, coffee &amp; vanilla, 14%&nbsp; </div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+      <div class="product-price-and-shipping ">
+      
+      
+      
+      <span class="sr-only">Cena</span>
+      <span class="price" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+        <span itemprop="priceCurrency" content="PLN"></span><span itemprop="price" content="52">52,00&nbsp;zł</span>
+      </span>
+
+      
+
+      
+    </div>
+  
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="button-container cart">
+	<form action="https://funkyshop.pl/pl/koszyk" method="post">
+		<input type="hidden" name="token" value="b866420ae8aaf943d02267723ab32727">
+		<input type="hidden" value="24" class="quantity_product quantity_product_4943" name="quantity_product">
+		<input type="hidden" value="1" class="minimal_quantity minimal_quantity_4943" name="minimal_quantity">
+		<input type="hidden" value="0" class="id_product_attribute id_product_attribute_4943" name="id_product_attribute">
+		<input type="hidden" value="4943" class="id_product" name="id_product">
+		<input type="hidden" name="id_customization" value="" class="product_customization_id">
+			
+		<input type="hidden" class="input-group form-control qty qty_product qty_product_4943" name="qty" value="1" data-min="1">
+		  <button class="btn btn-product add-to-cart leo-bt-cart leo-bt-cart_4943 leo-enable" data-button-action="add-to-cart" type="submit">
+			<span class="leo-loading cssload-speeding-wheel"></span>
+			<span class="leo-bt-cart-content">
+				<i class="icon-btn-product icon-cart material-icons shopping-cart"></i>
+				<span class="name-btn-product">Dodaj do koszyka</span>
+			</span>
+		  </button>
+	</form>
+</div>
+
+</div>
+  </div>
+</article>
+
+                                                            
+            </div>
+                    
+            
+            
+                                       
+            <div class="ajax_block_product col-sp-12 col-xs-6 col-sm-6 col-md-6 col-lg-4 col-xl-4
+                 last-in-line
+                                                 first-item-of-tablet-line                 first-item-of-mobile-line                                ">
+                
+                                                                                                <article class="product-miniature js-product-miniature" data-id-product="3868" data-id-product-attribute="0" itemscope="" itemtype="http://schema.org/Product">
+  <div class="thumbnail-container">
+    <div class="product-image">
+
+
+        			    	<a href="https://funkyshop.pl/pl/nowosci/3868-liberty-2026-330ml.html" class="thumbnail product-thumbnail">
+				  <img class="img-fluid" src="https://funkyshop.pl/10803-home_default/liberty-2026-330ml.jpg" alt="Liberty (2026) 330ml" data-full-size-image-url="https://funkyshop.pl/10803-large_default/liberty-2026-330ml.jpg">
+				  					<span class="product-additional" data-idproduct="3868"></span>
+				  				</a>
+
+		      
+
+
+<div class="functional-buttons clearfix">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="quickview no-variants hidden-sm-down">
+<a href="#" class="quick-view" data-link-action="quickview" title="Quick view">
+	<span class="leo-quickview-bt-loading cssload-speeding-wheel"></span>
+	<span class="leo-quickview-bt-content">
+		<i class="material-icons search"></i>
+		<span>Quick view</span>
+	</span>
+</a>
+</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="wishlist">
+			<a class="leo-wishlist-button btn-product btn-primary btn" href="javascript:void(0)" data-id-wishlist="" data-id-product="3868" data-id-product-attribute="0" title="Dodaj do listy życzeń">
+			<span class="leo-wishlist-bt-loading cssload-speeding-wheel"></span>
+			<span class="leo-wishlist-bt-content">
+				<i class="icon-btn-product icon-wishlist material-icons"></i>
+				<span class="name-btn-product">Dodaj do listy życzeń</span>
+			</span>
+		</a>
+	</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+</div></div>
+    <div class="product-meta">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+  <p class="h3 product-title" itemprop="name"><a href="https://funkyshop.pl/pl/nowosci/3868-liberty-2026-330ml.html">Liberty (2026) 330ml</a></p>
+
+<a class="manufacturer-product" href="https://funkyshop.pl/pl/brand/143-pinta-barrel-brewing">
+    Pinta Barrel Brewing
+</a>
+
+  <div class="product-description-short" itemprop="description"> Bourbon BA Imp Stout w. vanilla, coconut &amp; BA coffee, 12%&nbsp; </div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+      <div class="product-price-and-shipping ">
+      
+      
+      
+      <span class="sr-only">Cena</span>
+      <span class="price" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+        <span itemprop="priceCurrency" content="PLN"></span><span itemprop="price" content="52">52,00&nbsp;zł</span>
+      </span>
+
+      
+
+      
+    </div>
+  
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="button-container cart">
+	<form action="https://funkyshop.pl/pl/koszyk" method="post">
+		<input type="hidden" name="token" value="b866420ae8aaf943d02267723ab32727">
+		<input type="hidden" value="11" class="quantity_product quantity_product_3868" name="quantity_product">
+		<input type="hidden" value="1" class="minimal_quantity minimal_quantity_3868" name="minimal_quantity">
+		<input type="hidden" value="0" class="id_product_attribute id_product_attribute_3868" name="id_product_attribute">
+		<input type="hidden" value="3868" class="id_product" name="id_product">
+		<input type="hidden" name="id_customization" value="" class="product_customization_id">
+			
+		<input type="hidden" class="input-group form-control qty qty_product qty_product_3868" name="qty" value="1" data-min="1">
+		  <button class="btn btn-product add-to-cart leo-bt-cart leo-bt-cart_3868 leo-enable" data-button-action="add-to-cart" type="submit">
+			<span class="leo-loading cssload-speeding-wheel"></span>
+			<span class="leo-bt-cart-content">
+				<i class="icon-btn-product icon-cart material-icons shopping-cart"></i>
+				<span class="name-btn-product">Dodaj do koszyka</span>
+			</span>
+		  </button>
+	</form>
+</div>
+
+</div>
+  </div>
+</article>
+
+                                                            
+            </div>
+                    
+            
+            
+                                       
+            <div class="ajax_block_product col-sp-12 col-xs-6 col-sm-6 col-md-6 col-lg-4 col-xl-4
+                 first-in-line                                 last-item-of-tablet-line
+                                 last-item-of-mobile-line
+                                                ">
+                
+                                                                                                <article class="product-miniature js-product-miniature" data-id-product="5836" data-id-product-attribute="0" itemscope="" itemtype="http://schema.org/Product">
+  <div class="thumbnail-container">
+    <div class="product-image">
+
+
+        			    	<a href="https://funkyshop.pl/pl/piwo-rzemieslnicze/5836-hazy-discovery-setubal-500ml.html" class="thumbnail product-thumbnail">
+				  <img class="img-fluid" src="https://funkyshop.pl/10799-home_default/hazy-discovery-setubal-500ml.jpg" alt="Hazy Discovery Setubal 500ml" data-full-size-image-url="https://funkyshop.pl/10799-large_default/hazy-discovery-setubal-500ml.jpg">
+				  					<span class="product-additional" data-idproduct="5836"></span>
+				  				</a>
+
+		      
+
+
+<div class="functional-buttons clearfix">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="quickview no-variants hidden-sm-down">
+<a href="#" class="quick-view" data-link-action="quickview" title="Quick view">
+	<span class="leo-quickview-bt-loading cssload-speeding-wheel"></span>
+	<span class="leo-quickview-bt-content">
+		<i class="material-icons search"></i>
+		<span>Quick view</span>
+	</span>
+</a>
+</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="wishlist">
+			<a class="leo-wishlist-button btn-product btn-primary btn" href="javascript:void(0)" data-id-wishlist="" data-id-product="5836" data-id-product-attribute="0" title="Dodaj do listy życzeń">
+			<span class="leo-wishlist-bt-loading cssload-speeding-wheel"></span>
+			<span class="leo-wishlist-bt-content">
+				<i class="icon-btn-product icon-wishlist material-icons"></i>
+				<span class="name-btn-product">Dodaj do listy życzeń</span>
+			</span>
+		</a>
+	</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+</div></div>
+    <div class="product-meta">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+  <p class="h3 product-title" itemprop="name"><a href="https://funkyshop.pl/pl/piwo-rzemieslnicze/5836-hazy-discovery-setubal-500ml.html">Hazy Discovery Setubal 500ml</a></p>
+
+<a class="manufacturer-product" href="https://funkyshop.pl/pl/brand/56-pinta">
+    PINTA
+</a>
+
+  <div class="product-description-short" itemprop="description"> Citra/Krush Cryo/Riwaka Amplifire Hazy IPA, 6.5% </div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+      <div class="product-price-and-shipping ">
+      
+      
+      
+      <span class="sr-only">Cena</span>
+      <span class="price" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+        <span itemprop="priceCurrency" content="PLN"></span><span itemprop="price" content="19.5">19,50&nbsp;zł</span>
+      </span>
+
+      			<div class="extra-return-services image-only">
+				<label>
+					<img src="/modules/bantrecyclingdeposit/uploads/bant_er_696e046eeb64f.jpg" alt="Miniatura dodatkowego produktu" class="extra-return--image">
+				</label>
+		</div>
+	
+
+      
+    </div>
+  
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="button-container cart">
+	<form action="https://funkyshop.pl/pl/koszyk" method="post">
+		<input type="hidden" name="token" value="b866420ae8aaf943d02267723ab32727">
+		<input type="hidden" value="2" class="quantity_product quantity_product_5836" name="quantity_product">
+		<input type="hidden" value="1" class="minimal_quantity minimal_quantity_5836" name="minimal_quantity">
+		<input type="hidden" value="0" class="id_product_attribute id_product_attribute_5836" name="id_product_attribute">
+		<input type="hidden" value="5836" class="id_product" name="id_product">
+		<input type="hidden" name="id_customization" value="" class="product_customization_id">
+			
+		<input type="hidden" class="input-group form-control qty qty_product qty_product_5836" name="qty" value="1" data-min="1">
+		  <button class="btn btn-product add-to-cart leo-bt-cart leo-bt-cart_5836 leo-enable" data-button-action="add-to-cart" type="submit">
+			<span class="leo-loading cssload-speeding-wheel"></span>
+			<span class="leo-bt-cart-content">
+				<i class="icon-btn-product icon-cart material-icons shopping-cart"></i>
+				<span class="name-btn-product">Dodaj do koszyka</span>
+			</span>
+		  </button>
+	</form>
+</div>
+
+</div>
+  </div>
+</article>
+
+                                                            
+            </div>
+                    
+            
+            
+                                       
+            <div class="ajax_block_product col-sp-12 col-xs-6 col-sm-6 col-md-6 col-lg-4 col-xl-4
+                                                 first-item-of-tablet-line                 first-item-of-mobile-line                                ">
+                
+                                                                                                <article class="product-miniature js-product-miniature" data-id-product="5837" data-id-product-attribute="0" itemscope="" itemtype="http://schema.org/Product">
+  <div class="thumbnail-container">
+    <div class="product-image">
+
+
+        			    	<a href="https://funkyshop.pl/pl/piwo-rzemieslnicze/5837-perfect-piece-x-other-half-500ml.html" class="thumbnail product-thumbnail">
+				  <img class="img-fluid" src="https://funkyshop.pl/10801-home_default/perfect-piece-x-other-half-500ml.jpg" alt="Perfect Piece (x Other Half) 500ml" data-full-size-image-url="https://funkyshop.pl/10801-large_default/perfect-piece-x-other-half-500ml.jpg">
+				  					<span class="product-additional" data-idproduct="5837"></span>
+				  				</a>
+
+		      
+
+
+<div class="functional-buttons clearfix">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="quickview no-variants hidden-sm-down">
+<a href="#" class="quick-view" data-link-action="quickview" title="Quick view">
+	<span class="leo-quickview-bt-loading cssload-speeding-wheel"></span>
+	<span class="leo-quickview-bt-content">
+		<i class="material-icons search"></i>
+		<span>Quick view</span>
+	</span>
+</a>
+</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="wishlist">
+			<a class="leo-wishlist-button btn-product btn-primary btn" href="javascript:void(0)" data-id-wishlist="" data-id-product="5837" data-id-product-attribute="0" title="Dodaj do listy życzeń">
+			<span class="leo-wishlist-bt-loading cssload-speeding-wheel"></span>
+			<span class="leo-wishlist-bt-content">
+				<i class="icon-btn-product icon-wishlist material-icons"></i>
+				<span class="name-btn-product">Dodaj do listy życzeń</span>
+			</span>
+		</a>
+	</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+</div></div>
+    <div class="product-meta">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+  <p class="h3 product-title" itemprop="name"><a href="https://funkyshop.pl/pl/piwo-rzemieslnicze/5837-perfect-piece-x-other-half-500ml.html">Perfect Piece (x Other Half) 500ml</a></p>
+
+<a class="manufacturer-product" href="https://funkyshop.pl/pl/brand/56-pinta">
+    PINTA
+</a>
+
+  <div class="product-description-short" itemprop="description"> Nectaron/Motueka/Dolcita Hazy IPA, 6.5% </div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+      <div class="product-price-and-shipping ">
+      
+      
+      
+      <span class="sr-only">Cena</span>
+      <span class="price" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+        <span itemprop="priceCurrency" content="PLN"></span><span itemprop="price" content="21.5">21,50&nbsp;zł</span>
+      </span>
+
+      			<div class="extra-return-services image-only">
+				<label>
+					<img src="/modules/bantrecyclingdeposit/uploads/bant_er_696e046eeb64f.jpg" alt="Miniatura dodatkowego produktu" class="extra-return--image">
+				</label>
+		</div>
+	
+
+      
+    </div>
+  
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="button-container cart">
+	<form action="https://funkyshop.pl/pl/koszyk" method="post">
+		<input type="hidden" name="token" value="b866420ae8aaf943d02267723ab32727">
+		<input type="hidden" value="15" class="quantity_product quantity_product_5837" name="quantity_product">
+		<input type="hidden" value="1" class="minimal_quantity minimal_quantity_5837" name="minimal_quantity">
+		<input type="hidden" value="0" class="id_product_attribute id_product_attribute_5837" name="id_product_attribute">
+		<input type="hidden" value="5837" class="id_product" name="id_product">
+		<input type="hidden" name="id_customization" value="" class="product_customization_id">
+			
+		<input type="hidden" class="input-group form-control qty qty_product qty_product_5837" name="qty" value="1" data-min="1">
+		  <button class="btn btn-product add-to-cart leo-bt-cart leo-bt-cart_5837 leo-enable" data-button-action="add-to-cart" type="submit">
+			<span class="leo-loading cssload-speeding-wheel"></span>
+			<span class="leo-bt-cart-content">
+				<i class="icon-btn-product icon-cart material-icons shopping-cart"></i>
+				<span class="name-btn-product">Dodaj do koszyka</span>
+			</span>
+		  </button>
+	</form>
+</div>
+
+</div>
+  </div>
+</article>
+
+                                                            
+            </div>
+                    
+            
+            
+                                       
+            <div class="ajax_block_product col-sp-12 col-xs-6 col-sm-6 col-md-6 col-lg-4 col-xl-4
+                 last-in-line
+                                                 last-item-of-tablet-line
+                                 last-item-of-mobile-line
+                                                ">
+                
+                                                                                                <article class="product-miniature js-product-miniature" data-id-product="5838" data-id-product-attribute="0" itemscope="" itemtype="http://schema.org/Product">
+  <div class="thumbnail-container">
+    <div class="product-image">
+
+
+        			    	<a href="https://funkyshop.pl/pl/piwo-rzemieslnicze/5838-xiv-330ml.html" class="thumbnail product-thumbnail">
+				  <img class="img-fluid" src="https://funkyshop.pl/10807-home_default/xiv-330ml.jpg" alt="XIV 330ml" data-full-size-image-url="https://funkyshop.pl/10807-large_default/xiv-330ml.jpg">
+				  					<span class="product-additional" data-idproduct="5838"></span>
+				  				</a>
+
+		      
+
+
+<div class="functional-buttons clearfix">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="quickview no-variants hidden-sm-down">
+<a href="#" class="quick-view" data-link-action="quickview" title="Quick view">
+	<span class="leo-quickview-bt-loading cssload-speeding-wheel"></span>
+	<span class="leo-quickview-bt-content">
+		<i class="material-icons search"></i>
+		<span>Quick view</span>
+	</span>
+</a>
+</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="wishlist">
+			<a class="leo-wishlist-button btn-product btn-primary btn" href="javascript:void(0)" data-id-wishlist="" data-id-product="5838" data-id-product-attribute="0" title="Dodaj do listy życzeń">
+			<span class="leo-wishlist-bt-loading cssload-speeding-wheel"></span>
+			<span class="leo-wishlist-bt-content">
+				<i class="icon-btn-product icon-wishlist material-icons"></i>
+				<span class="name-btn-product">Dodaj do listy życzeń</span>
+			</span>
+		</a>
+	</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+</div></div>
+    <div class="product-meta">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+  <p class="h3 product-title" itemprop="name"><a href="https://funkyshop.pl/pl/piwo-rzemieslnicze/5838-xiv-330ml.html">XIV 330ml</a></p>
+
+<a class="manufacturer-product" href="https://funkyshop.pl/pl/brand/39-artezan">
+    Artezan
+</a>
+
+  <div class="product-description-short" itemprop="description"> Bourbon &amp; Rum BA Mocha Imperial Stout, 13% </div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+      <div class="product-price-and-shipping ">
+      
+      
+      
+      <span class="sr-only">Cena</span>
+      <span class="price" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+        <span itemprop="priceCurrency" content="PLN"></span><span itemprop="price" content="52">52,00&nbsp;zł</span>
+      </span>
+
+      
+
+      
+    </div>
+  
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="button-container cart">
+	<form action="https://funkyshop.pl/pl/koszyk" method="post">
+		<input type="hidden" name="token" value="b866420ae8aaf943d02267723ab32727">
+		<input type="hidden" value="25" class="quantity_product quantity_product_5838" name="quantity_product">
+		<input type="hidden" value="1" class="minimal_quantity minimal_quantity_5838" name="minimal_quantity">
+		<input type="hidden" value="0" class="id_product_attribute id_product_attribute_5838" name="id_product_attribute">
+		<input type="hidden" value="5838" class="id_product" name="id_product">
+		<input type="hidden" name="id_customization" value="" class="product_customization_id">
+			
+		<input type="hidden" class="input-group form-control qty qty_product qty_product_5838" name="qty" value="1" data-min="1">
+		  <button class="btn btn-product add-to-cart leo-bt-cart leo-bt-cart_5838 leo-enable" data-button-action="add-to-cart" type="submit">
+			<span class="leo-loading cssload-speeding-wheel"></span>
+			<span class="leo-bt-cart-content">
+				<i class="icon-btn-product icon-cart material-icons shopping-cart"></i>
+				<span class="name-btn-product">Dodaj do koszyka</span>
+			</span>
+		  </button>
+	</form>
+</div>
+
+</div>
+  </div>
+</article>
+
+                                                            
+            </div>
+                    
+            
+            
+                                       
+            <div class="ajax_block_product col-sp-12 col-xs-6 col-sm-6 col-md-6 col-lg-4 col-xl-4
+                 first-in-line                                 first-item-of-tablet-line                 first-item-of-mobile-line                                ">
+                
+                                                                                                <article class="product-miniature js-product-miniature" data-id-product="5839" data-id-product-attribute="0" itemscope="" itemtype="http://schema.org/Product">
+  <div class="thumbnail-container">
+    <div class="product-image">
+
+
+        			    	<a href="https://funkyshop.pl/pl/piwo-rzemieslnicze/5839-samiec-alfa-bananas-chocolate-foster-330ml.html" class="thumbnail product-thumbnail">
+				  <img class="img-fluid" src="https://funkyshop.pl/10806-home_default/samiec-alfa-bananas-chocolate-foster-330ml.jpg" alt="Samiec Alfa Bananas &amp; Chocolate Foster 330ml" data-full-size-image-url="https://funkyshop.pl/10806-large_default/samiec-alfa-bananas-chocolate-foster-330ml.jpg">
+				  					<span class="product-additional" data-idproduct="5839"></span>
+				  				</a>
+
+		      
+
+
+<div class="functional-buttons clearfix">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="quickview no-variants hidden-sm-down">
+<a href="#" class="quick-view" data-link-action="quickview" title="Quick view">
+	<span class="leo-quickview-bt-loading cssload-speeding-wheel"></span>
+	<span class="leo-quickview-bt-content">
+		<i class="material-icons search"></i>
+		<span>Quick view</span>
+	</span>
+</a>
+</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="wishlist">
+			<a class="leo-wishlist-button btn-product btn-primary btn" href="javascript:void(0)" data-id-wishlist="" data-id-product="5839" data-id-product-attribute="0" title="Dodaj do listy życzeń">
+			<span class="leo-wishlist-bt-loading cssload-speeding-wheel"></span>
+			<span class="leo-wishlist-bt-content">
+				<i class="icon-btn-product icon-wishlist material-icons"></i>
+				<span class="name-btn-product">Dodaj do listy życzeń</span>
+			</span>
+		</a>
+	</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+</div></div>
+    <div class="product-meta">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+  <p class="h3 product-title" itemprop="name"><a href="https://funkyshop.pl/pl/piwo-rzemieslnicze/5839-samiec-alfa-bananas-chocolate-foster-330ml.html">Samiec Alfa Bananas &amp; Chocolate Foster 330ml</a></p>
+
+<a class="manufacturer-product" href="https://funkyshop.pl/pl/brand/39-artezan">
+    Artezan
+</a>
+
+  <div class="product-description-short" itemprop="description"> Bourbon BA Banana/Cocoa Nibs/Maple Syrup Imperial Stout, 13% </div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+      <div class="product-price-and-shipping ">
+      
+      
+      
+      <span class="sr-only">Cena</span>
+      <span class="price" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+        <span itemprop="priceCurrency" content="PLN"></span><span itemprop="price" content="52">52,00&nbsp;zł</span>
+      </span>
+
+      
+
+      
+    </div>
+  
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="button-container cart">
+	<form action="https://funkyshop.pl/pl/koszyk" method="post">
+		<input type="hidden" name="token" value="b866420ae8aaf943d02267723ab32727">
+		<input type="hidden" value="20" class="quantity_product quantity_product_5839" name="quantity_product">
+		<input type="hidden" value="1" class="minimal_quantity minimal_quantity_5839" name="minimal_quantity">
+		<input type="hidden" value="0" class="id_product_attribute id_product_attribute_5839" name="id_product_attribute">
+		<input type="hidden" value="5839" class="id_product" name="id_product">
+		<input type="hidden" name="id_customization" value="" class="product_customization_id">
+			
+		<input type="hidden" class="input-group form-control qty qty_product qty_product_5839" name="qty" value="1" data-min="1">
+		  <button class="btn btn-product add-to-cart leo-bt-cart leo-bt-cart_5839 leo-enable" data-button-action="add-to-cart" type="submit">
+			<span class="leo-loading cssload-speeding-wheel"></span>
+			<span class="leo-bt-cart-content">
+				<i class="icon-btn-product icon-cart material-icons shopping-cart"></i>
+				<span class="name-btn-product">Dodaj do koszyka</span>
+			</span>
+		  </button>
+	</form>
+</div>
+
+</div>
+  </div>
+</article>
+
+                                                            
+            </div>
+                    
+            
+            
+                                       
+            <div class="ajax_block_product col-sp-12 col-xs-6 col-sm-6 col-md-6 col-lg-4 col-xl-4
+                                                 last-item-of-tablet-line
+                                 last-item-of-mobile-line
+                                                ">
+                
+                                                                                                <article class="product-miniature js-product-miniature" data-id-product="5747" data-id-product-attribute="0" itemscope="" itemtype="http://schema.org/Product">
+  <div class="thumbnail-container">
+    <div class="product-image">
+
+
+        			    	<a href="https://funkyshop.pl/pl/piwo-rzemieslnicze/5747-hazy-discovery-sunnyside-500ml.html" class="thumbnail product-thumbnail">
+				  <img class="img-fluid" src="https://funkyshop.pl/10589-home_default/hazy-discovery-sunnyside-500ml.jpg" alt="Hazy Discovery Sunnyside 500ml" data-full-size-image-url="https://funkyshop.pl/10589-large_default/hazy-discovery-sunnyside-500ml.jpg">
+				  					<span class="product-additional" data-idproduct="5747"></span>
+				  				</a>
+
+		      
+
+
+<div class="functional-buttons clearfix">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="quickview no-variants hidden-sm-down">
+<a href="#" class="quick-view" data-link-action="quickview" title="Quick view">
+	<span class="leo-quickview-bt-loading cssload-speeding-wheel"></span>
+	<span class="leo-quickview-bt-content">
+		<i class="material-icons search"></i>
+		<span>Quick view</span>
+	</span>
+</a>
+</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="wishlist">
+			<a class="leo-wishlist-button btn-product btn-primary btn" href="javascript:void(0)" data-id-wishlist="" data-id-product="5747" data-id-product-attribute="0" title="Dodaj do listy życzeń">
+			<span class="leo-wishlist-bt-loading cssload-speeding-wheel"></span>
+			<span class="leo-wishlist-bt-content">
+				<i class="icon-btn-product icon-wishlist material-icons"></i>
+				<span class="name-btn-product">Dodaj do listy życzeń</span>
+			</span>
+		</a>
+	</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+</div></div>
+    <div class="product-meta">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+  <p class="h3 product-title" itemprop="name"><a href="https://funkyshop.pl/pl/piwo-rzemieslnicze/5747-hazy-discovery-sunnyside-500ml.html">Hazy Discovery Sunnyside 500ml</a></p>
+
+<a class="manufacturer-product" href="https://funkyshop.pl/pl/brand/56-pinta">
+    PINTA
+</a>
+
+  <div class="product-description-short" itemprop="description"> Galaxy/Krush/Dolcita Cryo Hazy IPA, 6.5% </div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+      <div class="product-price-and-shipping ">
+      
+      
+      
+      <span class="sr-only">Cena</span>
+      <span class="price" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+        <span itemprop="priceCurrency" content="PLN"></span><span itemprop="price" content="19">19,00&nbsp;zł</span>
+      </span>
+
+      			<div class="extra-return-services image-only">
+				<label>
+					<img src="/modules/bantrecyclingdeposit/uploads/bant_er_696e046eeb64f.jpg" alt="Miniatura dodatkowego produktu" class="extra-return--image">
+				</label>
+		</div>
+	
+
+      
+    </div>
+  
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+</div>
+  </div>
+</article>
+
+                                                            
+            </div>
+                    
+            
+            
+                                       
+            <div class="ajax_block_product col-sp-12 col-xs-6 col-sm-6 col-md-6 col-lg-4 col-xl-4
+                 last-in-line
+                                                 first-item-of-tablet-line                 first-item-of-mobile-line                                ">
+                
+                                                                                                <article class="product-miniature js-product-miniature" data-id-product="5746" data-id-product-attribute="0" itemscope="" itemtype="http://schema.org/Product">
+  <div class="thumbnail-container">
+    <div class="product-image">
+
+
+        			    	<a href="https://funkyshop.pl/pl/piwo-rzemieslnicze/5746-hazy-discovery-groningen-500ml.html" class="thumbnail product-thumbnail">
+				  <img class="img-fluid" src="https://funkyshop.pl/10588-home_default/hazy-discovery-groningen-500ml.jpg" alt="Hazy Discovery Groningen 500ml" data-full-size-image-url="https://funkyshop.pl/10588-large_default/hazy-discovery-groningen-500ml.jpg">
+				  					<span class="product-additional" data-idproduct="5746"></span>
+				  				</a>
+
+		      
+
+
+<div class="functional-buttons clearfix">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="quickview no-variants hidden-sm-down">
+<a href="#" class="quick-view" data-link-action="quickview" title="Quick view">
+	<span class="leo-quickview-bt-loading cssload-speeding-wheel"></span>
+	<span class="leo-quickview-bt-content">
+		<i class="material-icons search"></i>
+		<span>Quick view</span>
+	</span>
+</a>
+</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="wishlist">
+			<a class="leo-wishlist-button btn-product btn-primary btn" href="javascript:void(0)" data-id-wishlist="" data-id-product="5746" data-id-product-attribute="0" title="Dodaj do listy życzeń">
+			<span class="leo-wishlist-bt-loading cssload-speeding-wheel"></span>
+			<span class="leo-wishlist-bt-content">
+				<i class="icon-btn-product icon-wishlist material-icons"></i>
+				<span class="name-btn-product">Dodaj do listy życzeń</span>
+			</span>
+		</a>
+	</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+</div></div>
+    <div class="product-meta">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+  <p class="h3 product-title" itemprop="name"><a href="https://funkyshop.pl/pl/piwo-rzemieslnicze/5746-hazy-discovery-groningen-500ml.html">Hazy Discovery Groningen 500ml</a></p>
+
+<a class="manufacturer-product" href="https://funkyshop.pl/pl/brand/56-pinta">
+    PINTA
+</a>
+
+  <div class="product-description-short" itemprop="description"> Motueka Amplifire/Citra/Mosaic Cryo Hazy IPA, 6.5% </div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+      <div class="product-price-and-shipping ">
+      
+      
+      
+      <span class="sr-only">Cena</span>
+      <span class="price" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+        <span itemprop="priceCurrency" content="PLN"></span><span itemprop="price" content="19">19,00&nbsp;zł</span>
+      </span>
+
+      			<div class="extra-return-services image-only">
+				<label>
+					<img src="/modules/bantrecyclingdeposit/uploads/bant_er_696e046eeb64f.jpg" alt="Miniatura dodatkowego produktu" class="extra-return--image">
+				</label>
+		</div>
+	
+
+      
+    </div>
+  
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="button-container cart">
+	<form action="https://funkyshop.pl/pl/koszyk" method="post">
+		<input type="hidden" name="token" value="b866420ae8aaf943d02267723ab32727">
+		<input type="hidden" value="5" class="quantity_product quantity_product_5746" name="quantity_product">
+		<input type="hidden" value="1" class="minimal_quantity minimal_quantity_5746" name="minimal_quantity">
+		<input type="hidden" value="0" class="id_product_attribute id_product_attribute_5746" name="id_product_attribute">
+		<input type="hidden" value="5746" class="id_product" name="id_product">
+		<input type="hidden" name="id_customization" value="" class="product_customization_id">
+			
+		<input type="hidden" class="input-group form-control qty qty_product qty_product_5746" name="qty" value="1" data-min="1">
+		  <button class="btn btn-product add-to-cart leo-bt-cart leo-bt-cart_5746 leo-enable" data-button-action="add-to-cart" type="submit">
+			<span class="leo-loading cssload-speeding-wheel"></span>
+			<span class="leo-bt-cart-content">
+				<i class="icon-btn-product icon-cart material-icons shopping-cart"></i>
+				<span class="name-btn-product">Dodaj do koszyka</span>
+			</span>
+		  </button>
+	</form>
+</div>
+
+</div>
+  </div>
+</article>
+
+                                                            
+            </div>
+                    
+            
+            
+                                       
+            <div class="ajax_block_product col-sp-12 col-xs-6 col-sm-6 col-md-6 col-lg-4 col-xl-4
+                 first-in-line                 last-line                 last-item-of-tablet-line
+                                 last-item-of-mobile-line
+                                                ">
+                
+                                                                                                <article class="product-miniature js-product-miniature" data-id-product="5810" data-id-product-attribute="0" itemscope="" itemtype="http://schema.org/Product">
+  <div class="thumbnail-container">
+    <div class="product-image">
+
+
+        			    	<a href="https://funkyshop.pl/pl/piwo-rzemieslnicze/5810-gelato-xtreme-it-floats-x-white-dog-500ml.html" class="thumbnail product-thumbnail">
+				  <img class="img-fluid" src="https://funkyshop.pl/10796-home_default/gelato-xtreme-it-floats-x-white-dog-500ml.jpg" alt="Gelato XTREME: It Floats! (x White Dog) 500ml" data-full-size-image-url="https://funkyshop.pl/10796-large_default/gelato-xtreme-it-floats-x-white-dog-500ml.jpg">
+				  					<span class="product-additional" data-idproduct="5810"></span>
+				  				</a>
+
+		      
+
+
+<div class="functional-buttons clearfix">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="quickview no-variants hidden-sm-down">
+<a href="#" class="quick-view" data-link-action="quickview" title="Quick view">
+	<span class="leo-quickview-bt-loading cssload-speeding-wheel"></span>
+	<span class="leo-quickview-bt-content">
+		<i class="material-icons search"></i>
+		<span>Quick view</span>
+	</span>
+</a>
+</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="wishlist">
+			<a class="leo-wishlist-button btn-product btn-primary btn" href="javascript:void(0)" data-id-wishlist="" data-id-product="5810" data-id-product-attribute="0" title="Dodaj do listy życzeń">
+			<span class="leo-wishlist-bt-loading cssload-speeding-wheel"></span>
+			<span class="leo-wishlist-bt-content">
+				<i class="icon-btn-product icon-wishlist material-icons"></i>
+				<span class="name-btn-product">Dodaj do listy życzeń</span>
+			</span>
+		</a>
+	</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+</div></div>
+    <div class="product-meta">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+  <p class="h3 product-title" itemprop="name"><a href="https://funkyshop.pl/pl/piwo-rzemieslnicze/5810-gelato-xtreme-it-floats-x-white-dog-500ml.html">Gelato XTREME: It Floats! (x White Dog) 500ml</a></p>
+
+<a class="manufacturer-product" href="https://funkyshop.pl/pl/brand/2-funky-fluid">
+    Funky Fluid
+</a>
+
+  <div class="product-description-short" itemprop="description"> Multifruit XTREME Ice Cream Sour, 8% </div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+      <div class="product-price-and-shipping ">
+      
+      
+      
+      <span class="sr-only">Cena</span>
+      <span class="price" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+        <span itemprop="priceCurrency" content="PLN"></span><span itemprop="price" content="30">30,00&nbsp;zł</span>
+      </span>
+
+      			<div class="extra-return-services image-only">
+				<label>
+					<img src="/modules/bantrecyclingdeposit/uploads/bant_er_696e046eeb64f.jpg" alt="Miniatura dodatkowego produktu" class="extra-return--image">
+				</label>
+		</div>
+	
+
+      
+    </div>
+  
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="button-container cart">
+	<form action="https://funkyshop.pl/pl/koszyk" method="post">
+		<input type="hidden" name="token" value="b866420ae8aaf943d02267723ab32727">
+		<input type="hidden" value="35" class="quantity_product quantity_product_5810" name="quantity_product">
+		<input type="hidden" value="1" class="minimal_quantity minimal_quantity_5810" name="minimal_quantity">
+		<input type="hidden" value="0" class="id_product_attribute id_product_attribute_5810" name="id_product_attribute">
+		<input type="hidden" value="5810" class="id_product" name="id_product">
+		<input type="hidden" name="id_customization" value="" class="product_customization_id">
+			
+		<input type="hidden" class="input-group form-control qty qty_product qty_product_5810" name="qty" value="1" data-min="1">
+		  <button class="btn btn-product add-to-cart leo-bt-cart leo-bt-cart_5810 leo-enable" data-button-action="add-to-cart" type="submit">
+			<span class="leo-loading cssload-speeding-wheel"></span>
+			<span class="leo-bt-cart-content">
+				<i class="icon-btn-product icon-cart material-icons shopping-cart"></i>
+				<span class="name-btn-product">Dodaj do koszyka</span>
+			</span>
+		  </button>
+	</form>
+</div>
+
+</div>
+  </div>
+</article>
+
+                                                            
+            </div>
+                    
+            
+            
+                                       
+            <div class="ajax_block_product col-sp-12 col-xs-6 col-sm-6 col-md-6 col-lg-4 col-xl-4
+                                 last-line                 first-item-of-tablet-line                 first-item-of-mobile-line                 last-mobile-line                ">
+                
+                                                                                                <article class="product-miniature js-product-miniature" data-id-product="5835" data-id-product-attribute="0" itemscope="" itemtype="http://schema.org/Product">
+  <div class="thumbnail-container">
+    <div class="product-image">
+
+
+        			    	<a href="https://funkyshop.pl/pl/piwo-rzemieslnicze/5835-lervig-rackhouse-barrel-aged-set-4x375ml.html" class="thumbnail product-thumbnail">
+				  <img class="img-fluid" src="https://funkyshop.pl/10793-home_default/lervig-rackhouse-barrel-aged-set-4x375ml.jpg" alt="Lervig Rackhouse Barrel Aged Set 4x375ml" data-full-size-image-url="https://funkyshop.pl/10793-large_default/lervig-rackhouse-barrel-aged-set-4x375ml.jpg">
+				  					<span class="product-additional" data-idproduct="5835"><img loading="lazy" class="img-fluid" title="Lervig Rackhouse Barrel Aged Set 4x375ml" alt="Lervig Rackhouse Barrel Aged Set 4x375ml" src="https://funkyshop.pl/10792-home_default/lervig-rackhouse-barrel-aged-set-4x375ml.jpg" width="500" height="500"></span>
+				  				</a>
+
+		      
+
+
+<div class="functional-buttons clearfix">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="quickview no-variants hidden-sm-down">
+<a href="#" class="quick-view" data-link-action="quickview" title="Quick view">
+	<span class="leo-quickview-bt-loading cssload-speeding-wheel"></span>
+	<span class="leo-quickview-bt-content">
+		<i class="material-icons search"></i>
+		<span>Quick view</span>
+	</span>
+</a>
+</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="wishlist">
+			<a class="leo-wishlist-button btn-product btn-primary btn" href="javascript:void(0)" data-id-wishlist="" data-id-product="5835" data-id-product-attribute="0" title="Dodaj do listy życzeń">
+			<span class="leo-wishlist-bt-loading cssload-speeding-wheel"></span>
+			<span class="leo-wishlist-bt-content">
+				<i class="icon-btn-product icon-wishlist material-icons"></i>
+				<span class="name-btn-product">Dodaj do listy życzeń</span>
+			</span>
+		</a>
+	</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+</div></div>
+    <div class="product-meta">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+  <p class="h3 product-title" itemprop="name"><a href="https://funkyshop.pl/pl/piwo-rzemieslnicze/5835-lervig-rackhouse-barrel-aged-set-4x375ml.html">Lervig Rackhouse Barrel Aged Set 4x375ml</a></p>
+
+<a class="manufacturer-product" href="https://funkyshop.pl/pl/brand/133-lervig">
+    LERVIG
+</a>
+
+  <div class="product-description-short" itemprop="description"> 4x 375ml Barrel Aged Lervig </div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+      <div class="product-price-and-shipping has_discount">
+              
+        <span class="sr-only">Normalna cena</span>
+        <span class="regular-price">360,00&nbsp;zł</span>
+                  <span class="discount-percentage">-5%</span>
+              
+      
+      
+      <span class="sr-only">Cena</span>
+      <span class="price" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+        <span itemprop="priceCurrency" content="PLN"></span><span itemprop="price" content="342">342,00&nbsp;zł</span>
+      </span>
+
+      
+
+      
+    </div>
+  
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+</div>
+  </div>
+</article>
+
+                                                            
+            </div>
+                    
+            
+            
+                                       
+            <div class="ajax_block_product col-sp-12 col-xs-6 col-sm-6 col-md-6 col-lg-4 col-xl-4
+                 last-in-line
+                                 last-line                 last-item-of-tablet-line
+                                 last-item-of-mobile-line
+                                 last-mobile-line                ">
+                
+                                                                                                <article class="product-miniature js-product-miniature" data-id-product="5811" data-id-product-attribute="0" itemscope="" itemtype="http://schema.org/Product">
+  <div class="thumbnail-container">
+    <div class="product-image">
+
+
+        			    	<a href="https://funkyshop.pl/pl/piwo-rzemieslnicze/5811-gelato-week-26-set-4-puszki-500ml.html" class="thumbnail product-thumbnail">
+				  <img class="img-fluid" src="https://funkyshop.pl/10731-home_default/gelato-week-26-set-4-puszki-500ml.jpg" alt="Gelato Week '26 Set (4 puszki 500ml)" data-full-size-image-url="https://funkyshop.pl/10731-large_default/gelato-week-26-set-4-puszki-500ml.jpg">
+				  					<span class="product-additional" data-idproduct="5811"></span>
+				  				</a>
+
+		      
+
+
+<div class="functional-buttons clearfix">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="quickview no-variants hidden-sm-down">
+<a href="#" class="quick-view" data-link-action="quickview" title="Quick view">
+	<span class="leo-quickview-bt-loading cssload-speeding-wheel"></span>
+	<span class="leo-quickview-bt-content">
+		<i class="material-icons search"></i>
+		<span>Quick view</span>
+	</span>
+</a>
+</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="wishlist">
+			<a class="leo-wishlist-button btn-product btn-primary btn" href="javascript:void(0)" data-id-wishlist="" data-id-product="5811" data-id-product-attribute="0" title="Dodaj do listy życzeń">
+			<span class="leo-wishlist-bt-loading cssload-speeding-wheel"></span>
+			<span class="leo-wishlist-bt-content">
+				<i class="icon-btn-product icon-wishlist material-icons"></i>
+				<span class="name-btn-product">Dodaj do listy życzeń</span>
+			</span>
+		</a>
+	</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+</div></div>
+    <div class="product-meta">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+  <p class="h3 product-title" itemprop="name"><a href="https://funkyshop.pl/pl/piwo-rzemieslnicze/5811-gelato-week-26-set-4-puszki-500ml.html">Gelato Week '26 Set (4 puszki 500ml)</a></p>
+
+<a class="manufacturer-product" href="https://funkyshop.pl/pl/brand/2-funky-fluid">
+    Funky Fluid
+</a>
+
+  <div class="product-description-short" itemprop="description"> Zestaw 2 Gelato +2 Gelato XTREME 500ml&nbsp; </div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+      <div class="product-price-and-shipping has_discount">
+              
+        <span class="sr-only">Normalna cena</span>
+        <span class="regular-price">100,00&nbsp;zł</span>
+                  <span class="discount-percentage">-5%</span>
+              
+      
+      
+      <span class="sr-only">Cena</span>
+      <span class="price" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+        <span itemprop="priceCurrency" content="PLN"></span><span itemprop="price" content="95">95,00&nbsp;zł</span>
+      </span>
+
+      <div class="x13pricehistory-product-list x13pricehistory-product-list--default  has-discount " data-product="5811">
+    <div class="x13pricehistory-product-list__omnibus-text">
+        Najniższa cena: <strong class="x13pricehistory-product-list__omnibus-price">90,00&nbsp;zł</strong> <span class="discount discount-percentage">+6%</span>
+    </div>
+    </div>
+
+      
+    </div>
+  
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="button-container cart">
+	<form action="https://funkyshop.pl/pl/koszyk" method="post">
+		<input type="hidden" name="token" value="b866420ae8aaf943d02267723ab32727">
+		<input type="hidden" value="16" class="quantity_product quantity_product_5811" name="quantity_product">
+		<input type="hidden" value="1" class="minimal_quantity minimal_quantity_5811" name="minimal_quantity">
+		<input type="hidden" value="0" class="id_product_attribute id_product_attribute_5811" name="id_product_attribute">
+		<input type="hidden" value="5811" class="id_product" name="id_product">
+		<input type="hidden" name="id_customization" value="" class="product_customization_id">
+			
+		<input type="hidden" class="input-group form-control qty qty_product qty_product_5811" name="qty" value="1" data-min="1">
+		  <button class="btn btn-product add-to-cart leo-bt-cart leo-bt-cart_5811 leo-enable" data-button-action="add-to-cart" type="submit">
+			<span class="leo-loading cssload-speeding-wheel"></span>
+			<span class="leo-bt-cart-content">
+				<i class="icon-btn-product icon-cart material-icons shopping-cart"></i>
+				<span class="name-btn-product">Dodaj do koszyka</span>
+			</span>
+		  </button>
+	</form>
+</div>
+
+</div>
+  </div>
+</article>
+
+                                                            
+            </div>
+            </div>
+</div>
+<script>
+if (window.jQuery) {
+    $(document).ready(function(){
+        if (prestashop.page.page_name == 'category'){
+            setDefaultListGrid();
+        }
+    });
+}
+</script>   
+  </div>
+
+  
+    <nav class="pagination">
+  <div class="col-xs-12 col-md-6 col-lg-4 text-md-left text-xs-center">
+    
+      Pokazano 1-24 z 174 pozycji
+    
+  </div>
+
+  <div class="col-xs-12 col-md-6 col-lg-8">
+    
+           <ul class="page-list clearfix text-md-right text-xs-center">
+                  <li class="current">
+                          <a rel="nofollow" href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze" class="disabled js-search-link">
+                                  1
+                              </a>
+                      </li>
+                  <li>
+                          <a rel="nofollow" href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?page=2" class="js-search-link" aria-label="Strona 2 listy piw rzemieślniczych w FunkyShop">
+                                  2
+                              </a>
+                      </li>
+                  <li>
+                          <a rel="nofollow" href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?page=3" class="js-search-link">
+                                  3
+                              </a>
+                      </li>
+                  <li>
+                          <span class="spacer">…</span>
+                      </li>
+                  <li>
+                          <a rel="nofollow" href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?page=8" class="js-search-link">
+                                  8
+                              </a>
+                      </li>
+                  <li>
+                          <a rel="next" href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze?page=2" class="next js-search-link" aria-label="Strona 2 listy piw rzemieślniczych w FunkyShop">
+                                  <span>Następny</span><i class="fa fa-long-arrow-right"></i>
+                              </a>
+                      </li>
+              </ul>
+          
+  </div>
+
+</nav>
+  
+
+  <div class="hidden-md-up text-xs-right up">
+    <a href="#header" class="btn btn-secondary">
+      Powrót do góry
+      <i class="material-icons"></i>
+    </a>
+  </div>
+</div>
+          
+        </div>
+
+        <div id="js-product-list-bottom">
+          
+            <div id="js-product-list-bottom"></div>
+          
+        </div>
+
+          </section>
+
+  </section>
+
+    
+  </div>
+
+
+            
+          </div>
+                  </div>
+        	
+      </section>
+
+      <footer id="footer" class="footer-container">
+        
+          
+  <div class="footer-top">
+          <div class="inner"></div>
+      </div>
+
+
+  <div class="footer-center">
+          <div class="inner"><!-- @file modules\appagebuilder\views\templates\hook\ApRow -->
+<div class="wrapper">
+
+<div class="container">
+    <div class="row box-newletter ApRow  " style="">
+                                            <!-- @file modules\appagebuilder\views\templates\hook\ApColumn -->
+<div class="col-xl-6 col-lg-12 col-md-12 col-sm-12 col-xs-12 col-sp-12 newsletter-main ApColumn ">
+                    <!-- @file modules\appagebuilder\views\templates\hook\ApModule -->
+<div class="block_newsletter block">
+  <p class="title_block" id="block-newsletter-label">Newsletter</p>
+  <div class="block_content">
+    <form action="https://funkyshop.pl/pl/#footer" method="post">
+      <div class="row">
+        <div class="col-xs-12 col-conditions">
+                    </div>
+        <div class="col-xs-12 col-form">
+          <div class="input-wrapper">
+            <input name="email" type="text" value="" placeholder="Twój email..." aria-labelledby="block-newsletter-label">
+            <button class="btn btn-outline float-xs-right" name="submitNewsletter" type="submit" value="Subskrybuj" disabled="disabled" aria-label="Subscribe to newsletter">
+              <i class="fa fa-long-arrow-right"></i>
+            </button>
+          </div>
+          <input type="hidden" name="action" value="0">
+		  <input type="hidden" name="r-action" value="newsletter"><input type="hidden" name="r-token" value="">
+
+          <div class="clearfix"></div>
+        </div>
+        <div class="col-xs-12 col-mesg">
+                                        
+    <div class="gdpr_consent gdpr_module_17">
+        <span class="custom-checkbox">
+            <label class="psgdpr_consent_message">
+                <input id="psgdpr_consent_checkbox_17" name="psgdpr_consent_checkbox" type="checkbox" value="1" class="psgdpr_consent_checkboxes_17">
+                <span><i class="material-icons rtl-no-flip checkbox-checked psgdpr_consent_icon"></i></span>
+                <span>Wyrażam zgodę na otrzymywanie od LEJMITO Sp. z o.o.&nbsp; informacji handlowych, w tym cyklicznego newslettera za pomocą środków komunikacji elektronicznej, na podany w niniejszym formularzu adres poczty elektronicznej.</span>            </label>
+        </span>
+    </div>
+
+
+<script type="text/javascript">
+    var psgdpr_front_controller = "https://funkyshop.pl/pl/module/psgdpr/FrontAjaxGdpr";
+    psgdpr_front_controller = psgdpr_front_controller.replace(/\amp;/g,'');
+    var psgdpr_id_customer = "0";
+    var psgdpr_customer_token = "da39a3ee5e6b4b0d3255bfef95601890afd80709";
+    var psgdpr_id_guest = "0";
+    var psgdpr_guest_token = "058a102e36c6faf0c3279ecec47f480f369c7a1b";
+
+    document.addEventListener('DOMContentLoaded', function() {
+        let psgdpr_id_module = "17";
+        let parentForm = $('.gdpr_module_' + psgdpr_id_module).closest('form');
+
+        let toggleFormActive = function() {
+            let parentForm = $('.gdpr_module_' + psgdpr_id_module).closest('form');
+            let checkbox = $('#psgdpr_consent_checkbox_' + psgdpr_id_module);
+            let element = $('.gdpr_module_' + psgdpr_id_module);
+            let iLoopLimit = 0;
+
+            // by default forms submit will be disabled, only will enable if agreement checkbox is checked
+            if (element.prop('checked') != true) {
+                element.closest('form').find('[type="submit"]').attr('disabled', 'disabled');
+            }
+            $(document).on("change" ,'.psgdpr_consent_checkboxes_' + psgdpr_id_module, function() {
+                if ($(this).prop('checked') == true) {
+                    $(this).closest('form').find('[type="submit"]').removeAttr('disabled');
+                } else {
+                    $(this).closest('form').find('[type="submit"]').attr('disabled', 'disabled');
+                }
+
+            });
+        }
+
+        // Triggered on page loading
+        toggleFormActive();
+
+        $(document).on('submit', parentForm, function(event) {
+            $.ajax({
+                type: 'POST',
+                url: psgdpr_front_controller,
+                data: {
+                    ajax: true,
+                    action: 'AddLog',
+                    id_customer: psgdpr_id_customer,
+                    customer_token: psgdpr_customer_token,
+                    id_guest: psgdpr_id_guest,
+                    guest_token: psgdpr_guest_token,
+                    id_module: psgdpr_id_module,
+                },
+                error: function (err) {
+                    console.log(err);
+                }
+            });
+        });
+    });
+</script>
+
+
+                      </div>
+      </div>
+    </form>
+  </div>
+</div>
+
+    </div><!-- @file modules\appagebuilder\views\templates\hook\ApColumn -->
+<div class="col-xl-6 col-lg-12 col-md-12 col-sm-12 col-xs-12 col-sp-12  ApColumn ">
+                    <!-- @file modules\appagebuilder\views\templates\hook\ApModule -->
+
+
+  <div class="block-social">
+  	<p class="social-title">
+  		Bądź na bieżąco!<br>Alkohol szkodzi zdrowiu.<br>Pij odpowiedzialnie.
+    </p>
+    <ul>
+              <li class="facebook"><a href="https://www.facebook.com/funkyfluid" title="Facebook" target="_blank" rel="nofollow"><span>Facebook</span></a></li>
+              <li class="instagram"><a href="https://www.instagram.com/browarfunkyfluid/" title="Instagram" target="_blank" rel="nofollow"><span>Instagram</span></a></li>
+          </ul>
+  </div>
+
+
+    </div>            </div>
+</div>
+</div>
+    <!-- @file modules\appagebuilder\views\templates\hook\ApRow -->
+<div class="wrapper" style="background: #661542 no-repeat">
+
+<div class="container">
+    <div class="row box-footerlink ApRow  has-bg bg-fullwidth-container" style="">
+                                            <!-- @file modules\appagebuilder\views\templates\hook\ApColumn -->
+<div class="col-xl-3 col-lg-3 col-md-6 col-sm-6 col-xs-12 col-sp-12  ApColumn ">
+                    <!-- @file modules\appagebuilder\views\templates\hook\ApBlockLink -->
+            <div class="block ApLink ApBlockLink">
+                            <h4 class="title_block">
+                    Funky Shop
+                </h4>
+                        
+                            <ul>
+                                                            <li><a href="https://funkyshop.pl/pl/content/5-formy-platnosci" target="_self">Sposoby płatności</a></li>
+                                                                                <li><a href="https://funkyshop.pl/pl/content/3-regulamin" target="_self">Regulamin</a></li>
+                                                                                <li><a href="https://funkyshop.pl/pl/content/2-polityka-prywatnosci" target="_self">Polityka prywatności</a></li>
+                                                                                <li><a href="https://funkyshop.pl/pl/content/6-warunki-odstapienia" target="_self">Odstąpienie od umowy</a></li>
+                                                                                <li><a href="https://funkyshop.pl/pl/content/10-polityka-cookies" target="_self">Polityka cookies</a></li>
+                                                                                <li><a href="https://funkyshop.pl/pl/mapa-strony" target="_self">Mapa strony</a></li>
+                                                    </ul>
+                    </div>
+    
+    </div><!-- @file modules\appagebuilder\views\templates\hook\ApColumn -->
+<div class="col-xl-3 col-lg-3 col-md-6 col-sm-6 col-xs-12 col-sp-12  ApColumn ">
+                    <!-- @file modules\appagebuilder\views\templates\hook\ApGeneral -->
+<div class="block contact-footer ApHtml">
+	            <h4 class="title_block">Kontakt</h4>
+                    <div class="block_content"><table><tbody><tr><td><p><i class="material-icons" style="color: #ffffff;">email</i></p></td><td><p class="contact-par"><a href="mailto:shop@funkyfluid.pl">shop@funkyfluid.pl</a></p></td></tr><tr><td><p><i class="material-icons" style="color: #ffffff;">home</i></p></td><td><p class="contact-par"><a href="/pl/kontakt">Formularz kontaktowy</a></p></td></tr></tbody></table></div>
+    	</div>
+    </div><!-- @file modules\appagebuilder\views\templates\hook\ApColumn -->
+<div class="col-xl-3 col-lg-3 col-md-6 col-sm-6 col-xs-12 col-sp-12 check-also-column ApColumn ">
+                    <!-- @file modules\appagebuilder\views\templates\hook\ApGeneral -->
+<div class="block check-footer ApHtml">
+	            <h4 class="title_block">Sprawdź również</h4>
+                    <div class="block_content"><table><tbody><tr><td><span class="social-icons" id="icon-4"><i class="fab fa-facebook-square" style="color: #fff;"></i></span></td><td><p class="contact-par"><a href="https://www.facebook.com/Funky-Shop-Craft-Beer-Online-102308188463114" rel="nofollow" target="_blank">Nasza strona</a></p></td></tr><tr><td><span class="social-icons" id="icon-1"><i class="fab fa-instagram" style="color: #fff;"></i></span></td><td><p class="contact-par"><a href="https://www.instagram.com/browarfunkyfluid/" rel="nofollow" target="_blank">Funky Fluid</a></p></td></tr><tr><td><span class="social-icons" id="icon-2"><i class="fab fa-facebook-square" style="color: #fff;"></i></span></td><td><p class="contact-par"><a href="https://www.facebook.com/funkyfluid" rel="nofollow" target="_blank">Funky Fluid</a></p></td></tr><tr><td><span class="social-icons" id="icon-3"><i class="fab fa-facebook-square" style="color: #fff;"></i></span></td><td><p class="contact-par"><a href="https://www.facebook.com/Funky-Fest-Craft-Beer-Party-103781251433213/" rel="nofollow" target="_blank">Funky Fest</a></p></td></tr></tbody></table></div>
+    	</div>
+    </div><!-- @file modules\appagebuilder\views\templates\hook\ApColumn -->
+<div class="col-xl-3 col-lg-3 col-md-6 col-sm-6 col-xs-12 col-sp-12 ap-popup2 ApColumn ">
+                    <!-- @file modules\appagebuilder\views\templates\hook\ApFacebook -->
+
+<script type="text/javascript">
+    var fb_lang = 'en_US';
+</script>
+
+    <script type="text/javascript">
+        fb_lang = "pl_PL";
+    </script>
+
+<div class="widget-facebook block">
+		<div id="fb-root" class=" fb_reset"><div style="position: absolute; top: -10000px; width: 0px; height: 0px;"><div></div></div></div>
+        <h4 class="title_block">Ostatnie posty</h4>
+            <script type="text/javascript">
+ap_list_functions.push(function(){
+    console.log(fb_lang);
+    // Check avoid include duplicate library Facebook SDK
+    if($("#facebook-jssdk").length == 0) {
+        (function(d, s, id) {
+          var js, fjs = d.getElementsByTagName(s)[0];
+          if (d.getElementById(id)) return;
+          js = d.createElement(s); js.id = id;
+          js.src = "https://connect.facebook.net/" + fb_lang + "/sdk.js#xfbml=1&version=v5.0";
+          fjs.parentNode.insertBefore(js, fjs);
+        }(document, 'script', 'facebook-jssdk'));
+    }
+});
+</script>
+
+    <div class="fb-page fb_iframe_widget" data-href="https://www.facebook.com/Funky-Shop-Craft-Beer-Online-102308188463114" data-tabs="timeline" data-adapt-container-width="true" data-show-facepile="true" fb-xfbml-state="rendered" fb-iframe-plugin-query="adapt_container_width=true&amp;app_id=&amp;container_width=270&amp;href=https%3A%2F%2Fwww.facebook.com%2FFunky-Shop-Craft-Beer-Online-102308188463114&amp;locale=pl_PL&amp;sdk=joey&amp;show_facepile=true&amp;tabs=timeline"><span style="vertical-align: top; width: 0px; height: 0px; overflow: hidden;"><iframe name="f890ae5ef73b8489f" width="1000px" height="1000px" data-testid="fb:page Facebook Social Plugin" title="fb:page Facebook Social Plugin" frameborder="0" allowtransparency="true" allowfullscreen="true" scrolling="no" allow="encrypted-media" src="https://www.facebook.com/v5.0/plugins/page.php?adapt_container_width=true&amp;app_id=&amp;channel=https%3A%2F%2Fstaticxx.facebook.com%2Fx%2Fconnect%2Fxd_arbiter%2F%3Fversion%3D46%23cb%3Dff19bf3899a8a9439%26domain%3Dfunkyshop.pl%26is_canvas%3Dfalse%26origin%3Dhttps%253A%252F%252Ffunkyshop.pl%252Ff6d5f5b76314c62f2%26relation%3Dparent.parent&amp;container_width=270&amp;href=https%3A%2F%2Fwww.facebook.com%2FFunky-Shop-Craft-Beer-Online-102308188463114&amp;locale=pl_PL&amp;sdk=joey&amp;show_facepile=true&amp;tabs=timeline" style="border-width: medium; border-style: none; border-color: currentcolor; border-image: initial; visibility: visible; width: 0px; height: 0px;"></iframe></span></div>
+    	</div>
+    </div>            </div>
+</div>
+</div>
+        
+	<script>
+		ap_list_functions.push(function(){
+			$.stellar({horizontalScrolling:false}); 
+		});
+	</script>
+    
+    </div>
+      </div>
+
+
+  <div class="footer-bottom">
+          <div class="inner"><!-- @file modules\appagebuilder\views\templates\hook\ApRow -->
+<div class="wrapper" style="background: #661542 repeat-x top">
+
+<div class="container">
+    <div class="row box-coppyh8 ApRow  has-bg bg-fullwidth-container" style="">
+                                            <!-- @file modules\appagebuilder\views\templates\hook\ApColumn -->
+<div class="col-xl-12 col-lg-12 col-md-12 col-sm-12 col-xs-12 col-sp-12  ApColumn ">
+                    <!-- @file modules\appagebuilder\views\templates\hook\ApGenCode -->
+
+	<div>Copyright © 2026 Projekt i realizacja <a class="copyright" href="https://wenet.pl/oferta/sklepy-internetowe" target="_blank" rel="nofollow noopener noreferrer" data-mce-href="https://wenet.pl/oferta/sklepy-internetowe">WeNet Group S.A.</a></div>
+
+    </div>            </div>
+</div>
+</div>
+        
+	<script>
+		ap_list_functions.push(function(){
+			$.stellar({horizontalScrolling:false}); 
+		});
+	</script>
+    
+    </div>
+      </div>
+        
+      </footer>
+                      <div id="back-top" style="display: none;"><a href="#" class="fa fa-angle-double-up" aria-label="Przejdź na górę strony"></a></div>
+      
+    <div class="megamenu-overlay" data-megamenu-id="9184166521380958"></div></main>
+
+    
+        <script type="text/javascript" src="https://funkyshop.pl/themes/core.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/pmgoogleanalytycs4pro/views/js/scripts_17.js"></script>
+  <script type="text/javascript" src="https://www.google.com/recaptcha/api.js?render=6LfV7hsrAAAAAFM2myNNgqZuypFI573dG2Jvvvju"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/themes/leo_clark/assets/js/theme.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/ps_emailsubscription/views/js/ps_emailsubscription.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/blockreassurance/views/dist/front.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/psagechecker/views/js/front.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/dpdshipping/views/js/dpdshipping-common.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/dpdshipping/views/js/dpdshipping-pudo-default.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/x13pricehistory/views/js/front.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/x13pricehistory/views/js/front-list.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/x13gpsr/views/js/front.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/appagebuilder/views/js/countdown.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/leoslideshow/views/js/iView/raphael-min.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/leoslideshow/views/js/iView/iview.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/leoslideshow/views/js/leoslideshow.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/leofeature/views/js/leofeature_cart.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/leofeature/views/js/jquery.mousewheel.min.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/leofeature/views/js/jquery.mCustomScrollbar.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/leofeature/views/js/jquery.rating.pack.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/leofeature/views/js/leofeature_review.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/leofeature/views/js/leofeature_wishlist.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/leoquicklogin/views/js/leoquicklogin.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/pmcookie//views/js/jquery-confirm.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/pmcookie//views/js/front-1.0.5.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/js/jquery/ui/jquery-ui.min.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/js/jquery/plugins/fancybox/jquery.fancybox.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/js/jquery/plugins/jquery.cooki-plugin.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/ps_facetedsearch/views/dist/front.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/ps_searchbar/ps_searchbar.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/ps_shoppingcart/ps_shoppingcart.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/leobootstrapmenu/views/js/leobootstrapmenu.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/blockgrouptop/views/js/blockgrouptop.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/leoproductsearch/views/js/jquery.autocomplete_productsearch.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/leoproductsearch/views/js/leosearch.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/bantrecyclingdeposit/views/js/front.js" defer=""></script>
+  <script type="text/javascript" src="https://funkyshop.pl/themes/leo_clark/assets/js/custom.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/appagebuilder/views/js/waypoints.min.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/appagebuilder/views/js/instafeed.min.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/appagebuilder/views/js/jquery.stellar.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/appagebuilder/views/js/owl.carousel.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/appagebuilder/views/js/imagesloaded.pkgd.min.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/appagebuilder/views/js/slick.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/appagebuilder/views/js/jquery.elevateZoom-3.0.8.min.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/appagebuilder/views/js/script.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/themes/leo_clark/modules/appagebuilder/views/js/profiles/profile1513951283.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/recaptcha3/views/js/recaptcha_v3.js"></script>
+
+
+<script type="text/javascript">
+	var choosefile_text = "Wybierz plik";
+	var turnoff_popup_text = "Nie pokazuj więcej tego wyskakującego okienka";
+	
+	var size_item_quickview = 82;
+	var style_scroll_quickview = 'vertical';
+	
+	var size_item_page = 113;
+	var style_scroll_page = 'horizontal';
+	
+	var size_item_quickview_attr = 101;	
+	var style_scroll_quickview_attr = 'vertical';
+	
+	var size_item_popup = 160;
+	var style_scroll_popup = 'vertical';
+</script>    
+
+    
+      <div class="modal leo-quicklogin-modal fade" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">×</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <div class="leo-quicklogin-form row">
+		<div class="leo-form leo-login-form col-sm-6 leo-form-active">
+		<p class="leo-login-title">			
+			<span class="title-both">
+				Logowanie do istniejącego konta
+			</span>
+		
+			<span class="title-only">
+				Zaloguj się na swoje konto
+			</span>		
+		</p>
+		<form class="lql-form-content leo-login-form-content" action="#" method="post">
+			<div class="form-group lql-form-mesg has-success">					
+			</div>			
+			<div class="form-group lql-form-mesg has-danger">					
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="email" class="form-control lql-email-login" name="lql-email-login" required="" placeholder="Adres e-mail">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="password" class="form-control lql-pass-login" name="lql-pass-login" required="" placeholder="Hasło">
+			</div>
+			<div class="form-group row lql-form-content-element">				
+				<div class="col-xs-6">
+											<input type="checkbox" class="lql-rememberme" name="lql-rememberme">
+						<label class="form-control-label"><span>Zapamiętaj mnie</span></label>
+									</div>				
+				<div class="col-xs-6 text-sm-right">
+					<a role="button" href="#" class="leoquicklogin-forgotpass">Zapomniałeś hasła ?</a>
+				</div>
+			</div>
+			<div class="form-group text-right">
+				<button type="submit" class="form-control-submit lql-form-bt lql-login-bt btn btn-primary">			
+					<span class="leoquicklogin-loading leoquicklogin-cssload-speeding-wheel"></span>
+					<i class="leoquicklogin-icon leoquicklogin-success-icon material-icons"></i>
+					<i class="leoquicklogin-icon leoquicklogin-fail-icon material-icons"></i>
+					<span class="lql-bt-txt">					
+						 Zaloguj się
+					</span>
+				</button>
+			</div>
+			<div class="form-group lql-callregister">
+				<a role="button" href="#" class="lql-callregister-action">Nie masz konta? Załóż je!</a>
+			</div>
+		</form>
+		<div class="leo-resetpass-form">
+			<p>Zresetuj hasło</p>
+			<form class="lql-form-content leo-resetpass-form-content" action="#" method="post">
+				<div class="form-group lql-form-mesg has-success">					
+				</div>			
+				<div class="form-group lql-form-mesg has-danger">					
+				</div>
+				<div class="form-group lql-form-content-element">
+					<input type="email" class="form-control lql-email-reset" name="lql-email-reset" required="" placeholder="Adres e-mail">
+				</div>
+				<div class="form-group">					
+					<button type="submit" class="form-control-submit lql-form-bt leoquicklogin-reset-pass-bt btn btn-primary">			
+						<span class="leoquicklogin-loading leoquicklogin-cssload-speeding-wheel"></span>
+						<i class="leoquicklogin-icon leoquicklogin-success-icon material-icons"></i>
+						<i class="leoquicklogin-icon leoquicklogin-fail-icon material-icons"></i>
+						<span class="lql-bt-txt">					
+							Zresetuj hasło
+						</span>
+					</button>
+				</div>
+				
+			</form>
+		</div>
+	</div>
+	
+	<div class="leo-form leo-register-form col-sm-6 leo-form-active">
+		<p class="leo-register-title">
+			Nowa rejestracja konta
+		</p>
+		<form class="lql-form-content leo-register-form-content" action="#" method="post">
+			<div class="form-group lql-form-mesg has-success">					
+			</div>			
+			<div class="form-group lql-form-mesg has-danger">					
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="text" class="form-control lql-register-firstname" name="lql-register-firstname" maxlength="20" placeholder="Imię">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="text" class="form-control lql-register-lastname" name="lql-register-lastname" required="" placeholder="Nazwisko">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="email" class="form-control lql-register-email" name="lql-register-email" required="" placeholder="Adres e-mail">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="password" class="form-control lql-register-pass" name="lql-register-pass" required="" placeholder="Hasło">
+			</div>
+						<div class="form-group text-right">				
+				<button type="submit" name="submit" class="form-control-submit lql-form-bt lql-register-bt btn btn-primary">			
+					<span class="leoquicklogin-loading leoquicklogin-cssload-speeding-wheel"></span>
+					<i class="leoquicklogin-icon leoquicklogin-success-icon material-icons"></i>
+					<i class="leoquicklogin-icon leoquicklogin-fail-icon material-icons"></i>
+					<span class="lql-bt-txt">					
+						Utwórz konto
+					</span>
+				</button>
+			</div>
+			<div class="form-group lql-calllogin">
+				<div>Posiadasz już konto?</div>
+				<a role="button" href="#" class="lql-calllogin-action">Zaloguj się</a>
+				lub
+				<a role="button" href="#" class="lql-calllogin-action lql-callreset-action">zresetuj hasło</a>
+			</div>
+		</form>
+	</div>
+</div>
+
+<div class="lql-social-login clearfix show-bt-txt">
+	<p class="lql-social-login-title">
+		Połącz się przez sieci społecznościowe
+	</p>
+			<!--
+		<div class="fb-login-button" data-max-rows="1" data-size="large" data-button-type="login_with" data-show-faces="false" data-auto-logout-link="false" data-use-continue-as="false" scope="public_profile,email" onlogin="checkLoginState();"></div>
+		-->
+		<button class="btn social-login-bt facebook-login-bt" onclick="doFbLogin();"><span class="fa fa-facebook"></span>Zaloguj się przez Facebook</button>
+		
+		<!--
+		<div class="g-signin2" data-scope="profile email" data-longtitle="true" data-theme="dark" data-onsuccess="googleSignIn" data-onfailure="googleFail"></div>
+	-->
+		</div>
+
+            </div> 
+            <div class="modal-footer"></div>
+        </div>
+    </div>
+</div><div class="leoquicklogin-mask"></div>
+
+<div class="leoquicklogin-slidebar slidebar_left">
+    <div class="leoquicklogin-slidebar-wrapper">
+        <div class="leoquicklogin-slidebar-top">
+            <button type="button" class="leoquicklogin-slidebar-close btn btn-secondary">
+                <i class="material-icons"></i>
+                <span>zamknij</span>
+            </button>
+        </div>
+        <div class="leo-quicklogin-form row">
+		<div class="leo-form leo-login-form col-sm-6 leo-form-active">
+		<p class="leo-login-title">			
+			<span class="title-both">
+				Logowanie do istniejącego konta
+			</span>
+		
+			<span class="title-only">
+				Zaloguj się na swoje konto
+			</span>		
+		</p>
+		<form class="lql-form-content leo-login-form-content" action="#" method="post">
+			<div class="form-group lql-form-mesg has-success">					
+			</div>			
+			<div class="form-group lql-form-mesg has-danger">					
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="email" class="form-control lql-email-login" name="lql-email-login" required="" placeholder="Adres e-mail">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="password" class="form-control lql-pass-login" name="lql-pass-login" required="" placeholder="Hasło">
+			</div>
+			<div class="form-group row lql-form-content-element">				
+				<div class="col-xs-6">
+											<input type="checkbox" class="lql-rememberme" name="lql-rememberme">
+						<label class="form-control-label"><span>Zapamiętaj mnie</span></label>
+									</div>				
+				<div class="col-xs-6 text-sm-right">
+					<a role="button" href="#" class="leoquicklogin-forgotpass">Zapomniałeś hasła ?</a>
+				</div>
+			</div>
+			<div class="form-group text-right">
+				<button type="submit" class="form-control-submit lql-form-bt lql-login-bt btn btn-primary">			
+					<span class="leoquicklogin-loading leoquicklogin-cssload-speeding-wheel"></span>
+					<i class="leoquicklogin-icon leoquicklogin-success-icon material-icons"></i>
+					<i class="leoquicklogin-icon leoquicklogin-fail-icon material-icons"></i>
+					<span class="lql-bt-txt">					
+						 Zaloguj się
+					</span>
+				</button>
+			</div>
+			<div class="form-group lql-callregister">
+				<a role="button" href="#" class="lql-callregister-action">Nie masz konta? Załóż je!</a>
+			</div>
+		</form>
+		<div class="leo-resetpass-form">
+			<p>Zresetuj hasło</p>
+			<form class="lql-form-content leo-resetpass-form-content" action="#" method="post">
+				<div class="form-group lql-form-mesg has-success">					
+				</div>			
+				<div class="form-group lql-form-mesg has-danger">					
+				</div>
+				<div class="form-group lql-form-content-element">
+					<input type="email" class="form-control lql-email-reset" name="lql-email-reset" required="" placeholder="Adres e-mail">
+				</div>
+				<div class="form-group">					
+					<button type="submit" class="form-control-submit lql-form-bt leoquicklogin-reset-pass-bt btn btn-primary">			
+						<span class="leoquicklogin-loading leoquicklogin-cssload-speeding-wheel"></span>
+						<i class="leoquicklogin-icon leoquicklogin-success-icon material-icons"></i>
+						<i class="leoquicklogin-icon leoquicklogin-fail-icon material-icons"></i>
+						<span class="lql-bt-txt">					
+							Zresetuj hasło
+						</span>
+					</button>
+				</div>
+				
+			</form>
+		</div>
+	</div>
+	
+	<div class="leo-form leo-register-form col-sm-6 leo-form-active">
+		<p class="leo-register-title">
+			Nowa rejestracja konta
+		</p>
+		<form class="lql-form-content leo-register-form-content" action="#" method="post">
+			<div class="form-group lql-form-mesg has-success">					
+			</div>			
+			<div class="form-group lql-form-mesg has-danger">					
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="text" class="form-control lql-register-firstname" name="lql-register-firstname" maxlength="20" placeholder="Imię">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="text" class="form-control lql-register-lastname" name="lql-register-lastname" required="" placeholder="Nazwisko">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="email" class="form-control lql-register-email" name="lql-register-email" required="" placeholder="Adres e-mail">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="password" class="form-control lql-register-pass" name="lql-register-pass" required="" placeholder="Hasło">
+			</div>
+						<div class="form-group text-right">				
+				<button type="submit" name="submit" class="form-control-submit lql-form-bt lql-register-bt btn btn-primary">			
+					<span class="leoquicklogin-loading leoquicklogin-cssload-speeding-wheel"></span>
+					<i class="leoquicklogin-icon leoquicklogin-success-icon material-icons"></i>
+					<i class="leoquicklogin-icon leoquicklogin-fail-icon material-icons"></i>
+					<span class="lql-bt-txt">					
+						Utwórz konto
+					</span>
+				</button>
+			</div>
+			<div class="form-group lql-calllogin">
+				<div>Posiadasz już konto?</div>
+				<a role="button" href="#" class="lql-calllogin-action">Zaloguj się</a>
+				lub
+				<a role="button" href="#" class="lql-calllogin-action lql-callreset-action">zresetuj hasło</a>
+			</div>
+		</form>
+	</div>
+</div>
+
+<div class="lql-social-login clearfix show-bt-txt">
+	<p class="lql-social-login-title">
+		Połącz się przez sieci społecznościowe
+	</p>
+			<!--
+		<div class="fb-login-button" data-max-rows="1" data-size="large" data-button-type="login_with" data-show-faces="false" data-auto-logout-link="false" data-use-continue-as="false" scope="public_profile,email" onlogin="checkLoginState();"></div>
+		-->
+		<button class="btn social-login-bt facebook-login-bt" onclick="doFbLogin();"><span class="fa fa-facebook"></span>Zaloguj się przez Facebook</button>
+		
+		<!--
+		<div class="g-signin2" data-scope="profile email" data-longtitle="true" data-theme="dark" data-onsuccess="googleSignIn" data-onfailure="googleFail"></div>
+	-->
+		</div>
+
+        <div class="leoquicklogin-slidebar-bottom">
+            <button type="button" class="leoquicklogin-slidebar-close btn btn-secondary">
+                <i class="material-icons"></i>
+                <span>zamknij</span>
+            </button>
+        </div>
+    </div>
+</div><div class="leoquicklogin-slidebar slidebar_right">
+    <div class="leoquicklogin-slidebar-wrapper">
+        <div class="leoquicklogin-slidebar-top">
+            <button type="button" class="leoquicklogin-slidebar-close btn btn-secondary">
+                <i class="material-icons"></i>
+                <span>zamknij</span>
+            </button>
+        </div>
+        <div class="leo-quicklogin-form row">
+		<div class="leo-form leo-login-form col-sm-6 leo-form-active">
+		<p class="leo-login-title">			
+			<span class="title-both">
+				Logowanie do istniejącego konta
+			</span>
+		
+			<span class="title-only">
+				Zaloguj się na swoje konto
+			</span>		
+		</p>
+		<form class="lql-form-content leo-login-form-content" action="#" method="post">
+			<div class="form-group lql-form-mesg has-success">					
+			</div>			
+			<div class="form-group lql-form-mesg has-danger">					
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="email" class="form-control lql-email-login" name="lql-email-login" required="" placeholder="Adres e-mail">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="password" class="form-control lql-pass-login" name="lql-pass-login" required="" placeholder="Hasło">
+			</div>
+			<div class="form-group row lql-form-content-element">				
+				<div class="col-xs-6">
+											<input type="checkbox" class="lql-rememberme" name="lql-rememberme">
+						<label class="form-control-label"><span>Zapamiętaj mnie</span></label>
+									</div>				
+				<div class="col-xs-6 text-sm-right">
+					<a role="button" href="#" class="leoquicklogin-forgotpass">Zapomniałeś hasła ?</a>
+				</div>
+			</div>
+			<div class="form-group text-right">
+				<button type="submit" class="form-control-submit lql-form-bt lql-login-bt btn btn-primary">			
+					<span class="leoquicklogin-loading leoquicklogin-cssload-speeding-wheel"></span>
+					<i class="leoquicklogin-icon leoquicklogin-success-icon material-icons"></i>
+					<i class="leoquicklogin-icon leoquicklogin-fail-icon material-icons"></i>
+					<span class="lql-bt-txt">					
+						 Zaloguj się
+					</span>
+				</button>
+			</div>
+			<div class="form-group lql-callregister">
+				<a role="button" href="#" class="lql-callregister-action">Nie masz konta? Załóż je!</a>
+			</div>
+		</form>
+		<div class="leo-resetpass-form">
+			<p>Zresetuj hasło</p>
+			<form class="lql-form-content leo-resetpass-form-content" action="#" method="post">
+				<div class="form-group lql-form-mesg has-success">					
+				</div>			
+				<div class="form-group lql-form-mesg has-danger">					
+				</div>
+				<div class="form-group lql-form-content-element">
+					<input type="email" class="form-control lql-email-reset" name="lql-email-reset" required="" placeholder="Adres e-mail">
+				</div>
+				<div class="form-group">					
+					<button type="submit" class="form-control-submit lql-form-bt leoquicklogin-reset-pass-bt btn btn-primary">			
+						<span class="leoquicklogin-loading leoquicklogin-cssload-speeding-wheel"></span>
+						<i class="leoquicklogin-icon leoquicklogin-success-icon material-icons"></i>
+						<i class="leoquicklogin-icon leoquicklogin-fail-icon material-icons"></i>
+						<span class="lql-bt-txt">					
+							Zresetuj hasło
+						</span>
+					</button>
+				</div>
+				
+			</form>
+		</div>
+	</div>
+	
+	<div class="leo-form leo-register-form col-sm-6 leo-form-active">
+		<p class="leo-register-title">
+			Nowa rejestracja konta
+		</p>
+		<form class="lql-form-content leo-register-form-content" action="#" method="post">
+			<div class="form-group lql-form-mesg has-success">					
+			</div>			
+			<div class="form-group lql-form-mesg has-danger">					
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="text" class="form-control lql-register-firstname" name="lql-register-firstname" maxlength="20" placeholder="Imię">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="text" class="form-control lql-register-lastname" name="lql-register-lastname" required="" placeholder="Nazwisko">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="email" class="form-control lql-register-email" name="lql-register-email" required="" placeholder="Adres e-mail">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="password" class="form-control lql-register-pass" name="lql-register-pass" required="" placeholder="Hasło">
+			</div>
+						<div class="form-group text-right">				
+				<button type="submit" name="submit" class="form-control-submit lql-form-bt lql-register-bt btn btn-primary">			
+					<span class="leoquicklogin-loading leoquicklogin-cssload-speeding-wheel"></span>
+					<i class="leoquicklogin-icon leoquicklogin-success-icon material-icons"></i>
+					<i class="leoquicklogin-icon leoquicklogin-fail-icon material-icons"></i>
+					<span class="lql-bt-txt">					
+						Utwórz konto
+					</span>
+				</button>
+			</div>
+			<div class="form-group lql-calllogin">
+				<div>Posiadasz już konto?</div>
+				<a role="button" href="#" class="lql-calllogin-action">Zaloguj się</a>
+				lub
+				<a role="button" href="#" class="lql-calllogin-action lql-callreset-action">zresetuj hasło</a>
+			</div>
+		</form>
+	</div>
+</div>
+
+<div class="lql-social-login clearfix show-bt-txt">
+	<p class="lql-social-login-title">
+		Połącz się przez sieci społecznościowe
+	</p>
+			<!--
+		<div class="fb-login-button" data-max-rows="1" data-size="large" data-button-type="login_with" data-show-faces="false" data-auto-logout-link="false" data-use-continue-as="false" scope="public_profile,email" onlogin="checkLoginState();"></div>
+		-->
+		<button class="btn social-login-bt facebook-login-bt" onclick="doFbLogin();"><span class="fa fa-facebook"></span>Zaloguj się przez Facebook</button>
+		
+		<!--
+		<div class="g-signin2" data-scope="profile email" data-longtitle="true" data-theme="dark" data-onsuccess="googleSignIn" data-onfailure="googleFail"></div>
+	-->
+		</div>
+
+        <div class="leoquicklogin-slidebar-bottom">
+            <button type="button" class="leoquicklogin-slidebar-close btn btn-secondary">
+                <i class="material-icons"></i>
+                <span>zamknij</span>
+            </button>
+        </div>
+    </div>
+</div><div class="leoquicklogin-slidebar slidebar_top">
+    <div class="leoquicklogin-slidebar-wrapper">
+        <div class="leoquicklogin-slidebar-top">
+            <button type="button" class="leoquicklogin-slidebar-close btn btn-secondary">
+                <i class="material-icons"></i>
+                <span>zamknij</span>
+            </button>
+        </div>
+        <div class="leo-quicklogin-form row">
+		<div class="leo-form leo-login-form col-sm-6 leo-form-active">
+		<p class="leo-login-title">			
+			<span class="title-both">
+				Logowanie do istniejącego konta
+			</span>
+		
+			<span class="title-only">
+				Zaloguj się na swoje konto
+			</span>		
+		</p>
+		<form class="lql-form-content leo-login-form-content" action="#" method="post">
+			<div class="form-group lql-form-mesg has-success">					
+			</div>			
+			<div class="form-group lql-form-mesg has-danger">					
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="email" class="form-control lql-email-login" name="lql-email-login" required="" placeholder="Adres e-mail">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="password" class="form-control lql-pass-login" name="lql-pass-login" required="" placeholder="Hasło">
+			</div>
+			<div class="form-group row lql-form-content-element">				
+				<div class="col-xs-6">
+											<input type="checkbox" class="lql-rememberme" name="lql-rememberme">
+						<label class="form-control-label"><span>Zapamiętaj mnie</span></label>
+									</div>				
+				<div class="col-xs-6 text-sm-right">
+					<a role="button" href="#" class="leoquicklogin-forgotpass">Zapomniałeś hasła ?</a>
+				</div>
+			</div>
+			<div class="form-group text-right">
+				<button type="submit" class="form-control-submit lql-form-bt lql-login-bt btn btn-primary">			
+					<span class="leoquicklogin-loading leoquicklogin-cssload-speeding-wheel"></span>
+					<i class="leoquicklogin-icon leoquicklogin-success-icon material-icons"></i>
+					<i class="leoquicklogin-icon leoquicklogin-fail-icon material-icons"></i>
+					<span class="lql-bt-txt">					
+						 Zaloguj się
+					</span>
+				</button>
+			</div>
+			<div class="form-group lql-callregister">
+				<a role="button" href="#" class="lql-callregister-action">Nie masz konta? Załóż je!</a>
+			</div>
+		</form>
+		<div class="leo-resetpass-form">
+			<p>Zresetuj hasło</p>
+			<form class="lql-form-content leo-resetpass-form-content" action="#" method="post">
+				<div class="form-group lql-form-mesg has-success">					
+				</div>			
+				<div class="form-group lql-form-mesg has-danger">					
+				</div>
+				<div class="form-group lql-form-content-element">
+					<input type="email" class="form-control lql-email-reset" name="lql-email-reset" required="" placeholder="Adres e-mail">
+				</div>
+				<div class="form-group">					
+					<button type="submit" class="form-control-submit lql-form-bt leoquicklogin-reset-pass-bt btn btn-primary">			
+						<span class="leoquicklogin-loading leoquicklogin-cssload-speeding-wheel"></span>
+						<i class="leoquicklogin-icon leoquicklogin-success-icon material-icons"></i>
+						<i class="leoquicklogin-icon leoquicklogin-fail-icon material-icons"></i>
+						<span class="lql-bt-txt">					
+							Zresetuj hasło
+						</span>
+					</button>
+				</div>
+				
+			</form>
+		</div>
+	</div>
+	
+	<div class="leo-form leo-register-form col-sm-6 leo-form-active">
+		<p class="leo-register-title">
+			Nowa rejestracja konta
+		</p>
+		<form class="lql-form-content leo-register-form-content" action="#" method="post">
+			<div class="form-group lql-form-mesg has-success">					
+			</div>			
+			<div class="form-group lql-form-mesg has-danger">					
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="text" class="form-control lql-register-firstname" name="lql-register-firstname" maxlength="20" placeholder="Imię">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="text" class="form-control lql-register-lastname" name="lql-register-lastname" required="" placeholder="Nazwisko">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="email" class="form-control lql-register-email" name="lql-register-email" required="" placeholder="Adres e-mail">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="password" class="form-control lql-register-pass" name="lql-register-pass" required="" placeholder="Hasło">
+			</div>
+						<div class="form-group text-right">				
+				<button type="submit" name="submit" class="form-control-submit lql-form-bt lql-register-bt btn btn-primary">			
+					<span class="leoquicklogin-loading leoquicklogin-cssload-speeding-wheel"></span>
+					<i class="leoquicklogin-icon leoquicklogin-success-icon material-icons"></i>
+					<i class="leoquicklogin-icon leoquicklogin-fail-icon material-icons"></i>
+					<span class="lql-bt-txt">					
+						Utwórz konto
+					</span>
+				</button>
+			</div>
+			<div class="form-group lql-calllogin">
+				<div>Posiadasz już konto?</div>
+				<a role="button" href="#" class="lql-calllogin-action">Zaloguj się</a>
+				lub
+				<a role="button" href="#" class="lql-calllogin-action lql-callreset-action">zresetuj hasło</a>
+			</div>
+		</form>
+	</div>
+</div>
+
+<div class="lql-social-login clearfix show-bt-txt">
+	<p class="lql-social-login-title">
+		Połącz się przez sieci społecznościowe
+	</p>
+			<!--
+		<div class="fb-login-button" data-max-rows="1" data-size="large" data-button-type="login_with" data-show-faces="false" data-auto-logout-link="false" data-use-continue-as="false" scope="public_profile,email" onlogin="checkLoginState();"></div>
+		-->
+		<button class="btn social-login-bt facebook-login-bt" onclick="doFbLogin();"><span class="fa fa-facebook"></span>Zaloguj się przez Facebook</button>
+		
+		<!--
+		<div class="g-signin2" data-scope="profile email" data-longtitle="true" data-theme="dark" data-onsuccess="googleSignIn" data-onfailure="googleFail"></div>
+	-->
+		</div>
+
+        <div class="leoquicklogin-slidebar-bottom">
+            <button type="button" class="leoquicklogin-slidebar-close btn btn-secondary">
+                <i class="material-icons"></i>
+                <span>zamknij</span>
+            </button>
+        </div>
+    </div>
+</div><div class="leoquicklogin-slidebar slidebar_bottom">
+    <div class="leoquicklogin-slidebar-wrapper">
+        <div class="leoquicklogin-slidebar-top">
+            <button type="button" class="leoquicklogin-slidebar-close btn btn-secondary">
+                <i class="material-icons"></i>
+                <span>zamknij</span>
+            </button>
+        </div>
+        <div class="leo-quicklogin-form row">
+		<div class="leo-form leo-login-form col-sm-6 leo-form-active">
+		<p class="leo-login-title">			
+			<span class="title-both">
+				Logowanie do istniejącego konta
+			</span>
+		
+			<span class="title-only">
+				Zaloguj się na swoje konto
+			</span>		
+		</p>
+		<form class="lql-form-content leo-login-form-content" action="#" method="post">
+			<div class="form-group lql-form-mesg has-success">					
+			</div>			
+			<div class="form-group lql-form-mesg has-danger">					
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="email" class="form-control lql-email-login" name="lql-email-login" required="" placeholder="Adres e-mail">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="password" class="form-control lql-pass-login" name="lql-pass-login" required="" placeholder="Hasło">
+			</div>
+			<div class="form-group row lql-form-content-element">				
+				<div class="col-xs-6">
+											<input type="checkbox" class="lql-rememberme" name="lql-rememberme">
+						<label class="form-control-label"><span>Zapamiętaj mnie</span></label>
+									</div>				
+				<div class="col-xs-6 text-sm-right">
+					<a role="button" href="#" class="leoquicklogin-forgotpass">Zapomniałeś hasła ?</a>
+				</div>
+			</div>
+			<div class="form-group text-right">
+				<button type="submit" class="form-control-submit lql-form-bt lql-login-bt btn btn-primary">			
+					<span class="leoquicklogin-loading leoquicklogin-cssload-speeding-wheel"></span>
+					<i class="leoquicklogin-icon leoquicklogin-success-icon material-icons"></i>
+					<i class="leoquicklogin-icon leoquicklogin-fail-icon material-icons"></i>
+					<span class="lql-bt-txt">					
+						 Zaloguj się
+					</span>
+				</button>
+			</div>
+			<div class="form-group lql-callregister">
+				<a role="button" href="#" class="lql-callregister-action">Nie masz konta? Załóż je!</a>
+			</div>
+		</form>
+		<div class="leo-resetpass-form">
+			<p>Zresetuj hasło</p>
+			<form class="lql-form-content leo-resetpass-form-content" action="#" method="post">
+				<div class="form-group lql-form-mesg has-success">					
+				</div>			
+				<div class="form-group lql-form-mesg has-danger">					
+				</div>
+				<div class="form-group lql-form-content-element">
+					<input type="email" class="form-control lql-email-reset" name="lql-email-reset" required="" placeholder="Adres e-mail">
+				</div>
+				<div class="form-group">					
+					<button type="submit" class="form-control-submit lql-form-bt leoquicklogin-reset-pass-bt btn btn-primary">			
+						<span class="leoquicklogin-loading leoquicklogin-cssload-speeding-wheel"></span>
+						<i class="leoquicklogin-icon leoquicklogin-success-icon material-icons"></i>
+						<i class="leoquicklogin-icon leoquicklogin-fail-icon material-icons"></i>
+						<span class="lql-bt-txt">					
+							Zresetuj hasło
+						</span>
+					</button>
+				</div>
+				
+			</form>
+		</div>
+	</div>
+	
+	<div class="leo-form leo-register-form col-sm-6 leo-form-active">
+		<p class="leo-register-title">
+			Nowa rejestracja konta
+		</p>
+		<form class="lql-form-content leo-register-form-content" action="#" method="post">
+			<div class="form-group lql-form-mesg has-success">					
+			</div>			
+			<div class="form-group lql-form-mesg has-danger">					
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="text" class="form-control lql-register-firstname" name="lql-register-firstname" maxlength="20" placeholder="Imię">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="text" class="form-control lql-register-lastname" name="lql-register-lastname" required="" placeholder="Nazwisko">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="email" class="form-control lql-register-email" name="lql-register-email" required="" placeholder="Adres e-mail">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="password" class="form-control lql-register-pass" name="lql-register-pass" required="" placeholder="Hasło">
+			</div>
+						<div class="form-group text-right">				
+				<button type="submit" name="submit" class="form-control-submit lql-form-bt lql-register-bt btn btn-primary">			
+					<span class="leoquicklogin-loading leoquicklogin-cssload-speeding-wheel"></span>
+					<i class="leoquicklogin-icon leoquicklogin-success-icon material-icons"></i>
+					<i class="leoquicklogin-icon leoquicklogin-fail-icon material-icons"></i>
+					<span class="lql-bt-txt">					
+						Utwórz konto
+					</span>
+				</button>
+			</div>
+			<div class="form-group lql-calllogin">
+				<div>Posiadasz już konto?</div>
+				<a role="button" href="#" class="lql-calllogin-action">Zaloguj się</a>
+				lub
+				<a role="button" href="#" class="lql-calllogin-action lql-callreset-action">zresetuj hasło</a>
+			</div>
+		</form>
+	</div>
+</div>
+
+<div class="lql-social-login clearfix show-bt-txt">
+	<p class="lql-social-login-title">
+		Połącz się przez sieci społecznościowe
+	</p>
+			<!--
+		<div class="fb-login-button" data-max-rows="1" data-size="large" data-button-type="login_with" data-show-faces="false" data-auto-logout-link="false" data-use-continue-as="false" scope="public_profile,email" onlogin="checkLoginState();"></div>
+		-->
+		<button class="btn social-login-bt facebook-login-bt" onclick="doFbLogin();"><span class="fa fa-facebook"></span>Zaloguj się przez Facebook</button>
+		
+		<!--
+		<div class="g-signin2" data-scope="profile email" data-longtitle="true" data-theme="dark" data-onsuccess="googleSignIn" data-onfailure="googleFail"></div>
+	-->
+		</div>
+
+        <div class="leoquicklogin-slidebar-bottom">
+            <button type="button" class="leoquicklogin-slidebar-close btn btn-secondary">
+                <i class="material-icons"></i>
+                <span>zamknij</span>
+            </button>
+        </div>
+    </div>
+</div>
+<div class="modal lql-social-modal fade" tabindex="-1" role="dialog" aria-hidden="true">
+	
+	  <div class="modal-dialog" role="document">
+		<div class="modal-content">
+		  <div class="modal-header">
+			<button type="button" class="close" data-dismiss="modal" aria-label="Close">
+			  <span aria-hidden="true">×</span>
+			</button>
+			<p class="modal-title lql-social-modal-mesg lql-social-loading">
+				<span class="leoquicklogin-cssload-speeding-wheel"></span>
+			</p>
+			<p class="modal-title lql-social-modal-mesg error-email">
+				<i class="material-icons"></i>
+				Nie można zalogować się bez adresu e-mail!
+			</p>
+			<p class="modal-title lql-social-modal-mesg error-email">				
+				Sprawdź swoje konto społecznościowe i zezwól na korzystanie z informacji e-mail
+			</p>
+			<p class="modal-title lql-social-modal-mesg error-login">
+				<i class="material-icons"></i>
+				Nie możesz się zalogować!
+			</p>
+			<p class="modal-title lql-social-modal-mesg error-login">
+				Skontaktuj się z nami lub spróbuj zalogować się w inny sposób
+			</p>
+			<p class="modal-title lql-social-modal-mesg success">
+				<i class="material-icons"></i>
+				Pomyślnie!
+			</p>
+			<p class="modal-title lql-social-modal-mesg success">			
+				Dziękujemy za zalogowanie
+			</p>
+		  </div>
+		  
+		  		 
+		</div>
+	  </div>
+	
+</div>
+<div data-type="slidebar_bottom" style="position: fixed; bottom:0px; left:0px" class="leo-fly-cart solo type-fixed enable-slidebar offset-left">
+	<div class="leo-fly-cart-icon-wrapper">
+		<a href="javascript:void(0)" class="leo-fly-cart-icon" data-type="slidebar_bottom"><i class="material-icons"></i></a>
+		<span class="leo-fly-cart-total">0</span>
+	</div>
+		<div class="leo-fly-cart-cssload-loader" style="display: none;"></div>
+</div>	<div class="leo-fly-cart-mask"></div>
+
+<div class="leo-fly-cart-slidebar slidebar_bottom disable">
+	
+	<div class="leo-fly-cart disable-dropdown">
+		<div class="leo-fly-cart-wrapper">
+			<div class="leo-fly-cart-icon-wrapper">
+				<a href="javascript:void(0)" class="leo-fly-cart-icon"><i class="material-icons"></i></a>
+				<span class="leo-fly-cart-total">0</span>
+			</div>
+						<div class="leo-fly-cart-cssload-loader" style="display: none;"></div>
+		</div>
+	</div>
+
+</div><div class="modal fade x13pricehistory-modal" tabindex="-1" role="dialog" aria-labelledby="x13pricehistory-modalLabel" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">×</span>
+        </button>
+        <h5 class="modal-title">Historia cen produktu</h5>
+      </div>
+      <div class="modal-body">
+      </div>
+    </div>
+  </div>
+</div>
+    
+  
+
+<div><div class="grecaptcha-badge" data-style="bottomright" style="width: 256px; height: 60px; display: block; transition: right 0.3s; position: fixed; bottom: 14px; right: -186px; box-shadow: gray 0px 0px 5px; border-radius: 2px; overflow: hidden;"><div class="grecaptcha-logo"><iframe title="reCAPTCHA" width="256" height="60" role="presentation" name="a-6cy9s630hpj6" frameborder="0" scrolling="no" sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation allow-modals allow-popups-to-escape-sandbox allow-storage-access-by-user-activation" src="https://www.google.com/recaptcha/api2/anchor?ar=1&amp;k=6LfV7hsrAAAAAFM2myNNgqZuypFI573dG2Jvvvju&amp;co=aHR0cHM6Ly9mdW5reXNob3AucGw6NDQz&amp;hl=en&amp;v=TnA7HacJFoBWt9hnlunBlYfK&amp;size=invisible&amp;anchor-ms=20000&amp;execute-ms=30000&amp;cb=t42etow3nyf0"></iframe></div><div class="grecaptcha-error"></div><textarea id="g-recaptcha-response-100000" name="g-recaptcha-response" class="g-recaptcha-response" style="width: 250px; height: 40px; border: 1px solid rgb(193, 193, 193); margin: 10px 25px; padding: 0px; resize: none; display: none;"></textarea></div><iframe style="display: none;"></iframe></div><div class="modal leo-modal leo-modal-wishlist fade" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog" role="document"><div class="modal-content"><div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button><p class="modal-title text-xs-center"></p></div><div class="modal-footer"><button type="button" class="btn btn-secondary" data-dismiss="modal">Anuluj</button><button type="button" class="leo-modal-wishlist-bt btn btn-primary"><span class="leo-modal-wishlist-loading cssload-speeding-wheel"></span><span class="leo-modal-wishlist-bt-text">Ok</span></button></div></div></div></div><section class="off-canvas-nav-megamenu" data-megamenu-id="9184166521380958"><nav class="offcanvas-mainnav"><div class="off-canvas-button-megamenu"><span class="off-canvas-nav"></span>Zamknij</div><ul class="nav navbar-nav megamenu horizontal"><li data-menu-type="category" class="nav-item parent dropdown active">
+    <a class="nav-link dropdown-toggle has-category" data-toggle="dropdown" href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze" target="_self">
+
+                    
+                    <span class="menu-title">Piwo rzemieślnicze</span>
+                                        
+            </a>
+        <b class="caret"></b>
+            <div class="dropdown-sub dropdown-menu" style="width:600px">
+            <div class="dropdown-menu-inner">
+                                    <div class="row">
+                                                    <div class="mega-col col-md-4">
+                                <div class="mega-col-inner">
+                                    <div class="leo-widget" data-id_widget="1613641002">
+    <div class="widget-links">
+		<div class="widget-inner">	
+		<div id="tabs1118693385" class="panel-group">
+			<ul class="nav-links">
+				  
+					<li><a href="https://funkyshop.pl/pl/2-funky-shop">wszystkie produkty</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/brand/2-funky-fluid">Funky Fluid</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/nowe-produkty">Nowości</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/index.php?controller=pricesdrop">Promocje</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/16-zestawy">Zestawy</a></li>
+							</ul>
+		</div>
+	</div>
+    </div>
+</div>                                </div>
+                            </div>
+                                                    <div class="mega-col col-md-4">
+                                <div class="mega-col-inner">
+                                    <div class="leo-widget" data-id_widget="1613641017">
+    <div class="widget-links">
+		<div class="widget-inner">	
+		<div id="tabs427826493" class="panel-group">
+			<ul class="nav-links">
+				  
+					<li><a href="https://funkyshop.pl/pl/5-mocno-chmielone">Mocno chmielone</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/6-ciemne">Ciemne</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/7-kwasnedzikie">Kwaśne/dzikie</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/9-owocowe">Owocowe</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/10-klasyczne">Klasyczne</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/11-vintage">Vintage/barrel aged</a></li>
+							</ul>
+		</div>
+	</div>
+    </div>
+</div>                                </div>
+                            </div>
+                                                    <div class="mega-col col-md-4">
+                                <div class="mega-col-inner">
+                                    <div class="leo-widget" data-id_widget="1613641028">
+    <div class="widget-links">
+		<div class="widget-inner">	
+		<div id="tabs494219662" class="panel-group">
+			<ul class="nav-links">
+				  
+					<li><a href="https://funkyshop.pl/pl/2-oferta?q=Kraj+pochodzenia-Polska">Polska</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/2-oferta?q=Kraj+pochodzenia-Anglia">Anglia</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/2-piwa-rzemieslnicze?q=Kraj+pochodzenia-Belgia">Belgia</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/2-oferta?q=Kraj+pochodzenia-Szwecja">Szwecja</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/2-oferta?q=Kraj+pochodzenia-USA">USA</a></li>
+							</ul>
+		</div>
+	</div>
+    </div>
+</div>                                </div>
+                            </div>
+                                            </div>
+                            </div>
+        </div>
+    </li><li data-menu-type="category" class="nav-item parent dropdown">
+    <a class="nav-link dropdown-toggle has-category" data-toggle="dropdown" href="https://funkyshop.pl/pl/3-piwo-bezalkoholowe" target="_self">
+                    
+                    <span class="menu-title">Piwo bezalkoholowe</span>
+                                	
+	    </a>
+    <b class="caret"></b>
+    <div class="dropdown-menu level1">
+    <div class="dropdown-menu-inner">
+        <div class="row">
+            <div class="col-sm-12 mega-col" data-colwidth="12" data-type="menu">
+                <div class="inner">
+                    <ul>
+                                                    <li data-menu-type="category" class="nav-item   ">
+            <a class="nav-link" href="https://funkyshop.pl/pl/14-zero-procent">
+            
+                            <span class="menu-title">0%</span>
+                                    
+                    </a>
+
+    </li>
+            
+                                                    <li data-menu-type="category" class="nav-item   ">
+            <a class="nav-link" href="https://funkyshop.pl/pl/15-ponad-00">
+            
+                            <span class="menu-title">Ponad 0,0%</span>
+                                    
+                    </a>
+
+    </li>
+            
+                                            </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+</li>    <li data-menu-type="category" class="nav-item  ">
+        <a class="nav-link has-category" href="https://funkyshop.pl/pl/18-cydry-miody-wina" target="_self">
+                            
+                            <span class="menu-title">Cydry/wina/miody pitne</span>
+                                                        </a>
+    </li>
+    <li data-menu-type="category" class="nav-item  ">
+        <a class="nav-link has-category" href="https://funkyshop.pl/pl/17-szklomerch" target="_self">
+                            
+                            <span class="menu-title">Szkło / Merch</span>
+                                                        </a>
+    </li>
+    <li data-menu-type="category" class="nav-item pink ">
+        <a class="nav-link has-category" href="https://funkyshop.pl/pl/23-browar-miesiaca" target="_self">
+                            
+                            <span class="menu-title">Browar miesiąca</span>
+                                                        </a>
+    </li>
+    <li data-menu-type="controller" class="nav-item  ">
+        <a class="nav-link has-category" href="https://funkyshop.pl/pl/kontakt" target="_self">
+                            
+                            <span class="menu-title">Kontakt</span>
+                                                        </a>
+    </li>
+</ul></nav></section><div class="modal leo-modal leo-modal-cart fade" tabindex="-1" role="dialog" aria-hidden="true">
+	<!--
+	<div class="vertical-alignment-helper">
+	-->
+	  <div class="modal-dialog" role="document">
+		<div class="modal-content">
+		  <div class="modal-header">
+			<button type="button" class="close" data-dismiss="modal" aria-label="Close">
+			  <span aria-hidden="true">×</span>
+			</button>
+			<p class="modal-title h6 text-xs-center leo-warning leo-alert">
+				<i class="material-icons">info_outline</i>				
+				Musisz podać ilość		
+			</p>
+			
+			<p class="modal-title h6 text-xs-center leo-info leo-alert">
+				<i class="material-icons">info_outline</i>				
+				Minimalna ilość zamówienia produktu<strong class="alert-min-qty"></strong>		
+			</p>	
+			
+			<p class="modal-title h6 text-xs-center leo-block leo-alert">				
+				<i class="material-icons">block</i>				
+				W magazynie brak wystarczającej ilości produktów	
+			</p>
+		  </div>
+		  <!--
+		  <div class="modal-body">
+			...
+		  </div>
+		  <div class="modal-footer">
+			
+			<button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+			<button type="button" class="btn btn-primary">Save changes</button>
+			
+		  </div>
+		  -->
+		</div>
+	  </div>
+	<!--
+	</div>
+	-->
+</div>
+<div class="leo-notification" style="width: 100%; top:0px; right:0%">
+</div>
+<div class="leo-temp leo-temp-success">
+	<div class="notification-wrapper">
+		<div class="notification notification-success">
+						<strong class="noti product-name"></strong>
+			<span class="noti noti-update">Produkt został zaktualizowany w koszyku</span>
+			<span class="noti noti-delete">Produkt został usunięty z Twojego koszyka</span>
+			<span class="noti noti-add"><strong class="noti-special"></strong> Produkt pomyślnie dodano do koszyka</span>
+			<span class="notification-close">X</span>
+			
+		</div>
+	</div>
+</div>
+<div class="leo-temp leo-temp-error">
+	<div class="notification-wrapper">
+		<div class="notification notification-error">
+						
+			<span class="noti noti-update">Błąd podczas aktualizacji</span>
+			<span class="noti noti-delete">Błąd podczas usuwania	</span>
+			<span class="noti noti-add">Nie możesz zamówić większej ilości tego produktu</span>
+			
+			<span class="notification-close">X</span>
+			
+		</div>
+	</div>
+</div>
+<div class="leo-temp leo-temp-warning">
+	<div class="notification-wrapper">
+		<div class="notification notification-warning">
+						<span class="noti noti-min">Minimalna ilość zamówienia produktu	 <strong class="noti-special"></strong></span>
+			<span class="noti noti-max">W magazynie brak wystarczającej ilości produktów</span>
+			
+			<span class="notification-close">X</span>
+			
+		</div>
+	</div>
+</div>
+<div class="leo-temp leo-temp-normal">
+	<div class="notification-wrapper">
+		<div class="notification notification-normal">
+						<span class="noti noti-check">Musisz podać ilość</span>
+			
+			<span class="notification-close">X</span>
+			
+		</div>
+	</div>
+</div>
+<div class="jconfirm jconfirm-light jconfirm-open"><div class="jconfirm-bg" style="opacity: 0.5; transition-duration: 0.2s; transition-timing-function: cubic-bezier(0.36, 0.55, 0.19, 1);"></div><div class="jconfirm-scrollpane"><div class="jconfirm-row"><div class="jconfirm-cell"><div class="jconfirm-holder" style="padding-top: 0px; padding-bottom: 0px;"><div class="jc-bs3-container"><div class="jc-bs3-row"><div class="jconfirm-box-container jconfirm-animated jconfirm-no-transition" style="transform: translate(0px, 0px); transition-duration: 0.2s; transition-timing-function: cubic-bezier(0.36, 0.55, 0.19, 1);"><div class="jconfirm-box jconfirm-hilight-shake jconfirm-type-default jconfirm-type-animated" role="dialog" aria-labelledby="jconfirm-box22479" tabindex="-1" style="width: 976px; transition-duration: 0.2s; transition-timing-function: cubic-bezier(0.36, 0.55, 0.19, 1); transition-property: all, margin;"><div class="jconfirm-closeIcon" style="display: none;">×</div><div class="jconfirm-title-c" style="display: none;"><span class="jconfirm-icon-c"></span><span class="jconfirm-title"></span></div><div class="jconfirm-content-pane no-scroll" style="transition-duration: 0.2s; transition-timing-function: cubic-bezier(0.36, 0.55, 0.19, 1); height: 228px; max-height: 618.312px;"><div class="jconfirm-content" id="jconfirm-box22479"><div><div id="pmcookie">
+	<div class="pmcookie-h1">Drogi użytkowniku</div>
+	<div class="pmcookie-h4">Poniżej możesz zmienić ustawienia plików cookies naszych i naszych partnerów. Korzystanie przez nas z plików cookie analitycznych oraz marketingowych wymaga Twojej zgody. W ramach cookies marketingowych wydzieliliśmy kategorię plików cookie związanych z wyświetlaniem reklam w związku z korzystaniem ze stron internetowych (reklamowe pliki cookie) oraz plików cookie pozwalających na docieranie do Ciebie ze spersonalizowaną reklamą w portalach społecznościowych (pliki cookie mediów społecznościowych). Więcej informacji o poszczególnych kategoriach plików cookie, które stosujemy w serwisie, znajdziesz poniżej. Jeżeli chcesz zaakceptować wszystkie pliki cookie, kliknij „Zaakceptuj wszystkie”. Jeżeli natomiast chcesz, żebyśmy stosowali tylko niezbędne pliki cookie, kliknij „Zapisz ustawienia i zamknij”. Aby zmieniać preferencje plików cookie, przesuń suwak przy wybranej kategorii. Masz prawo do wglądu w swoje ustawienia oraz do ich zmiany w dowolnym czasie. Korzystanie z plików cookie wiąże się z przetwarzaniem Twoich danych osobowych dotyczących Twojej aktywności w serwisie. Szczegółowe informacje o sposobie, w jaki my oraz nasi partnerzy używamy plików cookie oraz przetwarzamy Twoje dane, a także o przysługujących Ci prawach, znajdziesz w naszej Polityce Cookies.</div>
+</div>
+
+</div></div></div><div class="jconfirm-buttons pmjconfirm-buttons"><button type="button" class="btn pmcookie-show-all pm-show-more-color pmcookie-left">Ustawienia</button><button type="button" class="btn pmcookie-show-submit pm-submit-color">Zaakceptuj wszystkie</button><button type="button" class="btn pmcookie-show-submit pm-submit-required-color">Zatwierdź tylko wymagane</button></div><div class="jconfirm-clear"></div></div></div></div></div></div></div></div></div></div></body></html>

--- a/extension/tests/fixtures/funkyshop.nonbeer.html
+++ b/extension/tests/fixtures/funkyshop.nonbeer.html
@@ -1,0 +1,2777 @@
+<!DOCTYPE html><html lang="pl" class="default off-canvas"><head>
+    
+      
+  <meta charset="utf-8">
+
+
+  <meta http-equiv="x-ua-compatible" content="ie=edge">
+
+
+	<meta property="og:url" content="https://funkyshop.pl/pl/17-szklomerch">
+	<meta property="og:title" content="Szkło i merch – szklanki, kufle, pokale do piwa, gadżety">
+	<meta property="og:description" content="Uzupełnieniem naszej oferty jest szkło – różnorodne szklanki, kufle i pokale do piwa. Proponujemy szklanki w różnych kształtach i o różnych pojemnościach.">
+	<meta property="og:type" content="website">
+	<meta property="og:image" content="https://funkyshop.plhttps://funkyshop.pl/img/logo-1743421189.jpg">
+  <meta property="fb:app_id" content="2358507497629256">
+
+
+
+  <title>Szkło i merch – szklanki, kufle, pokale do piwa, gadżety</title>
+  <meta name="description" content="Uzupełnieniem naszej oferty jest szkło – różnorodne szklanki, kufle i pokale do piwa. Proponujemy szklanki w różnych kształtach i o różnych pojemnościach.">
+    
+            
+          
+        <link rel="canonical" href="https://funkyshop.pl/pl/17-szklomerch">
+    
+                  <link rel="alternate" href="https://funkyshop.pl/pl/17-szklomerch" hreflang="pl">
+                  <link rel="alternate" href="https://funkyshop.pl/en/17-glassmerch" hreflang="en-us">
+        
+
+
+
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+
+
+  <link rel="icon" type="image/vnd.microsoft.icon" href="https://funkyshop.pl/img/favicon.ico?1768995451">
+  <link rel="shortcut icon" type="image/x-icon" href="https://funkyshop.pl/img/favicon.ico?1768995451">
+
+
+  
+
+    <link rel="stylesheet" href="https://funkyshop.pl/themes/leo_clark/assets/cache/theme-7d467f1506.css" type="text/css" media="all">
+
+
+
+    
+
+
+  
+
+  <script src="https://connect.facebook.net/pl_PL/bundle/sdk.js/" async="" crossorigin="anonymous"></script><script async="" src="https://scripts.clarity.ms/0.8.66/clarity.js"></script><script id="facebook-jssdk" src="https://connect.facebook.net/pl_PL/sdk.js#xfbml=1&amp;version=v5.0"></script><script type="text/javascript" async="" charset="utf-8" src="https://www.gstatic.com/recaptcha/releases/TnA7HacJFoBWt9hnlunBlYfK/recaptcha__en.js" crossorigin="anonymous" integrity="sha384-r0+0DCYB9Tdq4Rpy9IvL6ouvcnluWOWNg9jAIO3yJA2C6v7nklWcHe/NE5zIDHbA"></script><script async="" src="https://www.clarity.ms/tag/x0m7ny811l"></script><script type="text/javascript">
+        var LEO_COOKIE_THEME = "LEO_CLARK_PANEL_CONFIG";
+        var add_cart_error = "Podczas przetwarzania \u017c\u0105dania wyst\u0105pi\u0142 b\u0142\u0105d. Prosz\u0119 spr\u00f3buj ponownie";
+        var ajaxsearch = "1";
+        var appagebuilderToken = "b866420ae8aaf943d02267723ab32727";
+        var buttonwishlist_title_add = "Dodaj do listy \u017cycze\u0144";
+        var buttonwishlist_title_remove = "Usu\u0144 z listy \u017cycze\u0144";
+        var cancel_rating_txt = "Anuluj ocen\u0119";
+        var disable_review_form_txt = "Nie istnieje kryterium oceny tego produktu lub tego j\u0119zyka";
+        var dpdshipping_csrf = "b866420ae8aaf943d02267723ab32727";
+        var dpdshipping_id_cart = 0;
+        var dpdshipping_id_pudo_carrier = "400";
+        var dpdshipping_id_pudo_cod_carrier = false;
+        var dpdshipping_iframe_cod_url = "\/\/pudofinder.dpd.com.pl\/widget?key=1ae3418e27627ab52bebdcc1a958fa04&direct_delivery_cod=1&query=";
+        var dpdshipping_iframe_url = "\/\/pudofinder.dpd.com.pl\/widget?key=1ae3418e27627ab52bebdcc1a958fa04&query=";
+        var dpdshipping_pickup_get_address_ajax_url = "https:\/\/funkyshop.pl\/pl\/module\/dpdshipping\/PickupGetAddressAjax";
+        var dpdshipping_pickup_is_point_with_cod_ajax_url = "https:\/\/funkyshop.pl\/pl\/module\/dpdshipping\/PickupIsCodPointAjax";
+        var dpdshipping_pickup_save_point_ajax_url = "https:\/\/funkyshop.pl\/pl\/module\/dpdshipping\/PickupSavePointAjax";
+        var dpdshipping_token = "bea04497872c76c08b76009b3e64ecd9366ac36c";
+        var enable_dropdown_defaultcart = 1;
+        var enable_flycart_effect = 1;
+        var enable_notification = 1;
+        var height_cart_item = "115";
+        var isLogged = false;
+        var leo_push = 0;
+        var leo_search_url = "https:\/\/funkyshop.pl\/pl\/wyszukiwarka";
+        var leo_token = "b866420ae8aaf943d02267723ab32727";
+        var leoproductsearch_static_token = "b866420ae8aaf943d02267723ab32727";
+        var leoproductsearch_token = "74f973185b85b6419d9aadd1a0b68fe9";
+        var lf_is_gen_rtl = false;
+        var lps_show_product_img = "1";
+        var lps_show_product_price = true;
+        var lql_ajax_url = "https:\/\/funkyshop.pl\/pl\/module\/leoquicklogin\/leocustomer";
+        var lql_is_gen_rtl = false;
+        var lql_module_dir = "\/modules\/leoquicklogin\/";
+        var lql_myaccount_url = "https:\/\/funkyshop.pl\/pl\/moje-konto";
+        var lql_redirect = "";
+        var number_cartitem_display = 3;
+        var numpro_display = "100";
+        var pm_ca_show = "1";
+        var pm_cookie_delay_time = 0;
+        var pm_cookie_gv2 = "1";
+        var pm_cookie_label = {"Check all":"Zaznacz wszystkie","Settings":"Ustawienia","Accept all":"Zaakceptuj wszystkie","Submit selected":"Zaakceptuj wybrane i zapisz","Accept required":"Zatwierd\u017a tylko wymagane"};
+        var pm_cookie_link = "https:\/\/funkyshop.pl\/pl\/module\/pmcookie\/cookie?ajax=1";
+        var pm_cookie_link_conf = "https:\/\/funkyshop.pl\/pl\/module\/pmcookie\/settings?conf=1";
+        var pm_cookie_only_required = 0;
+        var pm_cookie_opacity = 0.5;
+        var pm_cookie_reload = 0;
+        var pm_cookie_required = ["1"];
+        var pm_cookie_settings = false;
+        var pm_cookie_show_on_scroll = 0;
+        var pm_sr_show = "0";
+        var pm_ss_show = "1";
+        var pmgoogleanalytycs4pro_ajax_link = "https:\/\/funkyshop.pl\/pl\/module\/pmgoogleanalytycs4pro\/ajax";
+        var pmgoogleanalytycs4pro_controller = "category";
+        var pmgoogleanalytycs4pro_secure_key = "bee687996f5a96ce53916f82abc43992";
+        var prestashop = {"cart":{"products":[],"totals":{"total":{"type":"total","label":"Razem","amount":0,"value":"0,00\u00a0z\u0142"},"total_including_tax":{"type":"total","label":"Suma (brutto)","amount":0,"value":"0,00\u00a0z\u0142"},"total_excluding_tax":{"type":"total","label":"Suma (netto)","amount":0,"value":"0,00\u00a0z\u0142"}},"subtotals":{"products":{"type":"products","label":"Produkty","amount":0,"value":"0,00\u00a0z\u0142"},"discounts":null,"shipping":{"type":"shipping","label":"Pakowanie","amount":0,"value":""},"tax":{"type":"tax","label":"VAT (wliczony)","amount":0,"value":"0,00\u00a0z\u0142"}},"products_count":0,"summary_string":"0 sztuk","vouchers":{"allowed":1,"added":[]},"discounts":[],"minimalPurchase":1,"minimalPurchaseRequired":"Minimalny zakup na kwot\u0119 1,00\u00a0z\u0142 (netto) jest wymagany aby zatwierdzi\u0107 Twoje zam\u00f3wienie, obecna warto\u015b\u0107 koszyka to 0,00\u00a0z\u0142 (netto)."},"currency":{"id":1,"name":"Z\u0142oty polski","iso_code":"PLN","iso_code_num":"985","sign":"z\u0142"},"customer":{"lastname":null,"firstname":null,"email":null,"birthday":null,"newsletter":null,"newsletter_date_add":null,"optin":null,"website":null,"company":null,"siret":null,"ape":null,"is_logged":false,"gender":{"type":null,"name":null},"addresses":[]},"language":{"name":"Polski (Polish)","iso_code":"pl","locale":"pl-PL","language_code":"pl","is_rtl":"0","date_format_lite":"Y-m-d","date_format_full":"Y-m-d H:i:s","id":1},"page":{"title":"","canonical":"https:\/\/funkyshop.pl\/pl\/17-szklomerch","meta":{"title":"Szk\u0142o i merch \u2013 szklanki, kufle, pokale do piwa, gad\u017cety","description":"Uzupe\u0142nieniem naszej oferty jest szk\u0142o \u2013 r\u00f3\u017cnorodne szklanki, kufle i pokale do piwa. Proponujemy szklanki w r\u00f3\u017cnych kszta\u0142tach i o r\u00f3\u017cnych pojemno\u015bciach.","keywords":"","robots":"index"},"page_name":"category","body_classes":{"lang-pl":true,"lang-rtl":false,"country-PL":true,"currency-PLN":true,"layout-left-column":true,"page-category":true,"tax-display-enabled":true,"category-id-17":true,"category-Szk\u0142o\/Merch":true,"category-id-parent-2":true,"category-depth-level-2":true},"admin_notifications":[]},"shop":{"name":"Funky Shop","logo":"https:\/\/funkyshop.pl\/img\/logo-1743421189.jpg","stores_icon":"https:\/\/funkyshop.pl\/img\/logo_stores.png","favicon":"https:\/\/funkyshop.pl\/img\/favicon.ico"},"urls":{"base_url":"https:\/\/funkyshop.pl\/","current_url":"https:\/\/funkyshop.pl\/pl\/17-szklomerch","shop_domain_url":"https:\/\/funkyshop.pl","img_ps_url":"https:\/\/funkyshop.pl\/img\/","img_cat_url":"https:\/\/funkyshop.pl\/img\/c\/","img_lang_url":"https:\/\/funkyshop.pl\/img\/l\/","img_prod_url":"https:\/\/funkyshop.pl\/img\/p\/","img_manu_url":"https:\/\/funkyshop.pl\/img\/m\/","img_sup_url":"https:\/\/funkyshop.pl\/img\/su\/","img_ship_url":"https:\/\/funkyshop.pl\/img\/s\/","img_store_url":"https:\/\/funkyshop.pl\/img\/st\/","img_col_url":"https:\/\/funkyshop.pl\/img\/co\/","img_url":"https:\/\/funkyshop.pl\/themes\/leo_clark\/assets\/img\/","css_url":"https:\/\/funkyshop.pl\/themes\/leo_clark\/assets\/css\/","js_url":"https:\/\/funkyshop.pl\/themes\/leo_clark\/assets\/js\/","pic_url":"https:\/\/funkyshop.pl\/upload\/","pages":{"address":"https:\/\/funkyshop.pl\/pl\/adres","addresses":"https:\/\/funkyshop.pl\/pl\/adresy","authentication":"https:\/\/funkyshop.pl\/pl\/logowanie","cart":"https:\/\/funkyshop.pl\/pl\/koszyk","category":"https:\/\/funkyshop.pl\/pl\/index.php?controller=category","cms":"https:\/\/funkyshop.pl\/pl\/index.php?controller=cms","contact":"https:\/\/funkyshop.pl\/pl\/kontakt","discount":"https:\/\/funkyshop.pl\/pl\/rabaty","guest_tracking":"https:\/\/funkyshop.pl\/pl\/sledzenie-zamowien-gosci","history":"https:\/\/funkyshop.pl\/pl\/historia-zamowien","identity":"https:\/\/funkyshop.pl\/pl\/dane-osobiste","index":"https:\/\/funkyshop.pl\/pl\/","my_account":"https:\/\/funkyshop.pl\/pl\/moje-konto","order_confirmation":"https:\/\/funkyshop.pl\/pl\/potwierdzenie-zamowienia","order_detail":"https:\/\/funkyshop.pl\/pl\/index.php?controller=order-detail","order_follow":"https:\/\/funkyshop.pl\/pl\/sledzenie-zamowienia","order":"https:\/\/funkyshop.pl\/pl\/zamowienie","order_return":"https:\/\/funkyshop.pl\/pl\/index.php?controller=order-return","order_slip":"https:\/\/funkyshop.pl\/pl\/potwierdzenie-zwrotu","pagenotfound":"https:\/\/funkyshop.pl\/pl\/nie-znaleziono-strony","password":"https:\/\/funkyshop.pl\/pl\/odzyskiwanie-hasla","pdf_invoice":"https:\/\/funkyshop.pl\/pl\/index.php?controller=pdf-invoice","pdf_order_return":"https:\/\/funkyshop.pl\/pl\/index.php?controller=pdf-order-return","pdf_order_slip":"https:\/\/funkyshop.pl\/pl\/index.php?controller=pdf-order-slip","prices_drop":"https:\/\/funkyshop.pl\/pl\/promocje","product":"https:\/\/funkyshop.pl\/pl\/index.php?controller=product","search":"https:\/\/funkyshop.pl\/pl\/szukaj","sitemap":"https:\/\/funkyshop.pl\/pl\/mapa-strony","stores":"https:\/\/funkyshop.pl\/pl\/nasze-sklepy","supplier":"https:\/\/funkyshop.pl\/pl\/dostawcy","register":"https:\/\/funkyshop.pl\/pl\/logowanie?create_account=1","order_login":"https:\/\/funkyshop.pl\/pl\/zamowienie?login=1"},"alternative_langs":{"pl":"https:\/\/funkyshop.pl\/pl\/17-szklomerch","en-us":"https:\/\/funkyshop.pl\/en\/17-glassmerch"},"theme_assets":"\/themes\/leo_clark\/assets\/","actions":{"logout":"https:\/\/funkyshop.pl\/pl\/?mylogout="},"no_picture_image":{"bySize":{"small_default":{"url":"https:\/\/funkyshop.pl\/img\/p\/pl-default-small_default.jpg","width":98,"height":98},"cart_default":{"url":"https:\/\/funkyshop.pl\/img\/p\/pl-default-cart_default.jpg","width":125,"height":125},"medium_default":{"url":"https:\/\/funkyshop.pl\/img\/p\/pl-default-medium_default.jpg","width":400,"height":400},"home_default":{"url":"https:\/\/funkyshop.pl\/img\/p\/pl-default-home_default.jpg","width":500,"height":500},"large_default":{"url":"https:\/\/funkyshop.pl\/img\/p\/pl-default-large_default.jpg","width":1000,"height":1000}},"small":{"url":"https:\/\/funkyshop.pl\/img\/p\/pl-default-small_default.jpg","width":98,"height":98},"medium":{"url":"https:\/\/funkyshop.pl\/img\/p\/pl-default-medium_default.jpg","width":400,"height":400},"large":{"url":"https:\/\/funkyshop.pl\/img\/p\/pl-default-large_default.jpg","width":1000,"height":1000},"legend":""}},"configuration":{"display_taxes_label":true,"display_prices_tax_incl":true,"is_catalog":false,"show_prices":true,"opt_in":{"partner":false},"quantity_discount":{"type":"discount","label":"Rabat Jednostkowy"},"voucher_enabled":1,"return_enabled":1},"field_required":[],"breadcrumb":{"links":[{"title":"G\u0142\u00f3wna","url":"https:\/\/funkyshop.pl\/pl\/"},{"title":"Szk\u0142o\/Merch","url":"https:\/\/funkyshop.pl\/pl\/17-szklomerch"}],"count":2},"link":{"protocol_link":"https:\/\/","protocol_content":"https:\/\/"},"time":1782821793,"static_token":"b866420ae8aaf943d02267723ab32727","token":"74f973185b85b6419d9aadd1a0b68fe9","debug":false};
+        var psemailsubscription_subscription = "https:\/\/funkyshop.pl\/pl\/module\/ps_emailsubscription\/subscription";
+        var psr_icon_color = "#F19D76";
+        var recaptcha = {"newsletter":"1","contact":"1","resetpw":"1","login":"1","register":"1"};
+        var recaptchatoken = "6LfV7hsrAAAAAFM2myNNgqZuypFI573dG2Jvvvju";
+        var review_error = "Podczas przetwarzania \u017c\u0105dania wyst\u0105pi\u0142 b\u0142\u0105d. Prosz\u0119 spr\u00f3buj ponownie";
+        var show_popup = 0;
+        var text_no_product = "Brak produkt\u00f3w";
+        var text_results_count = "results";
+        var type_dropdown_defaultcart = "dropdown";
+        var type_flycart_effect = "fade";
+        var width_cart_item = "265";
+        var wishlist_add = "Produkt zosta\u0142 pomy\u015blnie dodany do Twojej listy \u017cycze\u0144\t";
+        var wishlist_cancel_txt = "Anuluj";
+        var wishlist_confirm_del_txt = "Usun\u0105\u0107 wybrany element?";
+        var wishlist_del_default_txt = "Nie mo\u017cna usun\u0105\u0107 domy\u015blnej listy \u017cycze\u0144";
+        var wishlist_email_txt = "E-mail";
+        var wishlist_loggin_required = "Musisz by\u0107 zalogowany, aby zarz\u0105dza\u0107 swoj\u0105 list\u0105 \u017cycze\u0144\t";
+        var wishlist_ok_txt = "Ok";
+        var wishlist_quantity_required = "Musisz poda\u0107 ilo\u015b\u0107";
+        var wishlist_remove = "Produkt zosta\u0142 pomy\u015blnie usuni\u0119ty z Twojej listy \u017cycze\u0144";
+        var wishlist_reset_txt = "Resetuj";
+        var wishlist_send_txt = "Wy\u015blij";
+        var wishlist_send_wishlist_txt = "Wy\u015blij list\u0119 \u017cycze\u0144";
+        var wishlist_url = "https:\/\/funkyshop.pl\/pl\/module\/leofeature\/mywishlist";
+        var wishlist_viewwishlist = "Zobacz swoj\u0105 list\u0119 \u017cycze\u0144";
+      </script>
+<script type="text/javascript">
+	var choosefile_text = "Wybierz plik";
+	var turnoff_popup_text = "Nie pokazuj więcej tego wyskakującego okienka";
+	
+	var size_item_quickview = 82;
+	var style_scroll_quickview = 'vertical';
+	
+	var size_item_page = 113;
+	var style_scroll_page = 'horizontal';
+	
+	var size_item_quickview_attr = 101;	
+	var style_scroll_quickview_attr = 'vertical';
+	
+	var size_item_popup = 160;
+	var style_scroll_popup = 'vertical';
+</script>  <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.lazy/1.7.10/jquery.lazy.min.js"></script>
+  <script async="" src="https://access.eye-able.com/configs/funkyshop.pl.js"></script>
+
+  
+    <script type="text/javascript">
+        (function(c,l,a,r,i,t,y){
+            c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+            t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+            y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+        })(window, document, "clarity", "script", "x0m7ny811l");
+    </script>
+  
+  
+
+
+
+  
+<script>
+    var x13pricehistory_ajax_url = 'https://funkyshop.pl/pl/module/x13pricehistory/ajax';
+    var x13pricehistory_ajax_token = 'b866420ae8aaf943d02267723ab32727';
+</script>
+
+<!-- START > PM Google Analytycs 4.0 1.6.x and 1.7.x Module -->
+<script async="" data-keepinline="true" src="https://www.googletagmanager.com/gtag/js?id=G-ZKT34BH6DS"></script>
+
+
+<script>
+	window.dataLayer = window.dataLayer || [];
+	function gtag(){dataLayer.push(arguments);}
+	gtag('js', new Date());
+
+	gtag('config', 'G-ZKT34BH6DS', {'send_page_view': true});
+	gtag('set', {currency: 'PLN'});
+	gtag('set', {country: 'PL'});
+	</script>
+
+
+<!-- END > PM Google Analytycs 4.0 1.6.x and 1.7.x Module -->
+<style>
+  :root {
+    --x13gpsr-color-link: #24b9d7;
+    --x13gpsr-color-tab: #24b9d7;
+  }
+</style><script type="text/javascript">
+    var bant_extra_price_url = 'https://funkyshop.pl/pl/module/bantrecyclingdeposit/price';
+    var bant_er_id = '3279';
+    var bant_er_legacy_mode = 'false';
+</script>
+<!-- emarketing start -->
+
+
+
+
+<!-- emarketing end --><!-- @file modules\appagebuilder\views\templates\hook\header -->
+
+<script>
+	/**
+	 * List functions will run when document.ready()
+	 */
+	var ap_list_functions = [];
+	/**
+	 * List functions will run when window.load()
+	 */
+	var ap_list_functions_loaded = [];
+
+	/**
+	 * List functions will run when document.ready() for theme
+	 */
+
+	var products_list_functions = [];
+</script>
+
+
+<script type="text/javascript">
+	var leoOption = {
+		category_qty:1,
+		product_list_image:0,
+		product_one_img:1,
+		productCdown: 1,
+		productColor: 0,
+		homeWidth: 500,
+		homeheight: 500,
+	}
+
+	ap_list_functions.push(function(){
+		if (typeof $.LeoCustomAjax !== "undefined" && $.isFunction($.LeoCustomAjax)) {
+			var leoCustomAjax = new $.LeoCustomAjax();
+			leoCustomAjax.processAjax();
+		}
+	});
+</script>
+<script type="text/javascript">
+	
+	var FancyboxI18nClose = "Zamknij";
+	var FancyboxI18nNext = "Następny";
+	var FancyboxI18nPrev = "Poprzedni";
+	var current_link = "http://funkyshop.pl/pl/";		
+	var currentURL = window.location;
+	currentURL = String(currentURL);
+	currentURL = currentURL.replace("https://","").replace("http://","").replace("www.","").replace( /#\w*/, "" );
+	current_link = current_link.replace("https://","").replace("http://","").replace("www.","");
+	var text_warning_select_txt = "Wybierz pozycje do usunięcia";
+	var text_confirm_remove_txt = "Na pewno chcesz usunąć pozycje?";
+	var close_bt_txt = "Zamknij";
+	var list_menu = [];
+	var list_menu_tmp = {};
+	var list_tab = [];
+	var isHomeMenu = 0;
+	
+</script><script>
+    window.dataLayer = window.dataLayer || [];
+
+    function gtag() {
+        window.dataLayer.push(arguments);
+    }
+        gtag('consent', 'default', {
+        'functionality_storage': 'denied',
+        'analytics_storage': 'denied',
+        'ad_personalization': 'denied',
+        'ad_storage': 'denied',
+        'ad_user_data': 'denied',
+        'personalization_storage': 'denied',
+        'security_storage': 'denied',
+        'wait_for_update': 1000
+    });
+    gtag('set', 'url_passthrough', false);
+    gtag('set', 'ads_data_redaction', true);
+</script>
+
+
+
+
+
+    
+  <style type="text/css">.fancybox-margin{margin-right:0px;}</style><script async="" src="https://access.eye-able.com/configs/funkyshop.pl/default.js"></script><script async="" src="https://access.eye-able.com/access/eyeAbleAccess.js"></script><style type="text/css" data-fbcssmodules="css:fb.css.base css:fb.css.dialog css:fb.css.iframewidget">.fb_hidden{position:absolute;top:-10000px;z-index:10001}.fb_reposition{overflow:hidden;position:relative}.fb_invisible{display:none}.fb_reset{background:none;border:0px;border-spacing:0;color:#000;cursor:auto;direction:ltr;font-family:lucida grande,tahoma,verdana,arial,sans-serif;font-size:11px;font-style:normal;font-variant:normal;font-weight:400;letter-spacing:normal;line-height:1;margin:0;overflow:visible;padding:0;text-align:left;text-decoration:none;text-indent:0;text-shadow:none;text-transform:none;visibility:visible;white-space:normal;word-spacing:normal}.fb_reset>div{overflow:hidden}@keyframes fb_transform{0%{opacity:0;transform:scale(.95)}to{opacity:1;transform:scale(1)}}.fb_animate{animation:fb_transform .3s forwards}
+
+.fb_dialog{background:#525252b3;position:absolute;top:-10000px;z-index:10001}.fb_dialog_advanced{border-radius:8px;padding:10px}.fb_dialog_content{background:#fff;color:#373737}.fb_dialog_close_icon{background:url(https://connect.facebook.net/rsrc.php/v4/yq/r/IE9JII6Z1Ys.png) no-repeat scroll 0 0 transparent;cursor:pointer;display:block;height:15px;position:absolute;right:18px;top:17px;width:15px}.fb_dialog_mobile .fb_dialog_close_icon{left:5px;right:auto;top:5px}.fb_dialog_padding{background-color:transparent;position:absolute;width:1px;z-index:-1}.fb_dialog_close_icon:hover{background:url(https://connect.facebook.net/rsrc.php/v4/yq/r/IE9JII6Z1Ys.png) no-repeat scroll 0 -15px transparent}.fb_dialog_close_icon:active{background:url(https://connect.facebook.net/rsrc.php/v4/yq/r/IE9JII6Z1Ys.png) no-repeat scroll 0 -30px transparent}.fb_dialog_iframe{line-height:0}.fb_dialog_content .dialog_title{background:#6d84b4;border:1px solid #365899;color:#fff;font-size:14px;font-weight:700;margin:0}.fb_dialog_content .dialog_title>span{background:url(https://connect.facebook.net/rsrc.php/v4/yd/r/Cou7n-nqK52.gif) no-repeat 5px 50%;float:left;padding:5px 0 7px 26px}body.fb_hidden{height:100%;left:0;margin:0;overflow:visible;position:absolute;top:-10000px;transform:none;width:100%}.fb_dialog.fb_dialog_mobile.loading{background:url(https://connect.facebook.net/rsrc.php/v4/ya/r/3rhSv5V8j3o.gif) #fff no-repeat 50% 50%;min-height:100%;min-width:100%;overflow:hidden;position:absolute;top:0;z-index:10001}.fb_dialog.fb_dialog_mobile.loading.centered{background:none;height:auto;min-height:initial;min-width:initial;width:auto}.fb_dialog.fb_dialog_mobile.loading.centered #fb_dialog_loader_spinner{width:100%}.fb_dialog.fb_dialog_mobile.loading.centered .fb_dialog_content{background:none}.loading.centered #fb_dialog_loader_close{clear:both;color:#fff;display:block;font-size:18px;padding-top:20px}#fb-root #fb_dialog_ipad_overlay{background:#0006;inset:0;min-height:100%;position:absolute;width:100%;z-index:10000}#fb-root #fb_dialog_ipad_overlay.hidden{display:none}.fb_dialog.fb_dialog_mobile.loading iframe{visibility:hidden}.fb_dialog_mobile .fb_dialog_iframe{position:sticky;top:0}.fb_dialog_content .dialog_header{background:linear-gradient(from(#738aba),to(#2c4987));border-bottom:1px solid;border-color:#043b87;box-shadow:#fff 0 1px 1px -1px inset;color:#fff;font:700 14px Helvetica,sans-serif;text-overflow:ellipsis;text-shadow:rgba(0,30,84,.296875) 0px -1px 0px;vertical-align:middle;white-space:nowrap}.fb_dialog_content .dialog_header table{height:43px;width:100%}.fb_dialog_content .dialog_header td.header_left{font-size:12px;padding-left:5px;vertical-align:middle;width:60px}.fb_dialog_content .dialog_header td.header_right{font-size:12px;padding-right:5px;vertical-align:middle;width:60px}.fb_dialog_content .touchable_button{background:linear-gradient(from(#4267B2),to(#2a4887));background-clip:padding-box;border:1px solid #29487d;border-radius:3px;display:inline-block;line-height:18px;margin-top:3px;max-width:85px;padding:4px 12px;position:relative}.fb_dialog_content .dialog_header .touchable_button input{background:none;border:none;color:#fff;font:700 12px Helvetica,sans-serif;margin:2px -12px;padding:2px 6px 3px;text-shadow:rgba(0,30,84,.296875) 0px -1px 0px}.fb_dialog_content .dialog_header .header_center{color:#fff;font-size:16px;font-weight:700;line-height:18px;text-align:center;vertical-align:middle}.fb_dialog_content .dialog_content{background:url(https://connect.facebook.net/rsrc.php/v4/y9/r/jKEcVPZFk-2.gif) no-repeat 50% 50%;border:1px solid #4A4A4A;border-bottom:0;border-top:0;height:150px}.fb_dialog_content .dialog_footer{background:#f5f6f7;border:1px solid #4A4A4A;border-top-color:#ccc;height:40px}#fb_dialog_loader_close{float:left}.fb_dialog.fb_dialog_mobile .fb_dialog_close_icon{visibility:hidden}#fb_dialog_loader_spinner{animation:rotateSpinner 1.2s linear infinite;background-color:transparent;background-image:url(https://connect.facebook.net/rsrc.php/v4/y2/r/onuUJj0tCqE.png);background-position:50% 50%;background-repeat:no-repeat;height:24px;width:24px}@keyframes rotateSpinner{0%{transform:rotate(0)}to{transform:rotate(360deg)}}
+
+.fb_iframe_widget{display:inline-block;position:relative}.fb_iframe_widget span{display:inline-block;position:relative;text-align:justify}.fb_iframe_widget iframe{position:absolute}.fb_iframe_widget_fluid_desktop,.fb_iframe_widget_fluid_desktop span,.fb_iframe_widget_fluid_desktop iframe{max-width:100%}.fb_iframe_widget_fluid_desktop iframe{min-width:220px;position:relative}.fb_iframe_widget_lift{z-index:1}.fb_iframe_widget_fluid{display:inline}.fb_iframe_widget_fluid span{width:100%}
+</style></head>
+
+  <body id="category" class="lang-pl country-pl currency-pln layout-left-column page-category tax-display-enabled category-id-17 category-szklo-merch category-id-parent-2 category-depth-level-2 fullwidth" style="overflow: hidden;">
+
+    
+          <!-- Load Facebook SDK for JavaScript -->
+<!-- Load Facebook SDK for JavaScript -->
+
+    <!-- PM Google Analytycs 4 Pro - EVENTS CODE FOOTER -->
+<script type="text/javascript">
+
+	
+		console.log('Fired up event GA4: view_item_list > Category products list page');
+		gtag('event', 'view_item_list', {
+			items: [
+								{
+					item_id: '5450',
+					item_name: 'Funky Fluid Szklanka Craftmaster One 7th Anniversary 473ml',
+					coupon: '',
+					discount: -0,
+					index: 0,
+					item_list_name: 'Szkło/Merch',
+					item_list_id: 'category',
+					affiliation: '',
+					item_brand: 'Funky Fluid',
+					item_category: 'Szkło',
+					item_category2: 'Merch',																				item_variant: '',
+					price: 20,
+					currency: 'PLN',
+					quantity: 1
+				},
+								{
+					item_id: '4550',
+					item_name: 'Funky Fluid Szklanka Mosella 2025 200ml',
+					coupon: '',
+					discount: 0,
+					index: 1,
+					item_list_name: 'Szkło/Merch',
+					item_list_id: 'category',
+					affiliation: '',
+					item_brand: 'Funky Fluid',
+					item_category: 'Szkło',
+					item_category2: 'Merch',																				item_variant: '',
+					price: 25,
+					currency: 'PLN',
+					quantity: 1
+				},
+								{
+					item_id: '5143',
+					item_name: 'Funky Fluid Szklanka Gelato 2025 Sahm Sensorik 300ml',
+					coupon: '',
+					discount: 0,
+					index: 2,
+					item_list_name: 'Szkło/Merch',
+					item_list_id: 'category',
+					affiliation: '',
+					item_brand: 'Funky Fluid',
+					item_category: 'Szkło',
+					item_category2: 'Merch',																				item_variant: '',
+					price: 25,
+					currency: 'PLN',
+					quantity: 1
+				},
+							],
+			item_list_name: 'Szkło/Merch',
+			item_list_id: 'category'
+		});
+
+
+	
+	
+</script>
+<!-- PM Google Analytycs 4 Pro - EVENTS CODE FOOTER -->
+
+    
+
+    <main id="page">
+      
+              
+      <header id="header">
+        <div class="header-container">
+          
+            
+  <div class="header-banner">
+          <div class="container">
+              <div class="inner"><!--
+* 2007-2018 PrestaShop
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+* @author    PrestaShop SA <contact@prestashop.com>
+* @copyright 2007-2018 PrestaShop SA
+* @license   http://addons.prestashop.com/en/content/12-terms-and-conditions-of-use
+* International Registered Trademark & Property of PrestaShop SA
+-->
+<link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet" type="text/css" media="all">
+<link href="https://fonts.googleapis.com/css?family=Hind" rel="stylesheet" type="text/css" media="all">
+<link href="https://fonts.googleapis.com/css?family=Maven+Pro" rel="stylesheet" type="text/css" media="all">
+<link href="https://fonts.googleapis.com/css?family=Noto+Serif" rel="stylesheet" type="text/css" media="all">
+<link href="https://fonts.googleapis.com/css?family=Bitter" rel="stylesheet" type="text/css" media="all">
+<link href="https://fonts.googleapis.com/css?family=Forum" rel="stylesheet" type="text/css" media="all">
+
+<div id="psagechecker_block" class="preload">
+    <div id="psagechecker-lightbox" class="lightbox">
+        <div class="lightbox-content">
+            <div style="height:100%">
+                                <div class="age_verify_text_content">
+                    <div class="age_verify" style="font-family: Roboto !important;">
+                        <p>Dostęp do tej witryny nie jest udzielany osobom niepełnoletnim.</p>
+                    </div>
+                    <div class="blockAgeVerify">
+                        <div class="custom_msg_age_verify">
+                            <p>Aby uzyskać dostęp do sklepu potwierdź, że jesteś osobą pełnoletnią.</p>
+                        </div>
+                                                    <div class="age_verify_buttons">
+                                <button id="deny_button" class="btn btn_deny">Nie mam 18 lat</button>
+                                <button id="confirm_button" class="btn btn_confirm">Mam 18 lat, wchodzę</button>
+                            </div>
+                                            </div>
+                </div>
+                <div class="deny_msg_age_verify psagechecker-hide">
+                    <p>Przepraszamy, nie skończyłeś 18 lat, więc nie możesz uzyskać dostępu do naszej strony internetowej.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div id="overlay" class=""></div>
+</div>
+<style>
+
+    #psagechecker-lightbox{
+        background-color: #d7d7d7 !important;
+    }
+    #psagechecker-lightbox, #psagechecker-lightbox *{
+        font-family: Roboto !important;
+    }
+
+    .btn_deny{
+        background-color: #686868 !important;
+        color: #ffffff !important;
+    }
+    .btn_confirm{
+        background-color: #ec008c !important;
+        color: #ffffff !important;
+    }
+    #psagechecker_block .lightbox{
+        width : 500px ;
+        height : 400px !important;
+    }
+    #psagechecker_block #overlay {
+        background-color: rgba(0,0,0,0.7);
+        height: 100%;
+        left: 0;
+        position: fixed;
+        top: 0;
+        width: 100%;
+        z-index: 9999;
+    }
+</style>
+
+<script>
+var display_popup = "1";
+var age_required = "18";
+</script>
+
+</div>
+          </div>
+        </div>
+
+
+
+  <nav class="header-nav">
+    <div class="topnav">
+              <div class="inner"></div>
+          </div>
+    <div class="bottomnav">
+              <div class="inner"><!-- @file modules\appagebuilder\views\templates\hook\ApRow -->
+<div class="wrapper" style="background: repeat-x bottom">
+
+<div class="container">
+    <div class="row box-navh1 ApRow  has-bg bg-fullwidth-container" style="margin-top: 25px;margin-bottom: 50px;">
+                                            <!-- @file modules\appagebuilder\views\templates\hook\ApColumn -->
+<div class="col-xl-3 col-lg-12 col-md-12 col-sm-12 col-xs-12 col-sp-12 search-column ApColumn ">
+                    <!-- @file modules\appagebuilder\views\templates\hook\ApModule -->
+
+
+<!-- Block search module -->
+<div id="leo_search_block_top" class="block exclusive search-by-category">
+			<form method="get" action="https://funkyshop.pl/pl/index.php?controller=productsearch" id="leosearchtopbox" data-label-suggestion="Sugestia" data-search-for="Szukaj dla" data-in-category="w kategorii" data-products-for="Produkty dla" data-label-products="Produkty" data-view-all="Zobacz wszystkie">
+		<input type="hidden" name="fc" value="module">
+		<input type="hidden" name="module" value="leoproductsearch">
+		<input type="hidden" name="controller" value="productsearch">
+		<input type="hidden" name="txt_not_found" value="Nie znaleziono">
+                <input type="hidden" name="leoproductsearch_static_token" value="b866420ae8aaf943d02267723ab32727">
+		    			<div class="block_content clearfix leoproductsearch-content">
+					
+				<div class="list-cate-wrapper">
+					<input id="leosearchtop-cate-id" name="cate" value="" type="hidden">
+					<a href="javascript:void(0)" id="dropdownListCateTop" class="select-title" rel="nofollow" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+						<span>Wszystkie kategorie</span>
+						<i class="material-icons pull-xs-right">keyboard_arrow_down</i>
+					</a>
+					<div class="list-cate dropdown-menu" aria-labelledby="dropdownListCateTop">
+						<a href="#" data-cate-id="" data-cate-name="Wszystkie kategorie" class="cate-item active">Wszystkie kategorie</a>				
+						<a href="#" data-cate-id="2" data-cate-name="Funky Shop" class="cate-item cate-level-1">Funky Shop</a>
+						
+  <a href="#" data-cate-id="3" data-cate-name="Piwo Bezalkoholowe" class="cate-item cate-level-2">--Piwo Bezalkoholowe</a>
+  <a href="#" data-cate-id="14" data-cate-name="0%" class="cate-item cate-level-3">---0%</a>
+  <a href="#" data-cate-id="15" data-cate-name="Ponad 0,0%" class="cate-item cate-level-3">---Ponad 0,0%</a>
+  <a href="#" data-cate-id="4" data-cate-name="Piwo Rzemieślnicze" class="cate-item cate-level-2">--Piwo Rzemieślnicze</a>
+  <a href="#" data-cate-id="5" data-cate-name="Mocno chmielone" class="cate-item cate-level-3">---Mocno chmielone</a>
+  <a href="#" data-cate-id="6" data-cate-name="Ciemne" class="cate-item cate-level-3">---Ciemne</a>
+  <a href="#" data-cate-id="7" data-cate-name="Kwaśne/dzikie" class="cate-item cate-level-3">---Kwaśne/dzikie</a>
+  <a href="#" data-cate-id="9" data-cate-name="Owocowe" class="cate-item cate-level-3">---Owocowe</a>
+  <a href="#" data-cate-id="10" data-cate-name="Klasyczne" class="cate-item cate-level-3">---Klasyczne</a>
+  <a href="#" data-cate-id="11" data-cate-name="Vintage" class="cate-item cate-level-3">---Vintage</a>
+  <a href="#" data-cate-id="12" data-cate-name="Barrel aged" class="cate-item cate-level-3">---Barrel aged</a>
+  <a href="#" data-cate-id="19" data-cate-name="Cydr" class="cate-item cate-level-3">---Cydr</a>
+  <a href="#" data-cate-id="16" data-cate-name="Zestawy" class="cate-item cate-level-2">--Zestawy</a>
+  <a href="#" data-cate-id="17" data-cate-name="Szkło/Merch" class="cate-item cate-level-2">--Szkło/Merch</a>
+  <a href="#" data-cate-id="21" data-cate-name="Promo" class="cate-item cate-level-2">--Promo</a>
+  <a href="#" data-cate-id="23" data-cate-name="Browar miesiąca" class="cate-item cate-level-2">--Browar miesiąca</a>
+  
+					</div>
+				</div>
+						<div class="leoproductsearch-result">
+				<div class="leoproductsearch-loading cssload-speeding-wheel"></div>
+				<input class="search_query form-control grey ac_input" type="text" id="leo_search_query_top" name="search_query" data-content="" value="" placeholder="Szukaj" autocomplete="off">
+				<div class="ac_results lps_results"></div>
+			</div>
+			<button type="submit" id="leo_search_top_button" class="btn btn-default button button-small"><span><i class="material-icons search">search</i></span></button> 
+		</div>
+	</form>
+</div>
+<script type="text/javascript">
+	var blocksearch_type = 'top';
+</script>
+<!-- /Block search module -->
+
+    </div><!-- @file modules\appagebuilder\views\templates\hook\ApColumn -->
+<div class="col-xl-6 col-lg-12 col-md-12 col-sm-12 col-xs-12 col-sp-12 col-logo ApColumn ">
+                    <!-- @file modules\appagebuilder\views\templates\hook\ApGenCode -->
+
+	<div class="h-logo">    <a href="https://funkyshop.pl/">        <img class="img-fluid" src="https://funkyshop.pl/img/logo-1743421189.jpg" alt="Craft Beer Online">    </a></div>
+
+    </div><!-- @file modules\appagebuilder\views\templates\hook\ApColumn -->
+<div class="col-xl-3 col-lg-12 col-md-12 col-sm-12 col-xs-12 col-sp-12 right-icons ApColumn ">
+                    <!-- @file modules\appagebuilder\views\templates\hook\ApModule -->
+<!-- Block languages module -->
+	<!-- /Block languages module -->
+
+
+
+
+
+
+
+
+
+
+
+<div id="leo_block_top" class="popup-over e-scale float-md-right">
+    <a href="javascript:void(0)" data-toggle="dropdown" class="popup-title">
+    	<i class="material-icons">language</i>
+    	<span>Język</span>
+    </a>	    
+	<div class="popup-content">
+		<div class="row">
+			<div class="col-xs-12">
+				<div class="language-selector">
+					<span>Język:</span>
+					<ul class="link">
+										          	<li class="current">
+				            	<a href="https://funkyshop.pl/pl/17-szklomerch" class="dropdown-item">
+				            		<img src="/img/l/1.jpg" alt="Polski" width="16" height="11">
+				            	</a>
+				          	</li>
+				        				          	<li>
+				            	<a href="https://funkyshop.pl/en/17-glassmerch" class="dropdown-item">
+				            		<img src="/img/l/3.jpg" alt="Angielski" width="16" height="11">
+				            	</a>
+				          	</li>
+				        					</ul>
+				</div>
+				<div class="currency-selector">
+					<span>Waluta:</span>
+					<ul class="link">
+										        	<li>
+				          		<a title="Euro" rel="nofollow" href="https://funkyshop.pl/pl/17-szklomerch?SubmitCurrency=1&amp;id_currency=2" class="dropdown-item">EUR</a>
+				        	</li>
+				      					        	<li class="current">
+				          		<a title="Złoty polski" rel="nofollow" href="https://funkyshop.pl/pl/17-szklomerch?SubmitCurrency=1&amp;id_currency=1" class="dropdown-item">PLN</a>
+				        	</li>
+				      						</ul>
+				</div>
+			</div>
+		</div>
+	</div>
+</div><!-- @file modules\appagebuilder\views\templates\hook\ApModule -->
+<div class="userinfo-selector dropdown js-dropdown popup-over">
+  <a href="javascript:void(0)" data-toggle="dropdown" class="popup-title" title="Konto">
+    <i class="material-icons">account_circle</i>
+    <span class="hidden-md-down">Moje konto</span>
+  </a>
+  <ul class="popup-content dropdown-menu user-info">
+          <li>
+        <a class="signin leo-quicklogin" data-enable-sociallogin="enable" data-type="popup" data-layout="login" href="javascript:void(0)" title="Zaloguj się na swoje konto klienta" rel="nofollow">
+          <i class="fa fa-lock"></i>
+          <span>Zaloguj się</span>
+        </a>
+      </li>
+            <li>
+        <a class="signup leo-quickregister" data-enable-sociallogin="enable" data-type="popup" data-layout="register" href="javascript:void(0)" title="Zaloguj się na swoje konto klienta" rel="nofollow">
+          <i class="fa fa-lock"></i>
+          <span>Zarejestruj się</span>
+        </a>
+      </li>
+    
+          </ul>
+</div><!-- @file modules\appagebuilder\views\templates\hook\ApGenCode -->
+
+	          <a class="ap-btn-wishlist" href="//funkyshop.pl/pl/module/leofeature/mywishlist" title="Lista życzeń">        <i class="fa fa-heart"></i>    <span class="ap-total-wishlist ap-total">0</span>      </a>    
+<!-- @file modules\appagebuilder\views\templates\hook\ApModule -->
+<div id="cart-block">
+  <div class="cart-preview inactive leo-blockcart show-leo-loading" data-refresh-url="//funkyshop.pl/pl/module/ps_shoppingcart/ajax">
+    <div class="header">
+              <i class="fa fa-shopping-cart"></i>
+        <span class="cart-products-count">0</span>
+        <span class="cart-total">0,00&nbsp;zł</span>
+              
+            <span class="current-weight" style="display: none;">0</span>
+
+      <custom class="cart-total-value" style="display: none;">0</custom>
+    </div>
+  <div class="cssload-piano" style="display: none;"><div class="cssload-rect1"></div><div class="cssload-rect2"></div><div class="cssload-rect3"></div></div></div>
+</div><!-- @file modules\appagebuilder\views\templates\hook\ApGenCode -->
+
+	<div class="custom-text-header" data-refresh-url="//dev.funkyshop.pl/pl/module/ps_shoppingcart/ajax">
+    <p class="free-shiping">
+        Do darmowej<br>paczki<br>w Polsce<br>brakuje:
+                                                        <custom class="convRate" style="display:none;">1</custom>
+            <span class="to-free-shiping">229.00</span>
+            <span class="header-sign">&nbsp;zł</span>
+            </p>
+                            <span class="max-package" style="display: none;">24</span>
+<span class="current-package-size" style="display: none;">Small</span>
+<span class="current-in-cart" style="display: none;">0</span>
+   <!-- <p class="one-package-weight">
+                    Paczka<br>pełna w
+                <span class="free-package">
+                                   0
+        </span><span class="header-sign">&nbsp;
+                        %</span>
+        </span>
+    </p> -->
+    <p class="current-package">
+                    Obecny<br>
+            rozmiar<br>
+            paczki
+        :
+        <span class="current-package-size">
+                                                Mała
+                                    </span>
+    </p>
+</div>
+
+
+    </div>            </div>
+</div>
+</div>
+        
+	<script>
+		ap_list_functions.push(function(){
+			$.stellar({horizontalScrolling:false}); 
+		});
+	</script>
+    
+    </div>
+          </div>
+  </nav>
+
+
+
+  <div class="header-top">
+          <div class="inner"><!-- @file modules\appagebuilder\views\templates\hook\ApRow -->
+<div class="wrapper">
+
+<div class="container">
+    <div class="row box-top ApRow  has-bg bg-boxed" style="background: no-repeat;" data-bg_data=" no-repeat">
+                                            <!-- @file modules\appagebuilder\views\templates\hook\ApColumn -->
+<div class="col-xl-12 col-lg-12 col-md-12 col-sm-12 col-xs-12 col-sp-12 col-menu ApColumn ">
+                    <!-- @file modules\appagebuilder\views\templates\hook\ApSlideShow -->
+<div id="memgamenu-form_9184166521380958" class="ApMegamenu">
+			                        <nav data-megamenu-id="9184166521380958" class="leo-megamenu cavas_menu navbar navbar-default enable-canvas " role="navigation">
+                            <!-- Brand and toggle get grouped for better mobile display -->
+                            <div class="navbar-header">
+                                    <button type="button" class="navbar-toggler hidden-lg-up" data-toggle="collapse" data-target=".megamenu-off-canvas-9184166521380958">
+                                            <span class="sr-only">Przełącz nawigację</span>
+                                            ☰
+                                            <!--
+                                            <span class="icon-bar"></span>
+                                            <span class="icon-bar"></span>
+                                            <span class="icon-bar"></span>
+                                            -->
+                                    </button>
+                            </div>
+                            <!-- Collect the nav links, forms, and other content for toggling -->
+                                                        <div class="leo-top-menu collapse navbar-toggleable-md megamenu-off-canvas megamenu-off-canvas-9184166521380958"><ul class="nav navbar-nav megamenu horizontal"><li data-menu-type="category" class="nav-item parent  dropdown   ">
+    <a class="nav-link dropdown-toggle has-category" data-toggle="dropdown" href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze" target="_self">
+
+                    
+                    <span class="menu-title">Piwo rzemieślnicze</span>
+                                        
+            </a>
+        <b class="caret"></b>
+            <div class="dropdown-sub dropdown-menu" style="width:600px">
+            <div class="dropdown-menu-inner">
+                                    <div class="row">
+                                                    <div class="mega-col col-md-4">
+                                <div class="mega-col-inner">
+                                    <div class="leo-widget" data-id_widget="1613641002">
+    <div class="widget-links">
+		<div class="widget-inner">	
+		<div id="tabs1734881162" class="panel-group">
+			<ul class="nav-links">
+				  
+					<li><a href="https://funkyshop.pl/pl/2-funky-shop">wszystkie produkty</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/brand/2-funky-fluid">Funky Fluid</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/nowe-produkty">Nowości</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/index.php?controller=pricesdrop">Promocje</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/16-zestawy">Zestawy</a></li>
+							</ul>
+		</div>
+	</div>
+    </div>
+</div>                                </div>
+                            </div>
+                                                    <div class="mega-col col-md-4">
+                                <div class="mega-col-inner">
+                                    <div class="leo-widget" data-id_widget="1613641017">
+    <div class="widget-links">
+		<div class="widget-inner">	
+		<div id="tabs1728250055" class="panel-group">
+			<ul class="nav-links">
+				  
+					<li><a href="https://funkyshop.pl/pl/5-mocno-chmielone">Mocno chmielone</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/6-ciemne">Ciemne</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/7-kwasnedzikie">Kwaśne/dzikie</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/9-owocowe">Owocowe</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/10-klasyczne">Klasyczne</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/11-vintage">Vintage/barrel aged</a></li>
+							</ul>
+		</div>
+	</div>
+    </div>
+</div>                                </div>
+                            </div>
+                                                    <div class="mega-col col-md-4">
+                                <div class="mega-col-inner">
+                                    <div class="leo-widget" data-id_widget="1613641028">
+    <div class="widget-links">
+		<div class="widget-inner">	
+		<div id="tabs882229316" class="panel-group">
+			<ul class="nav-links">
+				  
+					<li><a href="https://funkyshop.pl/pl/2-oferta?q=Kraj+pochodzenia-Polska">Polska</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/2-oferta?q=Kraj+pochodzenia-Anglia">Anglia</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/2-piwa-rzemieslnicze?q=Kraj+pochodzenia-Belgia">Belgia</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/2-oferta?q=Kraj+pochodzenia-Szwecja">Szwecja</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/2-oferta?q=Kraj+pochodzenia-USA">USA</a></li>
+							</ul>
+		</div>
+	</div>
+    </div>
+</div>                                </div>
+                            </div>
+                                            </div>
+                            </div>
+        </div>
+    </li><li data-menu-type="category" class="nav-item parent dropdown">
+    <a class="nav-link dropdown-toggle has-category" data-toggle="dropdown" href="https://funkyshop.pl/pl/3-piwo-bezalkoholowe" target="_self">
+                    
+                    <span class="menu-title">Piwo bezalkoholowe</span>
+                                	
+	    </a>
+    <b class="caret"></b>
+    <div class="dropdown-menu level1">
+    <div class="dropdown-menu-inner">
+        <div class="row">
+            <div class="col-sm-12 mega-col" data-colwidth="12" data-type="menu">
+                <div class="inner">
+                    <ul>
+                                                    <li data-menu-type="category" class="nav-item   ">
+            <a class="nav-link" href="https://funkyshop.pl/pl/14-zero-procent">
+            
+                            <span class="menu-title">0%</span>
+                                    
+                    </a>
+
+    </li>
+            
+                                                    <li data-menu-type="category" class="nav-item   ">
+            <a class="nav-link" href="https://funkyshop.pl/pl/15-ponad-00">
+            
+                            <span class="menu-title">Ponad 0,0%</span>
+                                    
+                    </a>
+
+    </li>
+            
+                                            </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+</li>    <li data-menu-type="category" class="nav-item  ">
+        <a class="nav-link has-category" href="https://funkyshop.pl/pl/18-cydry-miody-wina" target="_self">
+                            
+                            <span class="menu-title">Cydry/wina/miody pitne</span>
+                                                        </a>
+    </li>
+    <li data-menu-type="category" class="nav-item active">
+        <a class="nav-link has-category" href="https://funkyshop.pl/pl/17-szklomerch" target="_self">
+                            
+                            <span class="menu-title">Szkło / Merch</span>
+                                                        </a>
+    </li>
+    <li data-menu-type="category" class="nav-item pink ">
+        <a class="nav-link has-category" href="https://funkyshop.pl/pl/23-browar-miesiaca" target="_self">
+                            
+                            <span class="menu-title">Browar miesiąca</span>
+                                                        </a>
+    </li>
+    <li data-menu-type="controller" class="nav-item  ">
+        <a class="nav-link has-category" href="https://funkyshop.pl/pl/kontakt" target="_self">
+                            
+                            <span class="menu-title">Kontakt</span>
+                                                        </a>
+    </li>
+</ul></div>
+            </nav>
+            <script type="text/javascript">
+            // <![CDATA[				
+                            // var type="horizontal";
+                            // checkActiveLink();
+                            // checkTarget();
+                            list_menu_tmp.id = '9184166521380958';
+                            list_menu_tmp.type = 'horizontal';
+            // ]]>
+            
+                                						
+                                    // offCanvas();
+                                    // var show_cavas = 1;
+                                    // console.log('testaaa');
+                                    // console.log(show_cavas);
+                                    list_menu_tmp.show_cavas =1;
+
+                    
+                                        
+                    list_menu_tmp.list_tab = list_tab;
+                    list_menu.push(list_menu_tmp);
+                    list_menu_tmp = {};	
+                    list_tab = {};
+                    
+            </script>
+    
+	</div>
+
+    </div>            </div>
+</div>
+</div>
+        
+	<script>
+		ap_list_functions.push(function(){
+			$.stellar({horizontalScrolling:false}); 
+		});
+	</script>
+    
+    </div>
+          </div>
+  
+          
+        </div>
+      </header>
+      
+        
+<aside id="notifications">
+  <div class="container">
+    
+    
+    
+      </div>
+</aside>
+      
+      <section id="wrapper">
+       
+              <div class="container">
+                
+                      
+          <div class="row">
+            
+              <div id="left-column" class="sidebar col-xs-12 col-sm-12 col-md-4 col-lg-3">
+                                  
+
+<div class="block-categories block block-highlighted hidden-sm-down">
+  <p class="title_block"><a href="https://funkyshop.pl/pl/2-funky-shop">Funky Shop</a></p>
+  <div class="block_content">
+    <ul class="category-top-menu">
+      <li>
+  <ul class="category-sub-menu"><li data-depth="0"><a href="https://funkyshop.pl/pl/3-piwo-bezalkoholowe">Piwo Bezalkoholowe</a><div class="navbar-toggler collapse-icons" data-toggle="collapse" data-target="#exCollapsingNavbar3"><i class="fa fa-caret-right add"></i><i class="fa fa-caret-down remove"></i></div><div class="collapse" id="exCollapsingNavbar3">
+  <ul class="category-sub-menu"><li data-depth="1"><a class="category-sub-link" href="https://funkyshop.pl/pl/14-zero-procent">0%</a></li><li data-depth="1"><a class="category-sub-link" href="https://funkyshop.pl/pl/15-ponad-00">Ponad 0,0%</a></li></ul></div></li><li data-depth="0"><a href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze">Piwo Rzemieślnicze</a><div class="navbar-toggler collapse-icons" data-toggle="collapse" data-target="#exCollapsingNavbar4"><i class="fa fa-caret-right add"></i><i class="fa fa-caret-down remove"></i></div><div class="collapse" id="exCollapsingNavbar4">
+  <ul class="category-sub-menu"><li data-depth="1"><a class="category-sub-link" href="https://funkyshop.pl/pl/5-mocno-chmielone">Mocno chmielone</a></li><li data-depth="1"><a class="category-sub-link" href="https://funkyshop.pl/pl/6-ciemne">Ciemne</a></li><li data-depth="1"><a class="category-sub-link" href="https://funkyshop.pl/pl/7-kwasnedzikie">Kwaśne/dzikie</a></li><li data-depth="1"><a class="category-sub-link" href="https://funkyshop.pl/pl/9-owocowe">Owocowe</a></li><li data-depth="1"><a class="category-sub-link" href="https://funkyshop.pl/pl/10-klasyczne">Klasyczne</a></li><li data-depth="1"><a class="category-sub-link" href="https://funkyshop.pl/pl/11-vintage">Vintage</a></li><li data-depth="1"><a class="category-sub-link" href="https://funkyshop.pl/pl/12-barrel-aged">Barrel aged</a></li><li data-depth="1"><a class="category-sub-link" href="https://funkyshop.pl/pl/19-cydr">Cydr</a></li></ul></div></li><li data-depth="0"><a href="https://funkyshop.pl/pl/16-zestawy">Zestawy</a></li><li data-depth="0"><a href="https://funkyshop.pl/pl/17-szklomerch">Szkło/Merch</a></li><li data-depth="0"><a href="https://funkyshop.pl/pl/21-promo">Promo</a></li><li data-depth="0"><a href="https://funkyshop.pl/pl/23-browar-miesiaca">Browar miesiąca</a></li></ul></li>
+    </ul>
+  </div>
+</div>
+<div id="search_filters_wrapper" class="hidden-sm-down">
+  <div id="search_filter_controls" class="hidden-md-up">
+      <span id="_mobile_search_filters_clear_all"></span>
+      <button class="btn btn-secondary ok">
+        <i class="material-icons rtl-no-flip"></i>
+        OK
+      </button>
+  </div>
+    <div id="search_filters">
+    
+      <p class="text-uppercase h6 hidden-sm-down">Filtruj według</p>
+    
+
+    
+          
+
+          <section class="facet clearfix">
+        <p class="h6 facet-title hidden-sm-down">Dostępność</p>
+                                                                              
+        <div class="title hidden-md-up" data-target="#facet_6397" data-toggle="collapse">
+          <p class="h6 facet-title">Dostępność</p>
+          <span class="navbar-toggler collapse-icons">
+            <i class="material-icons add"></i>
+            <i class="material-icons remove"></i>
+          </span>
+        </div>
+
+                  
+            <ul id="facet_6397" class="collapse">
+                              
+                <li>
+                  <label class="facet-label" for="facet_input_6397_0">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_6397_0" data-search-url="https://funkyshop.pl/pl/17-szklomerch?q=Dost%C4%99pno%C5%9B%C4%87-Dost%C4%99pny" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/17-szklomerch?q=Dost%C4%99pno%C5%9B%C4%87-Dost%C4%99pny" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      Dostępny
+                                              <span class="magnitude">(8)</span>
+                                          </a>
+                  </label>
+                </li>
+                                                                
+                <li>
+                  <label class="facet-label" for="facet_input_6397_2">
+                                          <span class="custom-checkbox">
+                        <input id="facet_input_6397_2" data-search-url="https://funkyshop.pl/pl/17-szklomerch?q=Dost%C4%99pno%C5%9B%C4%87-W+magazynie" type="checkbox">
+                                                  <span class="ps-shown-by-js"><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                                              </span>
+                    
+                    <a href="https://funkyshop.pl/pl/17-szklomerch?q=Dost%C4%99pno%C5%9B%C4%87-W+magazynie" class="_gray-darker search-link js-search-link" rel="nofollow">
+                      W magazynie
+                                              <span class="magnitude">(8)</span>
+                                          </a>
+                  </label>
+                </li>
+                          </ul>
+          
+
+              </section>
+          <section class="facet clearfix">
+        <p class="h6 facet-title hidden-sm-down">Cena</p>
+                                          
+        <div class="title hidden-md-up" data-target="#facet_81638" data-toggle="collapse">
+          <p class="h6 facet-title">Cena</p>
+          <span class="navbar-toggler collapse-icons">
+            <i class="material-icons add"></i>
+            <i class="material-icons remove"></i>
+          </span>
+        </div>
+
+                  
+                          <ul id="facet_81638" class="faceted-slider collapse" data-slider-min="18" data-slider-max="199" data-slider-id="81638" data-slider-values="null" data-slider-unit="zł" data-slider-label="Cena" data-slider-specifications="{&quot;symbol&quot;:[&quot;,&quot;,&quot;\u00a0&quot;,&quot;;&quot;,&quot;%&quot;,&quot;-&quot;,&quot;+&quot;,&quot;E&quot;,&quot;\u00d7&quot;,&quot;\u2030&quot;,&quot;\u221e&quot;,&quot;NaN&quot;],&quot;currencyCode&quot;:&quot;PLN&quot;,&quot;currencySymbol&quot;:&quot;z\u0142&quot;,&quot;numberSymbols&quot;:[&quot;,&quot;,&quot;\u00a0&quot;,&quot;;&quot;,&quot;%&quot;,&quot;-&quot;,&quot;+&quot;,&quot;E&quot;,&quot;\u00d7&quot;,&quot;\u2030&quot;,&quot;\u221e&quot;,&quot;NaN&quot;],&quot;positivePattern&quot;:&quot;#,##0.00\u00a0\u00a4&quot;,&quot;negativePattern&quot;:&quot;-#,##0.00\u00a0\u00a4&quot;,&quot;maxFractionDigits&quot;:2,&quot;minFractionDigits&quot;:2,&quot;groupingUsed&quot;:true,&quot;primaryGroupSize&quot;:3,&quot;secondaryGroupSize&quot;:3}" data-slider-encoded-url="https://funkyshop.pl/pl/17-szklomerch">
+                <li>
+                  <p id="facet_label_81638">18,00&nbsp;zł - 199,00&nbsp;zł</p>
+
+                  <div id="slider-range_81638" class="ui-slider ui-slider-horizontal ui-widget ui-widget-content ui-corner-all" aria-disabled="false"><div class="ui-slider-range ui-widget-header ui-corner-all" style="left: 0%; width: 100%;"></div><a class="ui-slider-handle ui-state-default ui-corner-all" href="#" style="left: 0%;" aria-label="Ustaw zakres cen"></a><a class="ui-slider-handle ui-state-default ui-corner-all" href="#" style="left: 100%;" aria-label="Ustaw zakres cen"></a></div>
+                </li>
+              </ul>
+                      
+              </section>
+      </div>
+
+</div>
+
+                              </div>
+            
+
+            
+  <div id="content-wrapper" class="left-column col-xs-12 col-sm-12 col-md-8 col-lg-9">
+    
+    
+  <section id="main">
+
+    
+  <div class="block-category">    
+              <div id="category-description" class="text-muted"><h1>Szkło/Merch</h1></div>
+      </div>
+  
+
+    <section id="products">
+      
+        <div>
+          
+            
+<div id="js-product-list-top" class="products-selection">
+  <div class="row">
+    <div class="col-lg-6 col-md-3 hidden-sm-down total-products">     
+      
+        <div class="display">
+          <div id="grid" class="leo_grid selected"><a rel="nofollow" href="#" title="Siatka"><i class="fa fa-th"></i></a></div>
+          <div id="list" class="leo_list "><a rel="nofollow" href="#" title="Lista"><i class="fa fa-list-ul"></i></a></div>
+        </div>
+      
+            	<p>Liczba produktów w Twoim koszyku: 3</p>
+          </div>
+    <div class="col-lg-6 col-md-9">
+      <div class="row sort-by-row">
+        
+          <span class="col-sm-3 col-md-3 hidden-sm-down sort-by">Sortuj według:</span>
+<div class="col-sm-9 col-xs-8 col-sp-12  col-md-9 products-sort-order dropdown">
+  <button class="btn-unstyle select-title" rel="nofollow" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <i class="material-icons float-xs-right"></i>
+  </button>
+  <div class="dropdown-menu">
+          <a rel="nofollow" href="https://funkyshop.pl/pl/17-szklomerch?order=product.sales.desc" class="select-list js-search-link">
+        Sprzedaż, od najwyższej do najniższej
+      </a>
+          <a rel="nofollow" href="https://funkyshop.pl/pl/17-szklomerch?order=product.position.asc" class="select-list js-search-link">
+        Trafność
+      </a>
+          <a rel="nofollow" href="https://funkyshop.pl/pl/17-szklomerch?order=product.name.asc" class="select-list js-search-link">
+        Nazwa, A do Z
+      </a>
+          <a rel="nofollow" href="https://funkyshop.pl/pl/17-szklomerch?order=product.name.desc" class="select-list js-search-link">
+        Nazwa, Z do A
+      </a>
+          <a rel="nofollow" href="https://funkyshop.pl/pl/17-szklomerch?order=product.price.asc" class="select-list js-search-link">
+        Cena, rosnąco
+      </a>
+          <a rel="nofollow" href="https://funkyshop.pl/pl/17-szklomerch?order=product.price.desc" class="select-list js-search-link">
+        Cena, malejąco
+      </a>
+          <a rel="nofollow" href="https://funkyshop.pl/pl/17-szklomerch?order=product.date_add.asc" class="select-list js-search-link">
+        Najstarsze produkty
+      </a>
+          <a rel="nofollow" href="https://funkyshop.pl/pl/17-szklomerch?order=product.date_add.desc" class="select-list js-search-link">
+        Najnowsze produkty
+      </a>
+      </div>
+</div>
+        
+
+                  <div class="col-sm-4 col-xs-4 col-sp-12 hidden-md-up filter-button">
+            <button id="search_filter_toggler" class="btn btn-outline">
+              Filtr
+            </button>
+          </div>
+              </div>
+    </div>
+    <div class="col-sm-12 hidden-md-up text-sm-center showing">
+      Pokazano 1-3 z 3 pozycji
+    </div>
+  </div>
+</div>
+          
+        </div>
+
+        
+          <div id="" class="hidden-sm-down">
+            <section id="js-active-search-filters" class="hide">
+  
+    <p class="h6 hidden-xs-up">Aktywne filtry</p>
+  
+
+  </section>
+
+          </div>
+        
+
+        <div>
+          
+            <div id="js-product-list">
+  <div class="products">  
+        
+
+    
+                    
+
+
+<!-- Products list -->
+
+
+<div class="product_list grid  plist-default3 ">
+    <div class="row">
+                    
+            
+            
+                                       
+            <div class="ajax_block_product col-sp-12 col-xs-6 col-sm-6 col-md-6 col-lg-4 col-xl-4
+                 first-in-line                 last-line                 first-item-of-tablet-line                 first-item-of-mobile-line                                ">
+                
+                                                                                                <article class="product-miniature js-product-miniature" data-id-product="5450" data-id-product-attribute="0" itemscope="" itemtype="http://schema.org/Product">
+  <div class="thumbnail-container">
+    <div class="product-image">
+
+
+        			    	<a href="https://funkyshop.pl/pl/szklomerch/5450-funky-fluid-szklanka-craftmaster-one-7th-anniversary-473ml-2.html" class="thumbnail product-thumbnail">
+				  <img class="img-fluid" src="https://funkyshop.pl/9927-home_default/funky-fluid-szklanka-craftmaster-one-7th-anniversary-473ml.jpg" alt="Funky Fluid Szklanka Craftmaster One 7th Anniversary 473ml" data-full-size-image-url="https://funkyshop.pl/9927-large_default/funky-fluid-szklanka-craftmaster-one-7th-anniversary-473ml.jpg">
+				  					<span class="product-additional" data-idproduct="5450"></span>
+				  				</a>
+
+		      
+
+
+<div class="functional-buttons clearfix">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="quickview no-variants hidden-sm-down">
+<a href="#" class="quick-view" data-link-action="quickview" title="Quick view">
+	<span class="leo-quickview-bt-loading cssload-speeding-wheel"></span>
+	<span class="leo-quickview-bt-content">
+		<i class="material-icons search"></i>
+		<span>Quick view</span>
+	</span>
+</a>
+</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="wishlist">
+			<a class="leo-wishlist-button btn-product btn-primary btn" href="javascript:void(0)" data-id-wishlist="" data-id-product="5450" data-id-product-attribute="0" title="Dodaj do listy życzeń">
+			<span class="leo-wishlist-bt-loading cssload-speeding-wheel"></span>
+			<span class="leo-wishlist-bt-content">
+				<i class="icon-btn-product icon-wishlist material-icons"></i>
+				<span class="name-btn-product">Dodaj do listy życzeń</span>
+			</span>
+		</a>
+	</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+</div></div>
+    <div class="product-meta">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+  <p class="h3 product-title" itemprop="name"><a href="https://funkyshop.pl/pl/szklomerch/5450-funky-fluid-szklanka-craftmaster-one-7th-anniversary-473ml-2.html">Funky Fluid Szklanka Craftmaster One 7th Anniversary 473ml</a></p>
+
+<a class="manufacturer-product" href="https://funkyshop.pl/pl/brand/2-funky-fluid">
+    Funky Fluid
+</a>
+
+  <div class="product-description-short" itemprop="description"> Rastal 473ml </div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+      <div class="product-price-and-shipping ">
+      
+      
+      
+      <span class="sr-only">Cena</span>
+      <span class="price" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+        <span itemprop="priceCurrency" content="PLN"></span><span itemprop="price" content="20">20,00&nbsp;zł</span>
+      </span>
+
+      
+
+      
+    </div>
+  
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+</div>
+  </div>
+</article>
+
+                                                            
+            </div>
+                    
+            
+            
+                                       
+            <div class="ajax_block_product col-sp-12 col-xs-6 col-sm-6 col-md-6 col-lg-4 col-xl-4
+                                 last-line                 last-item-of-tablet-line
+                                 last-item-of-mobile-line
+                                                ">
+                
+                                                                                                <article class="product-miniature js-product-miniature" data-id-product="4550" data-id-product-attribute="0" itemscope="" itemtype="http://schema.org/Product">
+  <div class="thumbnail-container">
+    <div class="product-image">
+
+
+        			    	<a href="https://funkyshop.pl/pl/szklomerch/4550-funky-fluid-szklanka-mosella-2025-200ml-2.html" class="thumbnail product-thumbnail">
+				  <img class="img-fluid" src="https://funkyshop.pl/9930-home_default/funky-fluid-szklanka-mosella-2025-200ml.jpg" alt="Funky Fluid Szklanka Mosella 2025 200ml" data-full-size-image-url="https://funkyshop.pl/9930-large_default/funky-fluid-szklanka-mosella-2025-200ml.jpg">
+				  					<span class="product-additional" data-idproduct="4550"></span>
+				  				</a>
+
+		      
+
+
+<div class="functional-buttons clearfix">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="quickview no-variants hidden-sm-down">
+<a href="#" class="quick-view" data-link-action="quickview" title="Quick view">
+	<span class="leo-quickview-bt-loading cssload-speeding-wheel"></span>
+	<span class="leo-quickview-bt-content">
+		<i class="material-icons search"></i>
+		<span>Quick view</span>
+	</span>
+</a>
+</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="wishlist">
+			<a class="leo-wishlist-button btn-product btn-primary btn" href="javascript:void(0)" data-id-wishlist="" data-id-product="4550" data-id-product-attribute="0" title="Dodaj do listy życzeń">
+			<span class="leo-wishlist-bt-loading cssload-speeding-wheel"></span>
+			<span class="leo-wishlist-bt-content">
+				<i class="icon-btn-product icon-wishlist material-icons"></i>
+				<span class="name-btn-product">Dodaj do listy życzeń</span>
+			</span>
+		</a>
+	</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+</div></div>
+    <div class="product-meta">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+  <p class="h3 product-title" itemprop="name"><a href="https://funkyshop.pl/pl/szklomerch/4550-funky-fluid-szklanka-mosella-2025-200ml-2.html">Funky Fluid Szklanka Mosella 2025 200ml</a></p>
+
+<a class="manufacturer-product" href="https://funkyshop.pl/pl/brand/2-funky-fluid">
+    Funky Fluid
+</a>
+
+  <div class="product-description-short" itemprop="description"> Rastal 200ml </div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+      <div class="product-price-and-shipping ">
+      
+      
+      
+      <span class="sr-only">Cena</span>
+      <span class="price" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+        <span itemprop="priceCurrency" content="PLN"></span><span itemprop="price" content="25">25,00&nbsp;zł</span>
+      </span>
+
+      
+
+      
+    </div>
+  
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="button-container cart">
+	<form action="https://funkyshop.pl/pl/koszyk" method="post">
+		<input type="hidden" name="token" value="b866420ae8aaf943d02267723ab32727">
+		<input type="hidden" value="38" class="quantity_product quantity_product_4550" name="quantity_product">
+		<input type="hidden" value="1" class="minimal_quantity minimal_quantity_4550" name="minimal_quantity">
+		<input type="hidden" value="0" class="id_product_attribute id_product_attribute_4550" name="id_product_attribute">
+		<input type="hidden" value="4550" class="id_product" name="id_product">
+		<input type="hidden" name="id_customization" value="" class="product_customization_id">
+			
+		<input type="hidden" class="input-group form-control qty qty_product qty_product_4550" name="qty" value="1" data-min="1">
+		  <button class="btn btn-product add-to-cart leo-bt-cart leo-bt-cart_4550 leo-enable" data-button-action="add-to-cart" type="submit">
+			<span class="leo-loading cssload-speeding-wheel"></span>
+			<span class="leo-bt-cart-content">
+				<i class="icon-btn-product icon-cart material-icons shopping-cart"></i>
+				<span class="name-btn-product">Dodaj do koszyka</span>
+			</span>
+		  </button>
+	</form>
+</div>
+
+</div>
+  </div>
+</article>
+
+                                                            
+            </div>
+                    
+            
+            
+                                       
+            <div class="ajax_block_product col-sp-12 col-xs-6 col-sm-6 col-md-6 col-lg-4 col-xl-4
+                 last-in-line
+                                 last-line                 first-item-of-tablet-line                 first-item-of-mobile-line                 last-mobile-line                ">
+                
+                                                                                                <article class="product-miniature js-product-miniature" data-id-product="5143" data-id-product-attribute="0" itemscope="" itemtype="http://schema.org/Product">
+  <div class="thumbnail-container">
+    <div class="product-image">
+
+
+        			    	<a href="https://funkyshop.pl/pl/szklomerch/5143-funky-fluid-szklanka-gelato-2025-sahm-sensorik-300ml.html" class="thumbnail product-thumbnail">
+				  <img class="img-fluid" src="https://funkyshop.pl/9929-home_default/funky-fluid-szklanka-gelato-2025-sahm-sensorik-300ml.jpg" alt="Funky Fluid Szklanka Gelato 2025 Sahm Sensorik 300ml" data-full-size-image-url="https://funkyshop.pl/9929-large_default/funky-fluid-szklanka-gelato-2025-sahm-sensorik-300ml.jpg">
+				  					<span class="product-additional" data-idproduct="5143"></span>
+				  				</a>
+
+		      
+
+
+<div class="functional-buttons clearfix">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="quickview no-variants hidden-sm-down">
+<a href="#" class="quick-view" data-link-action="quickview" title="Quick view">
+	<span class="leo-quickview-bt-loading cssload-speeding-wheel"></span>
+	<span class="leo-quickview-bt-content">
+		<i class="material-icons search"></i>
+		<span>Quick view</span>
+	</span>
+</a>
+</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+<div class="wishlist">
+			<a class="leo-wishlist-button btn-product btn-primary btn" href="javascript:void(0)" data-id-wishlist="" data-id-product="5143" data-id-product-attribute="0" title="Dodaj do listy życzeń">
+			<span class="leo-wishlist-bt-loading cssload-speeding-wheel"></span>
+			<span class="leo-wishlist-bt-content">
+				<i class="icon-btn-product icon-wishlist material-icons"></i>
+				<span class="name-btn-product">Dodaj do listy życzeń</span>
+			</span>
+		</a>
+	</div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+</div></div>
+    <div class="product-meta">
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+  <p class="h3 product-title" itemprop="name"><a href="https://funkyshop.pl/pl/szklomerch/5143-funky-fluid-szklanka-gelato-2025-sahm-sensorik-300ml.html">Funky Fluid Szklanka Gelato 2025 Sahm Sensorik 300ml</a></p>
+
+<a class="manufacturer-product" href="https://funkyshop.pl/pl/brand/2-funky-fluid">
+    Funky Fluid
+</a>
+
+  <div class="product-description-short" itemprop="description"> Sahm 300ml </div>
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+      <div class="product-price-and-shipping ">
+      
+      
+      
+      <span class="sr-only">Cena</span>
+      <span class="price" itemprop="offers" itemscope="" itemtype="http://schema.org/Offer">
+        <span itemprop="priceCurrency" content="PLN"></span><span itemprop="price" content="25">25,00&nbsp;zł</span>
+      </span>
+
+      
+
+      
+    </div>
+  
+
+<!-- @file modules\appagebuilder\views\templates\front\products\file_tpl -->
+
+</div>
+  </div>
+</article>
+
+                                                            
+            </div>
+            </div>
+</div>
+<script>
+if (window.jQuery) {
+    $(document).ready(function(){
+        if (prestashop.page.page_name == 'category'){
+            setDefaultListGrid();
+        }
+    });
+}
+</script>   
+  </div>
+
+  
+    <nav class="pagination">
+  <div class="col-xs-12 col-md-6 col-lg-4 text-md-left text-xs-center">
+    
+      Pokazano 1-3 z 3 pozycji
+    
+  </div>
+
+  <div class="col-xs-12 col-md-6 col-lg-8">
+    
+         
+  </div>
+
+</nav>
+  
+
+  <div class="hidden-md-up text-xs-right up">
+    <a href="#header" class="btn btn-secondary">
+      Powrót do góry
+      <i class="material-icons"></i>
+    </a>
+  </div>
+</div>
+          
+        </div>
+
+        <div id="js-product-list-bottom">
+          
+            <div id="js-product-list-bottom"></div>
+          
+        </div>
+
+          </section>
+
+  </section>
+
+    
+  </div>
+
+
+            
+          </div>
+                  </div>
+        	
+      </section>
+
+      <footer id="footer" class="footer-container">
+        
+          
+  <div class="footer-top">
+          <div class="inner"></div>
+      </div>
+
+
+  <div class="footer-center">
+          <div class="inner"><!-- @file modules\appagebuilder\views\templates\hook\ApRow -->
+<div class="wrapper">
+
+<div class="container">
+    <div class="row box-newletter ApRow  " style="">
+                                            <!-- @file modules\appagebuilder\views\templates\hook\ApColumn -->
+<div class="col-xl-6 col-lg-12 col-md-12 col-sm-12 col-xs-12 col-sp-12 newsletter-main ApColumn ">
+                    <!-- @file modules\appagebuilder\views\templates\hook\ApModule -->
+<div class="block_newsletter block">
+  <p class="title_block" id="block-newsletter-label">Newsletter</p>
+  <div class="block_content">
+    <form action="https://funkyshop.pl/pl/#footer" method="post">
+      <div class="row">
+        <div class="col-xs-12 col-conditions">
+                    </div>
+        <div class="col-xs-12 col-form">
+          <div class="input-wrapper">
+            <input name="email" type="text" value="" placeholder="Twój email..." aria-labelledby="block-newsletter-label">
+            <button class="btn btn-outline float-xs-right" name="submitNewsletter" type="submit" value="Subskrybuj" disabled="disabled" aria-label="Subscribe to newsletter">
+              <i class="fa fa-long-arrow-right"></i>
+            </button>
+          </div>
+          <input type="hidden" name="action" value="0">
+		  <input type="hidden" name="r-action" value="newsletter"><input type="hidden" name="r-token" value="">
+
+          <div class="clearfix"></div>
+        </div>
+        <div class="col-xs-12 col-mesg">
+                                        
+    <div class="gdpr_consent gdpr_module_17">
+        <span class="custom-checkbox">
+            <label class="psgdpr_consent_message">
+                <input id="psgdpr_consent_checkbox_17" name="psgdpr_consent_checkbox" type="checkbox" value="1" class="psgdpr_consent_checkboxes_17">
+                <span><i class="material-icons rtl-no-flip checkbox-checked psgdpr_consent_icon"></i></span>
+                <span>Wyrażam zgodę na otrzymywanie od LEJMITO Sp. z o.o.&nbsp; informacji handlowych, w tym cyklicznego newslettera za pomocą środków komunikacji elektronicznej, na podany w niniejszym formularzu adres poczty elektronicznej.</span>            </label>
+        </span>
+    </div>
+
+
+<script type="text/javascript">
+    var psgdpr_front_controller = "https://funkyshop.pl/pl/module/psgdpr/FrontAjaxGdpr";
+    psgdpr_front_controller = psgdpr_front_controller.replace(/\amp;/g,'');
+    var psgdpr_id_customer = "0";
+    var psgdpr_customer_token = "da39a3ee5e6b4b0d3255bfef95601890afd80709";
+    var psgdpr_id_guest = "11909349";
+    var psgdpr_guest_token = "65eaa49f0961e8e432f62d3480b68ee4e854b271";
+
+    document.addEventListener('DOMContentLoaded', function() {
+        let psgdpr_id_module = "17";
+        let parentForm = $('.gdpr_module_' + psgdpr_id_module).closest('form');
+
+        let toggleFormActive = function() {
+            let parentForm = $('.gdpr_module_' + psgdpr_id_module).closest('form');
+            let checkbox = $('#psgdpr_consent_checkbox_' + psgdpr_id_module);
+            let element = $('.gdpr_module_' + psgdpr_id_module);
+            let iLoopLimit = 0;
+
+            // by default forms submit will be disabled, only will enable if agreement checkbox is checked
+            if (element.prop('checked') != true) {
+                element.closest('form').find('[type="submit"]').attr('disabled', 'disabled');
+            }
+            $(document).on("change" ,'.psgdpr_consent_checkboxes_' + psgdpr_id_module, function() {
+                if ($(this).prop('checked') == true) {
+                    $(this).closest('form').find('[type="submit"]').removeAttr('disabled');
+                } else {
+                    $(this).closest('form').find('[type="submit"]').attr('disabled', 'disabled');
+                }
+
+            });
+        }
+
+        // Triggered on page loading
+        toggleFormActive();
+
+        $(document).on('submit', parentForm, function(event) {
+            $.ajax({
+                type: 'POST',
+                url: psgdpr_front_controller,
+                data: {
+                    ajax: true,
+                    action: 'AddLog',
+                    id_customer: psgdpr_id_customer,
+                    customer_token: psgdpr_customer_token,
+                    id_guest: psgdpr_id_guest,
+                    guest_token: psgdpr_guest_token,
+                    id_module: psgdpr_id_module,
+                },
+                error: function (err) {
+                    console.log(err);
+                }
+            });
+        });
+    });
+</script>
+
+
+                      </div>
+      </div>
+    </form>
+  </div>
+</div>
+
+    </div><!-- @file modules\appagebuilder\views\templates\hook\ApColumn -->
+<div class="col-xl-6 col-lg-12 col-md-12 col-sm-12 col-xs-12 col-sp-12  ApColumn ">
+                    <!-- @file modules\appagebuilder\views\templates\hook\ApModule -->
+
+
+  <div class="block-social">
+  	<p class="social-title">
+  		Bądź na bieżąco!<br>Alkohol szkodzi zdrowiu.<br>Pij odpowiedzialnie.
+    </p>
+    <ul>
+              <li class="facebook"><a href="https://www.facebook.com/funkyfluid" title="Facebook" target="_blank" rel="nofollow"><span>Facebook</span></a></li>
+              <li class="instagram"><a href="https://www.instagram.com/browarfunkyfluid/" title="Instagram" target="_blank" rel="nofollow"><span>Instagram</span></a></li>
+          </ul>
+  </div>
+
+
+    </div>            </div>
+</div>
+</div>
+    <!-- @file modules\appagebuilder\views\templates\hook\ApRow -->
+<div class="wrapper" style="background: #661542 no-repeat">
+
+<div class="container">
+    <div class="row box-footerlink ApRow  has-bg bg-fullwidth-container" style="">
+                                            <!-- @file modules\appagebuilder\views\templates\hook\ApColumn -->
+<div class="col-xl-3 col-lg-3 col-md-6 col-sm-6 col-xs-12 col-sp-12  ApColumn ">
+                    <!-- @file modules\appagebuilder\views\templates\hook\ApBlockLink -->
+            <div class="block ApLink ApBlockLink">
+                            <h4 class="title_block">
+                    Funky Shop
+                </h4>
+                        
+                            <ul>
+                                                            <li><a href="https://funkyshop.pl/pl/content/5-formy-platnosci" target="_self">Sposoby płatności</a></li>
+                                                                                <li><a href="https://funkyshop.pl/pl/content/3-regulamin" target="_self">Regulamin</a></li>
+                                                                                <li><a href="https://funkyshop.pl/pl/content/2-polityka-prywatnosci" target="_self">Polityka prywatności</a></li>
+                                                                                <li><a href="https://funkyshop.pl/pl/content/6-warunki-odstapienia" target="_self">Odstąpienie od umowy</a></li>
+                                                                                <li><a href="https://funkyshop.pl/pl/content/10-polityka-cookies" target="_self">Polityka cookies</a></li>
+                                                                                <li><a href="https://funkyshop.pl/pl/mapa-strony" target="_self">Mapa strony</a></li>
+                                                    </ul>
+                    </div>
+    
+    </div><!-- @file modules\appagebuilder\views\templates\hook\ApColumn -->
+<div class="col-xl-3 col-lg-3 col-md-6 col-sm-6 col-xs-12 col-sp-12  ApColumn ">
+                    <!-- @file modules\appagebuilder\views\templates\hook\ApGeneral -->
+<div class="block contact-footer ApHtml">
+	            <h4 class="title_block">Kontakt</h4>
+                    <div class="block_content"><table><tbody><tr><td><p><i class="material-icons" style="color: #ffffff;">email</i></p></td><td><p class="contact-par"><a href="mailto:shop@funkyfluid.pl">shop@funkyfluid.pl</a></p></td></tr><tr><td><p><i class="material-icons" style="color: #ffffff;">home</i></p></td><td><p class="contact-par"><a href="/pl/kontakt">Formularz kontaktowy</a></p></td></tr></tbody></table></div>
+    	</div>
+    </div><!-- @file modules\appagebuilder\views\templates\hook\ApColumn -->
+<div class="col-xl-3 col-lg-3 col-md-6 col-sm-6 col-xs-12 col-sp-12 check-also-column ApColumn ">
+                    <!-- @file modules\appagebuilder\views\templates\hook\ApGeneral -->
+<div class="block check-footer ApHtml">
+	            <h4 class="title_block">Sprawdź również</h4>
+                    <div class="block_content"><table><tbody><tr><td><span class="social-icons" id="icon-4"><i class="fab fa-facebook-square" style="color: #fff;"></i></span></td><td><p class="contact-par"><a href="https://www.facebook.com/Funky-Shop-Craft-Beer-Online-102308188463114" rel="nofollow" target="_blank">Nasza strona</a></p></td></tr><tr><td><span class="social-icons" id="icon-1"><i class="fab fa-instagram" style="color: #fff;"></i></span></td><td><p class="contact-par"><a href="https://www.instagram.com/browarfunkyfluid/" rel="nofollow" target="_blank">Funky Fluid</a></p></td></tr><tr><td><span class="social-icons" id="icon-2"><i class="fab fa-facebook-square" style="color: #fff;"></i></span></td><td><p class="contact-par"><a href="https://www.facebook.com/funkyfluid" rel="nofollow" target="_blank">Funky Fluid</a></p></td></tr><tr><td><span class="social-icons" id="icon-3"><i class="fab fa-facebook-square" style="color: #fff;"></i></span></td><td><p class="contact-par"><a href="https://www.facebook.com/Funky-Fest-Craft-Beer-Party-103781251433213/" rel="nofollow" target="_blank">Funky Fest</a></p></td></tr></tbody></table></div>
+    	</div>
+    </div><!-- @file modules\appagebuilder\views\templates\hook\ApColumn -->
+<div class="col-xl-3 col-lg-3 col-md-6 col-sm-6 col-xs-12 col-sp-12 ap-popup2 ApColumn ">
+                    <!-- @file modules\appagebuilder\views\templates\hook\ApFacebook -->
+
+<script type="text/javascript">
+    var fb_lang = 'en_US';
+</script>
+
+    <script type="text/javascript">
+        fb_lang = "pl_PL";
+    </script>
+
+<div class="widget-facebook block">
+		<div id="fb-root" class=" fb_reset"><div style="position: absolute; top: -10000px; width: 0px; height: 0px;"><div></div></div></div>
+        <h4 class="title_block">Ostatnie posty</h4>
+            <script type="text/javascript">
+ap_list_functions.push(function(){
+    console.log(fb_lang);
+    // Check avoid include duplicate library Facebook SDK
+    if($("#facebook-jssdk").length == 0) {
+        (function(d, s, id) {
+          var js, fjs = d.getElementsByTagName(s)[0];
+          if (d.getElementById(id)) return;
+          js = d.createElement(s); js.id = id;
+          js.src = "https://connect.facebook.net/" + fb_lang + "/sdk.js#xfbml=1&version=v5.0";
+          fjs.parentNode.insertBefore(js, fjs);
+        }(document, 'script', 'facebook-jssdk'));
+    }
+});
+</script>
+
+    <div class="fb-page fb_iframe_widget" data-href="https://www.facebook.com/Funky-Shop-Craft-Beer-Online-102308188463114" data-tabs="timeline" data-adapt-container-width="true" data-show-facepile="true" fb-xfbml-state="rendered" fb-iframe-plugin-query="adapt_container_width=true&amp;app_id=&amp;container_width=270&amp;href=https%3A%2F%2Fwww.facebook.com%2FFunky-Shop-Craft-Beer-Online-102308188463114&amp;locale=pl_PL&amp;sdk=joey&amp;show_facepile=true&amp;tabs=timeline"><span style="vertical-align: top; width: 0px; height: 0px; overflow: hidden;"><iframe name="fa7295449e1d68050" width="1000px" height="1000px" data-testid="fb:page Facebook Social Plugin" title="fb:page Facebook Social Plugin" frameborder="0" allowtransparency="true" allowfullscreen="true" scrolling="no" allow="encrypted-media" src="https://www.facebook.com/v5.0/plugins/page.php?adapt_container_width=true&amp;app_id=&amp;channel=https%3A%2F%2Fstaticxx.facebook.com%2Fx%2Fconnect%2Fxd_arbiter%2F%3Fversion%3D46%23cb%3Dfaa51e2d84c252ff5%26domain%3Dfunkyshop.pl%26is_canvas%3Dfalse%26origin%3Dhttps%253A%252F%252Ffunkyshop.pl%252Ffb937db0b359de465%26relation%3Dparent.parent&amp;container_width=270&amp;href=https%3A%2F%2Fwww.facebook.com%2FFunky-Shop-Craft-Beer-Online-102308188463114&amp;locale=pl_PL&amp;sdk=joey&amp;show_facepile=true&amp;tabs=timeline" style="border-width: medium; border-style: none; border-color: currentcolor; border-image: initial; visibility: visible; width: 0px; height: 0px;"></iframe></span></div>
+    	</div>
+    </div>            </div>
+</div>
+</div>
+        
+	<script>
+		ap_list_functions.push(function(){
+			$.stellar({horizontalScrolling:false}); 
+		});
+	</script>
+    
+    </div>
+      </div>
+
+
+  <div class="footer-bottom">
+          <div class="inner"><!-- @file modules\appagebuilder\views\templates\hook\ApRow -->
+<div class="wrapper" style="background: #661542 repeat-x top">
+
+<div class="container">
+    <div class="row box-coppyh8 ApRow  has-bg bg-fullwidth-container" style="">
+                                            <!-- @file modules\appagebuilder\views\templates\hook\ApColumn -->
+<div class="col-xl-12 col-lg-12 col-md-12 col-sm-12 col-xs-12 col-sp-12  ApColumn ">
+                    <!-- @file modules\appagebuilder\views\templates\hook\ApGenCode -->
+
+	<div>Copyright © 2026 Projekt i realizacja <a class="copyright" href="https://wenet.pl/oferta/sklepy-internetowe" target="_blank" rel="nofollow noopener noreferrer" data-mce-href="https://wenet.pl/oferta/sklepy-internetowe">WeNet Group S.A.</a></div>
+
+    </div>            </div>
+</div>
+</div>
+        
+	<script>
+		ap_list_functions.push(function(){
+			$.stellar({horizontalScrolling:false}); 
+		});
+	</script>
+    
+    </div>
+      </div>
+        
+      </footer>
+                      <div id="back-top" style="display: none;"><a href="#" class="fa fa-angle-double-up" aria-label="Przejdź na górę strony"></a></div>
+      
+    <div class="megamenu-overlay" data-megamenu-id="9184166521380958"></div></main>
+
+    
+        <script type="text/javascript" src="https://funkyshop.pl/themes/core.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/pmgoogleanalytycs4pro/views/js/scripts_17.js"></script>
+  <script type="text/javascript" src="https://www.google.com/recaptcha/api.js?render=6LfV7hsrAAAAAFM2myNNgqZuypFI573dG2Jvvvju"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/themes/leo_clark/assets/js/theme.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/ps_emailsubscription/views/js/ps_emailsubscription.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/blockreassurance/views/dist/front.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/psagechecker/views/js/front.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/dpdshipping/views/js/dpdshipping-common.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/dpdshipping/views/js/dpdshipping-pudo-default.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/x13pricehistory/views/js/front.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/x13pricehistory/views/js/front-list.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/x13gpsr/views/js/front.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/appagebuilder/views/js/countdown.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/leoslideshow/views/js/iView/raphael-min.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/leoslideshow/views/js/iView/iview.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/leoslideshow/views/js/leoslideshow.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/leofeature/views/js/leofeature_cart.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/leofeature/views/js/jquery.mousewheel.min.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/leofeature/views/js/jquery.mCustomScrollbar.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/leofeature/views/js/jquery.rating.pack.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/leofeature/views/js/leofeature_review.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/leofeature/views/js/leofeature_wishlist.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/leoquicklogin/views/js/leoquicklogin.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/pmcookie//views/js/jquery-confirm.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/pmcookie//views/js/front-1.0.5.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/js/jquery/ui/jquery-ui.min.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/js/jquery/plugins/fancybox/jquery.fancybox.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/js/jquery/plugins/jquery.cooki-plugin.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/ps_facetedsearch/views/dist/front.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/ps_searchbar/ps_searchbar.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/ps_shoppingcart/ps_shoppingcart.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/leobootstrapmenu/views/js/leobootstrapmenu.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/blockgrouptop/views/js/blockgrouptop.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/leoproductsearch/views/js/jquery.autocomplete_productsearch.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/leoproductsearch/views/js/leosearch.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/bantrecyclingdeposit/views/js/front.js" defer=""></script>
+  <script type="text/javascript" src="https://funkyshop.pl/themes/leo_clark/assets/js/custom.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/appagebuilder/views/js/waypoints.min.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/appagebuilder/views/js/instafeed.min.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/appagebuilder/views/js/jquery.stellar.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/appagebuilder/views/js/owl.carousel.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/appagebuilder/views/js/imagesloaded.pkgd.min.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/appagebuilder/views/js/slick.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/appagebuilder/views/js/jquery.elevateZoom-3.0.8.min.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/appagebuilder/views/js/script.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/themes/leo_clark/modules/appagebuilder/views/js/profiles/profile1513951283.js"></script>
+  <script type="text/javascript" src="https://funkyshop.pl/modules/recaptcha3/views/js/recaptcha_v3.js"></script>
+
+
+<script type="text/javascript">
+	var choosefile_text = "Wybierz plik";
+	var turnoff_popup_text = "Nie pokazuj więcej tego wyskakującego okienka";
+	
+	var size_item_quickview = 82;
+	var style_scroll_quickview = 'vertical';
+	
+	var size_item_page = 113;
+	var style_scroll_page = 'horizontal';
+	
+	var size_item_quickview_attr = 101;	
+	var style_scroll_quickview_attr = 'vertical';
+	
+	var size_item_popup = 160;
+	var style_scroll_popup = 'vertical';
+</script>    
+
+    
+      <div class="modal leo-quicklogin-modal fade" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">×</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <div class="leo-quicklogin-form row">
+		<div class="leo-form leo-login-form col-sm-6 leo-form-active">
+		<p class="leo-login-title">			
+			<span class="title-both">
+				Logowanie do istniejącego konta
+			</span>
+		
+			<span class="title-only">
+				Zaloguj się na swoje konto
+			</span>		
+		</p>
+		<form class="lql-form-content leo-login-form-content" action="#" method="post">
+			<div class="form-group lql-form-mesg has-success">					
+			</div>			
+			<div class="form-group lql-form-mesg has-danger">					
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="email" class="form-control lql-email-login" name="lql-email-login" required="" placeholder="Adres e-mail">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="password" class="form-control lql-pass-login" name="lql-pass-login" required="" placeholder="Hasło">
+			</div>
+			<div class="form-group row lql-form-content-element">				
+				<div class="col-xs-6">
+											<input type="checkbox" class="lql-rememberme" name="lql-rememberme">
+						<label class="form-control-label"><span>Zapamiętaj mnie</span></label>
+									</div>				
+				<div class="col-xs-6 text-sm-right">
+					<a role="button" href="#" class="leoquicklogin-forgotpass">Zapomniałeś hasła ?</a>
+				</div>
+			</div>
+			<div class="form-group text-right">
+				<button type="submit" class="form-control-submit lql-form-bt lql-login-bt btn btn-primary">			
+					<span class="leoquicklogin-loading leoquicklogin-cssload-speeding-wheel"></span>
+					<i class="leoquicklogin-icon leoquicklogin-success-icon material-icons"></i>
+					<i class="leoquicklogin-icon leoquicklogin-fail-icon material-icons"></i>
+					<span class="lql-bt-txt">					
+						 Zaloguj się
+					</span>
+				</button>
+			</div>
+			<div class="form-group lql-callregister">
+				<a role="button" href="#" class="lql-callregister-action">Nie masz konta? Załóż je!</a>
+			</div>
+		</form>
+		<div class="leo-resetpass-form">
+			<p>Zresetuj hasło</p>
+			<form class="lql-form-content leo-resetpass-form-content" action="#" method="post">
+				<div class="form-group lql-form-mesg has-success">					
+				</div>			
+				<div class="form-group lql-form-mesg has-danger">					
+				</div>
+				<div class="form-group lql-form-content-element">
+					<input type="email" class="form-control lql-email-reset" name="lql-email-reset" required="" placeholder="Adres e-mail">
+				</div>
+				<div class="form-group">					
+					<button type="submit" class="form-control-submit lql-form-bt leoquicklogin-reset-pass-bt btn btn-primary">			
+						<span class="leoquicklogin-loading leoquicklogin-cssload-speeding-wheel"></span>
+						<i class="leoquicklogin-icon leoquicklogin-success-icon material-icons"></i>
+						<i class="leoquicklogin-icon leoquicklogin-fail-icon material-icons"></i>
+						<span class="lql-bt-txt">					
+							Zresetuj hasło
+						</span>
+					</button>
+				</div>
+				
+			</form>
+		</div>
+	</div>
+	
+	<div class="leo-form leo-register-form col-sm-6 leo-form-active">
+		<p class="leo-register-title">
+			Nowa rejestracja konta
+		</p>
+		<form class="lql-form-content leo-register-form-content" action="#" method="post">
+			<div class="form-group lql-form-mesg has-success">					
+			</div>			
+			<div class="form-group lql-form-mesg has-danger">					
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="text" class="form-control lql-register-firstname" name="lql-register-firstname" maxlength="20" placeholder="Imię">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="text" class="form-control lql-register-lastname" name="lql-register-lastname" required="" placeholder="Nazwisko">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="email" class="form-control lql-register-email" name="lql-register-email" required="" placeholder="Adres e-mail">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="password" class="form-control lql-register-pass" name="lql-register-pass" required="" placeholder="Hasło">
+			</div>
+						<div class="form-group text-right">				
+				<button type="submit" name="submit" class="form-control-submit lql-form-bt lql-register-bt btn btn-primary">			
+					<span class="leoquicklogin-loading leoquicklogin-cssload-speeding-wheel"></span>
+					<i class="leoquicklogin-icon leoquicklogin-success-icon material-icons"></i>
+					<i class="leoquicklogin-icon leoquicklogin-fail-icon material-icons"></i>
+					<span class="lql-bt-txt">					
+						Utwórz konto
+					</span>
+				</button>
+			</div>
+			<div class="form-group lql-calllogin">
+				<div>Posiadasz już konto?</div>
+				<a role="button" href="#" class="lql-calllogin-action">Zaloguj się</a>
+				lub
+				<a role="button" href="#" class="lql-calllogin-action lql-callreset-action">zresetuj hasło</a>
+			</div>
+		</form>
+	</div>
+</div>
+
+<div class="lql-social-login clearfix show-bt-txt">
+	<p class="lql-social-login-title">
+		Połącz się przez sieci społecznościowe
+	</p>
+			<!--
+		<div class="fb-login-button" data-max-rows="1" data-size="large" data-button-type="login_with" data-show-faces="false" data-auto-logout-link="false" data-use-continue-as="false" scope="public_profile,email" onlogin="checkLoginState();"></div>
+		-->
+		<button class="btn social-login-bt facebook-login-bt" onclick="doFbLogin();"><span class="fa fa-facebook"></span>Zaloguj się przez Facebook</button>
+		
+		<!--
+		<div class="g-signin2" data-scope="profile email" data-longtitle="true" data-theme="dark" data-onsuccess="googleSignIn" data-onfailure="googleFail"></div>
+	-->
+		</div>
+
+            </div> 
+            <div class="modal-footer"></div>
+        </div>
+    </div>
+</div><div class="leoquicklogin-mask"></div>
+
+<div class="leoquicklogin-slidebar slidebar_left">
+    <div class="leoquicklogin-slidebar-wrapper">
+        <div class="leoquicklogin-slidebar-top">
+            <button type="button" class="leoquicklogin-slidebar-close btn btn-secondary">
+                <i class="material-icons"></i>
+                <span>zamknij</span>
+            </button>
+        </div>
+        <div class="leo-quicklogin-form row">
+		<div class="leo-form leo-login-form col-sm-6 leo-form-active">
+		<p class="leo-login-title">			
+			<span class="title-both">
+				Logowanie do istniejącego konta
+			</span>
+		
+			<span class="title-only">
+				Zaloguj się na swoje konto
+			</span>		
+		</p>
+		<form class="lql-form-content leo-login-form-content" action="#" method="post">
+			<div class="form-group lql-form-mesg has-success">					
+			</div>			
+			<div class="form-group lql-form-mesg has-danger">					
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="email" class="form-control lql-email-login" name="lql-email-login" required="" placeholder="Adres e-mail">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="password" class="form-control lql-pass-login" name="lql-pass-login" required="" placeholder="Hasło">
+			</div>
+			<div class="form-group row lql-form-content-element">				
+				<div class="col-xs-6">
+											<input type="checkbox" class="lql-rememberme" name="lql-rememberme">
+						<label class="form-control-label"><span>Zapamiętaj mnie</span></label>
+									</div>				
+				<div class="col-xs-6 text-sm-right">
+					<a role="button" href="#" class="leoquicklogin-forgotpass">Zapomniałeś hasła ?</a>
+				</div>
+			</div>
+			<div class="form-group text-right">
+				<button type="submit" class="form-control-submit lql-form-bt lql-login-bt btn btn-primary">			
+					<span class="leoquicklogin-loading leoquicklogin-cssload-speeding-wheel"></span>
+					<i class="leoquicklogin-icon leoquicklogin-success-icon material-icons"></i>
+					<i class="leoquicklogin-icon leoquicklogin-fail-icon material-icons"></i>
+					<span class="lql-bt-txt">					
+						 Zaloguj się
+					</span>
+				</button>
+			</div>
+			<div class="form-group lql-callregister">
+				<a role="button" href="#" class="lql-callregister-action">Nie masz konta? Załóż je!</a>
+			</div>
+		</form>
+		<div class="leo-resetpass-form">
+			<p>Zresetuj hasło</p>
+			<form class="lql-form-content leo-resetpass-form-content" action="#" method="post">
+				<div class="form-group lql-form-mesg has-success">					
+				</div>			
+				<div class="form-group lql-form-mesg has-danger">					
+				</div>
+				<div class="form-group lql-form-content-element">
+					<input type="email" class="form-control lql-email-reset" name="lql-email-reset" required="" placeholder="Adres e-mail">
+				</div>
+				<div class="form-group">					
+					<button type="submit" class="form-control-submit lql-form-bt leoquicklogin-reset-pass-bt btn btn-primary">			
+						<span class="leoquicklogin-loading leoquicklogin-cssload-speeding-wheel"></span>
+						<i class="leoquicklogin-icon leoquicklogin-success-icon material-icons"></i>
+						<i class="leoquicklogin-icon leoquicklogin-fail-icon material-icons"></i>
+						<span class="lql-bt-txt">					
+							Zresetuj hasło
+						</span>
+					</button>
+				</div>
+				
+			</form>
+		</div>
+	</div>
+	
+	<div class="leo-form leo-register-form col-sm-6 leo-form-active">
+		<p class="leo-register-title">
+			Nowa rejestracja konta
+		</p>
+		<form class="lql-form-content leo-register-form-content" action="#" method="post">
+			<div class="form-group lql-form-mesg has-success">					
+			</div>			
+			<div class="form-group lql-form-mesg has-danger">					
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="text" class="form-control lql-register-firstname" name="lql-register-firstname" maxlength="20" placeholder="Imię">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="text" class="form-control lql-register-lastname" name="lql-register-lastname" required="" placeholder="Nazwisko">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="email" class="form-control lql-register-email" name="lql-register-email" required="" placeholder="Adres e-mail">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="password" class="form-control lql-register-pass" name="lql-register-pass" required="" placeholder="Hasło">
+			</div>
+						<div class="form-group text-right">				
+				<button type="submit" name="submit" class="form-control-submit lql-form-bt lql-register-bt btn btn-primary">			
+					<span class="leoquicklogin-loading leoquicklogin-cssload-speeding-wheel"></span>
+					<i class="leoquicklogin-icon leoquicklogin-success-icon material-icons"></i>
+					<i class="leoquicklogin-icon leoquicklogin-fail-icon material-icons"></i>
+					<span class="lql-bt-txt">					
+						Utwórz konto
+					</span>
+				</button>
+			</div>
+			<div class="form-group lql-calllogin">
+				<div>Posiadasz już konto?</div>
+				<a role="button" href="#" class="lql-calllogin-action">Zaloguj się</a>
+				lub
+				<a role="button" href="#" class="lql-calllogin-action lql-callreset-action">zresetuj hasło</a>
+			</div>
+		</form>
+	</div>
+</div>
+
+<div class="lql-social-login clearfix show-bt-txt">
+	<p class="lql-social-login-title">
+		Połącz się przez sieci społecznościowe
+	</p>
+			<!--
+		<div class="fb-login-button" data-max-rows="1" data-size="large" data-button-type="login_with" data-show-faces="false" data-auto-logout-link="false" data-use-continue-as="false" scope="public_profile,email" onlogin="checkLoginState();"></div>
+		-->
+		<button class="btn social-login-bt facebook-login-bt" onclick="doFbLogin();"><span class="fa fa-facebook"></span>Zaloguj się przez Facebook</button>
+		
+		<!--
+		<div class="g-signin2" data-scope="profile email" data-longtitle="true" data-theme="dark" data-onsuccess="googleSignIn" data-onfailure="googleFail"></div>
+	-->
+		</div>
+
+        <div class="leoquicklogin-slidebar-bottom">
+            <button type="button" class="leoquicklogin-slidebar-close btn btn-secondary">
+                <i class="material-icons"></i>
+                <span>zamknij</span>
+            </button>
+        </div>
+    </div>
+</div><div class="leoquicklogin-slidebar slidebar_right">
+    <div class="leoquicklogin-slidebar-wrapper">
+        <div class="leoquicklogin-slidebar-top">
+            <button type="button" class="leoquicklogin-slidebar-close btn btn-secondary">
+                <i class="material-icons"></i>
+                <span>zamknij</span>
+            </button>
+        </div>
+        <div class="leo-quicklogin-form row">
+		<div class="leo-form leo-login-form col-sm-6 leo-form-active">
+		<p class="leo-login-title">			
+			<span class="title-both">
+				Logowanie do istniejącego konta
+			</span>
+		
+			<span class="title-only">
+				Zaloguj się na swoje konto
+			</span>		
+		</p>
+		<form class="lql-form-content leo-login-form-content" action="#" method="post">
+			<div class="form-group lql-form-mesg has-success">					
+			</div>			
+			<div class="form-group lql-form-mesg has-danger">					
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="email" class="form-control lql-email-login" name="lql-email-login" required="" placeholder="Adres e-mail">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="password" class="form-control lql-pass-login" name="lql-pass-login" required="" placeholder="Hasło">
+			</div>
+			<div class="form-group row lql-form-content-element">				
+				<div class="col-xs-6">
+											<input type="checkbox" class="lql-rememberme" name="lql-rememberme">
+						<label class="form-control-label"><span>Zapamiętaj mnie</span></label>
+									</div>				
+				<div class="col-xs-6 text-sm-right">
+					<a role="button" href="#" class="leoquicklogin-forgotpass">Zapomniałeś hasła ?</a>
+				</div>
+			</div>
+			<div class="form-group text-right">
+				<button type="submit" class="form-control-submit lql-form-bt lql-login-bt btn btn-primary">			
+					<span class="leoquicklogin-loading leoquicklogin-cssload-speeding-wheel"></span>
+					<i class="leoquicklogin-icon leoquicklogin-success-icon material-icons"></i>
+					<i class="leoquicklogin-icon leoquicklogin-fail-icon material-icons"></i>
+					<span class="lql-bt-txt">					
+						 Zaloguj się
+					</span>
+				</button>
+			</div>
+			<div class="form-group lql-callregister">
+				<a role="button" href="#" class="lql-callregister-action">Nie masz konta? Załóż je!</a>
+			</div>
+		</form>
+		<div class="leo-resetpass-form">
+			<p>Zresetuj hasło</p>
+			<form class="lql-form-content leo-resetpass-form-content" action="#" method="post">
+				<div class="form-group lql-form-mesg has-success">					
+				</div>			
+				<div class="form-group lql-form-mesg has-danger">					
+				</div>
+				<div class="form-group lql-form-content-element">
+					<input type="email" class="form-control lql-email-reset" name="lql-email-reset" required="" placeholder="Adres e-mail">
+				</div>
+				<div class="form-group">					
+					<button type="submit" class="form-control-submit lql-form-bt leoquicklogin-reset-pass-bt btn btn-primary">			
+						<span class="leoquicklogin-loading leoquicklogin-cssload-speeding-wheel"></span>
+						<i class="leoquicklogin-icon leoquicklogin-success-icon material-icons"></i>
+						<i class="leoquicklogin-icon leoquicklogin-fail-icon material-icons"></i>
+						<span class="lql-bt-txt">					
+							Zresetuj hasło
+						</span>
+					</button>
+				</div>
+				
+			</form>
+		</div>
+	</div>
+	
+	<div class="leo-form leo-register-form col-sm-6 leo-form-active">
+		<p class="leo-register-title">
+			Nowa rejestracja konta
+		</p>
+		<form class="lql-form-content leo-register-form-content" action="#" method="post">
+			<div class="form-group lql-form-mesg has-success">					
+			</div>			
+			<div class="form-group lql-form-mesg has-danger">					
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="text" class="form-control lql-register-firstname" name="lql-register-firstname" maxlength="20" placeholder="Imię">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="text" class="form-control lql-register-lastname" name="lql-register-lastname" required="" placeholder="Nazwisko">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="email" class="form-control lql-register-email" name="lql-register-email" required="" placeholder="Adres e-mail">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="password" class="form-control lql-register-pass" name="lql-register-pass" required="" placeholder="Hasło">
+			</div>
+						<div class="form-group text-right">				
+				<button type="submit" name="submit" class="form-control-submit lql-form-bt lql-register-bt btn btn-primary">			
+					<span class="leoquicklogin-loading leoquicklogin-cssload-speeding-wheel"></span>
+					<i class="leoquicklogin-icon leoquicklogin-success-icon material-icons"></i>
+					<i class="leoquicklogin-icon leoquicklogin-fail-icon material-icons"></i>
+					<span class="lql-bt-txt">					
+						Utwórz konto
+					</span>
+				</button>
+			</div>
+			<div class="form-group lql-calllogin">
+				<div>Posiadasz już konto?</div>
+				<a role="button" href="#" class="lql-calllogin-action">Zaloguj się</a>
+				lub
+				<a role="button" href="#" class="lql-calllogin-action lql-callreset-action">zresetuj hasło</a>
+			</div>
+		</form>
+	</div>
+</div>
+
+<div class="lql-social-login clearfix show-bt-txt">
+	<p class="lql-social-login-title">
+		Połącz się przez sieci społecznościowe
+	</p>
+			<!--
+		<div class="fb-login-button" data-max-rows="1" data-size="large" data-button-type="login_with" data-show-faces="false" data-auto-logout-link="false" data-use-continue-as="false" scope="public_profile,email" onlogin="checkLoginState();"></div>
+		-->
+		<button class="btn social-login-bt facebook-login-bt" onclick="doFbLogin();"><span class="fa fa-facebook"></span>Zaloguj się przez Facebook</button>
+		
+		<!--
+		<div class="g-signin2" data-scope="profile email" data-longtitle="true" data-theme="dark" data-onsuccess="googleSignIn" data-onfailure="googleFail"></div>
+	-->
+		</div>
+
+        <div class="leoquicklogin-slidebar-bottom">
+            <button type="button" class="leoquicklogin-slidebar-close btn btn-secondary">
+                <i class="material-icons"></i>
+                <span>zamknij</span>
+            </button>
+        </div>
+    </div>
+</div><div class="leoquicklogin-slidebar slidebar_top">
+    <div class="leoquicklogin-slidebar-wrapper">
+        <div class="leoquicklogin-slidebar-top">
+            <button type="button" class="leoquicklogin-slidebar-close btn btn-secondary">
+                <i class="material-icons"></i>
+                <span>zamknij</span>
+            </button>
+        </div>
+        <div class="leo-quicklogin-form row">
+		<div class="leo-form leo-login-form col-sm-6 leo-form-active">
+		<p class="leo-login-title">			
+			<span class="title-both">
+				Logowanie do istniejącego konta
+			</span>
+		
+			<span class="title-only">
+				Zaloguj się na swoje konto
+			</span>		
+		</p>
+		<form class="lql-form-content leo-login-form-content" action="#" method="post">
+			<div class="form-group lql-form-mesg has-success">					
+			</div>			
+			<div class="form-group lql-form-mesg has-danger">					
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="email" class="form-control lql-email-login" name="lql-email-login" required="" placeholder="Adres e-mail">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="password" class="form-control lql-pass-login" name="lql-pass-login" required="" placeholder="Hasło">
+			</div>
+			<div class="form-group row lql-form-content-element">				
+				<div class="col-xs-6">
+											<input type="checkbox" class="lql-rememberme" name="lql-rememberme">
+						<label class="form-control-label"><span>Zapamiętaj mnie</span></label>
+									</div>				
+				<div class="col-xs-6 text-sm-right">
+					<a role="button" href="#" class="leoquicklogin-forgotpass">Zapomniałeś hasła ?</a>
+				</div>
+			</div>
+			<div class="form-group text-right">
+				<button type="submit" class="form-control-submit lql-form-bt lql-login-bt btn btn-primary">			
+					<span class="leoquicklogin-loading leoquicklogin-cssload-speeding-wheel"></span>
+					<i class="leoquicklogin-icon leoquicklogin-success-icon material-icons"></i>
+					<i class="leoquicklogin-icon leoquicklogin-fail-icon material-icons"></i>
+					<span class="lql-bt-txt">					
+						 Zaloguj się
+					</span>
+				</button>
+			</div>
+			<div class="form-group lql-callregister">
+				<a role="button" href="#" class="lql-callregister-action">Nie masz konta? Załóż je!</a>
+			</div>
+		</form>
+		<div class="leo-resetpass-form">
+			<p>Zresetuj hasło</p>
+			<form class="lql-form-content leo-resetpass-form-content" action="#" method="post">
+				<div class="form-group lql-form-mesg has-success">					
+				</div>			
+				<div class="form-group lql-form-mesg has-danger">					
+				</div>
+				<div class="form-group lql-form-content-element">
+					<input type="email" class="form-control lql-email-reset" name="lql-email-reset" required="" placeholder="Adres e-mail">
+				</div>
+				<div class="form-group">					
+					<button type="submit" class="form-control-submit lql-form-bt leoquicklogin-reset-pass-bt btn btn-primary">			
+						<span class="leoquicklogin-loading leoquicklogin-cssload-speeding-wheel"></span>
+						<i class="leoquicklogin-icon leoquicklogin-success-icon material-icons"></i>
+						<i class="leoquicklogin-icon leoquicklogin-fail-icon material-icons"></i>
+						<span class="lql-bt-txt">					
+							Zresetuj hasło
+						</span>
+					</button>
+				</div>
+				
+			</form>
+		</div>
+	</div>
+	
+	<div class="leo-form leo-register-form col-sm-6 leo-form-active">
+		<p class="leo-register-title">
+			Nowa rejestracja konta
+		</p>
+		<form class="lql-form-content leo-register-form-content" action="#" method="post">
+			<div class="form-group lql-form-mesg has-success">					
+			</div>			
+			<div class="form-group lql-form-mesg has-danger">					
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="text" class="form-control lql-register-firstname" name="lql-register-firstname" maxlength="20" placeholder="Imię">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="text" class="form-control lql-register-lastname" name="lql-register-lastname" required="" placeholder="Nazwisko">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="email" class="form-control lql-register-email" name="lql-register-email" required="" placeholder="Adres e-mail">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="password" class="form-control lql-register-pass" name="lql-register-pass" required="" placeholder="Hasło">
+			</div>
+						<div class="form-group text-right">				
+				<button type="submit" name="submit" class="form-control-submit lql-form-bt lql-register-bt btn btn-primary">			
+					<span class="leoquicklogin-loading leoquicklogin-cssload-speeding-wheel"></span>
+					<i class="leoquicklogin-icon leoquicklogin-success-icon material-icons"></i>
+					<i class="leoquicklogin-icon leoquicklogin-fail-icon material-icons"></i>
+					<span class="lql-bt-txt">					
+						Utwórz konto
+					</span>
+				</button>
+			</div>
+			<div class="form-group lql-calllogin">
+				<div>Posiadasz już konto?</div>
+				<a role="button" href="#" class="lql-calllogin-action">Zaloguj się</a>
+				lub
+				<a role="button" href="#" class="lql-calllogin-action lql-callreset-action">zresetuj hasło</a>
+			</div>
+		</form>
+	</div>
+</div>
+
+<div class="lql-social-login clearfix show-bt-txt">
+	<p class="lql-social-login-title">
+		Połącz się przez sieci społecznościowe
+	</p>
+			<!--
+		<div class="fb-login-button" data-max-rows="1" data-size="large" data-button-type="login_with" data-show-faces="false" data-auto-logout-link="false" data-use-continue-as="false" scope="public_profile,email" onlogin="checkLoginState();"></div>
+		-->
+		<button class="btn social-login-bt facebook-login-bt" onclick="doFbLogin();"><span class="fa fa-facebook"></span>Zaloguj się przez Facebook</button>
+		
+		<!--
+		<div class="g-signin2" data-scope="profile email" data-longtitle="true" data-theme="dark" data-onsuccess="googleSignIn" data-onfailure="googleFail"></div>
+	-->
+		</div>
+
+        <div class="leoquicklogin-slidebar-bottom">
+            <button type="button" class="leoquicklogin-slidebar-close btn btn-secondary">
+                <i class="material-icons"></i>
+                <span>zamknij</span>
+            </button>
+        </div>
+    </div>
+</div><div class="leoquicklogin-slidebar slidebar_bottom">
+    <div class="leoquicklogin-slidebar-wrapper">
+        <div class="leoquicklogin-slidebar-top">
+            <button type="button" class="leoquicklogin-slidebar-close btn btn-secondary">
+                <i class="material-icons"></i>
+                <span>zamknij</span>
+            </button>
+        </div>
+        <div class="leo-quicklogin-form row">
+		<div class="leo-form leo-login-form col-sm-6 leo-form-active">
+		<p class="leo-login-title">			
+			<span class="title-both">
+				Logowanie do istniejącego konta
+			</span>
+		
+			<span class="title-only">
+				Zaloguj się na swoje konto
+			</span>		
+		</p>
+		<form class="lql-form-content leo-login-form-content" action="#" method="post">
+			<div class="form-group lql-form-mesg has-success">					
+			</div>			
+			<div class="form-group lql-form-mesg has-danger">					
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="email" class="form-control lql-email-login" name="lql-email-login" required="" placeholder="Adres e-mail">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="password" class="form-control lql-pass-login" name="lql-pass-login" required="" placeholder="Hasło">
+			</div>
+			<div class="form-group row lql-form-content-element">				
+				<div class="col-xs-6">
+											<input type="checkbox" class="lql-rememberme" name="lql-rememberme">
+						<label class="form-control-label"><span>Zapamiętaj mnie</span></label>
+									</div>				
+				<div class="col-xs-6 text-sm-right">
+					<a role="button" href="#" class="leoquicklogin-forgotpass">Zapomniałeś hasła ?</a>
+				</div>
+			</div>
+			<div class="form-group text-right">
+				<button type="submit" class="form-control-submit lql-form-bt lql-login-bt btn btn-primary">			
+					<span class="leoquicklogin-loading leoquicklogin-cssload-speeding-wheel"></span>
+					<i class="leoquicklogin-icon leoquicklogin-success-icon material-icons"></i>
+					<i class="leoquicklogin-icon leoquicklogin-fail-icon material-icons"></i>
+					<span class="lql-bt-txt">					
+						 Zaloguj się
+					</span>
+				</button>
+			</div>
+			<div class="form-group lql-callregister">
+				<a role="button" href="#" class="lql-callregister-action">Nie masz konta? Załóż je!</a>
+			</div>
+		</form>
+		<div class="leo-resetpass-form">
+			<p>Zresetuj hasło</p>
+			<form class="lql-form-content leo-resetpass-form-content" action="#" method="post">
+				<div class="form-group lql-form-mesg has-success">					
+				</div>			
+				<div class="form-group lql-form-mesg has-danger">					
+				</div>
+				<div class="form-group lql-form-content-element">
+					<input type="email" class="form-control lql-email-reset" name="lql-email-reset" required="" placeholder="Adres e-mail">
+				</div>
+				<div class="form-group">					
+					<button type="submit" class="form-control-submit lql-form-bt leoquicklogin-reset-pass-bt btn btn-primary">			
+						<span class="leoquicklogin-loading leoquicklogin-cssload-speeding-wheel"></span>
+						<i class="leoquicklogin-icon leoquicklogin-success-icon material-icons"></i>
+						<i class="leoquicklogin-icon leoquicklogin-fail-icon material-icons"></i>
+						<span class="lql-bt-txt">					
+							Zresetuj hasło
+						</span>
+					</button>
+				</div>
+				
+			</form>
+		</div>
+	</div>
+	
+	<div class="leo-form leo-register-form col-sm-6 leo-form-active">
+		<p class="leo-register-title">
+			Nowa rejestracja konta
+		</p>
+		<form class="lql-form-content leo-register-form-content" action="#" method="post">
+			<div class="form-group lql-form-mesg has-success">					
+			</div>			
+			<div class="form-group lql-form-mesg has-danger">					
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="text" class="form-control lql-register-firstname" name="lql-register-firstname" maxlength="20" placeholder="Imię">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="text" class="form-control lql-register-lastname" name="lql-register-lastname" required="" placeholder="Nazwisko">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="email" class="form-control lql-register-email" name="lql-register-email" required="" placeholder="Adres e-mail">
+			</div>
+			<div class="form-group lql-form-content-element">
+				<input type="password" class="form-control lql-register-pass" name="lql-register-pass" required="" placeholder="Hasło">
+			</div>
+						<div class="form-group text-right">				
+				<button type="submit" name="submit" class="form-control-submit lql-form-bt lql-register-bt btn btn-primary">			
+					<span class="leoquicklogin-loading leoquicklogin-cssload-speeding-wheel"></span>
+					<i class="leoquicklogin-icon leoquicklogin-success-icon material-icons"></i>
+					<i class="leoquicklogin-icon leoquicklogin-fail-icon material-icons"></i>
+					<span class="lql-bt-txt">					
+						Utwórz konto
+					</span>
+				</button>
+			</div>
+			<div class="form-group lql-calllogin">
+				<div>Posiadasz już konto?</div>
+				<a role="button" href="#" class="lql-calllogin-action">Zaloguj się</a>
+				lub
+				<a role="button" href="#" class="lql-calllogin-action lql-callreset-action">zresetuj hasło</a>
+			</div>
+		</form>
+	</div>
+</div>
+
+<div class="lql-social-login clearfix show-bt-txt">
+	<p class="lql-social-login-title">
+		Połącz się przez sieci społecznościowe
+	</p>
+			<!--
+		<div class="fb-login-button" data-max-rows="1" data-size="large" data-button-type="login_with" data-show-faces="false" data-auto-logout-link="false" data-use-continue-as="false" scope="public_profile,email" onlogin="checkLoginState();"></div>
+		-->
+		<button class="btn social-login-bt facebook-login-bt" onclick="doFbLogin();"><span class="fa fa-facebook"></span>Zaloguj się przez Facebook</button>
+		
+		<!--
+		<div class="g-signin2" data-scope="profile email" data-longtitle="true" data-theme="dark" data-onsuccess="googleSignIn" data-onfailure="googleFail"></div>
+	-->
+		</div>
+
+        <div class="leoquicklogin-slidebar-bottom">
+            <button type="button" class="leoquicklogin-slidebar-close btn btn-secondary">
+                <i class="material-icons"></i>
+                <span>zamknij</span>
+            </button>
+        </div>
+    </div>
+</div>
+<div class="modal lql-social-modal fade" tabindex="-1" role="dialog" aria-hidden="true">
+	
+	  <div class="modal-dialog" role="document">
+		<div class="modal-content">
+		  <div class="modal-header">
+			<button type="button" class="close" data-dismiss="modal" aria-label="Close">
+			  <span aria-hidden="true">×</span>
+			</button>
+			<p class="modal-title lql-social-modal-mesg lql-social-loading">
+				<span class="leoquicklogin-cssload-speeding-wheel"></span>
+			</p>
+			<p class="modal-title lql-social-modal-mesg error-email">
+				<i class="material-icons"></i>
+				Nie można zalogować się bez adresu e-mail!
+			</p>
+			<p class="modal-title lql-social-modal-mesg error-email">				
+				Sprawdź swoje konto społecznościowe i zezwól na korzystanie z informacji e-mail
+			</p>
+			<p class="modal-title lql-social-modal-mesg error-login">
+				<i class="material-icons"></i>
+				Nie możesz się zalogować!
+			</p>
+			<p class="modal-title lql-social-modal-mesg error-login">
+				Skontaktuj się z nami lub spróbuj zalogować się w inny sposób
+			</p>
+			<p class="modal-title lql-social-modal-mesg success">
+				<i class="material-icons"></i>
+				Pomyślnie!
+			</p>
+			<p class="modal-title lql-social-modal-mesg success">			
+				Dziękujemy za zalogowanie
+			</p>
+		  </div>
+		  
+		  		 
+		</div>
+	  </div>
+	
+</div>
+<div data-type="slidebar_bottom" style="position: fixed; bottom:0px; left:0px" class="leo-fly-cart solo type-fixed enable-slidebar offset-left">
+	<div class="leo-fly-cart-icon-wrapper">
+		<a href="javascript:void(0)" class="leo-fly-cart-icon" data-type="slidebar_bottom"><i class="material-icons"></i></a>
+		<span class="leo-fly-cart-total">0</span>
+	</div>
+		<div class="leo-fly-cart-cssload-loader" style="display: none;"></div>
+</div>	<div class="leo-fly-cart-mask"></div>
+
+<div class="leo-fly-cart-slidebar slidebar_bottom disable">
+	
+	<div class="leo-fly-cart disable-dropdown">
+		<div class="leo-fly-cart-wrapper">
+			<div class="leo-fly-cart-icon-wrapper">
+				<a href="javascript:void(0)" class="leo-fly-cart-icon"><i class="material-icons"></i></a>
+				<span class="leo-fly-cart-total">0</span>
+			</div>
+						<div class="leo-fly-cart-cssload-loader" style="display: none;"></div>
+		</div>
+	</div>
+
+</div><div class="modal fade x13pricehistory-modal" tabindex="-1" role="dialog" aria-labelledby="x13pricehistory-modalLabel" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">×</span>
+        </button>
+        <h5 class="modal-title">Historia cen produktu</h5>
+      </div>
+      <div class="modal-body">
+      </div>
+    </div>
+  </div>
+</div>
+    
+  
+
+<div class="modal leo-modal leo-modal-wishlist fade" tabindex="-1" role="dialog" aria-hidden="true"><div class="modal-dialog" role="document"><div class="modal-content"><div class="modal-header"><button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">×</span></button><p class="modal-title text-xs-center"></p></div><div class="modal-footer"><button type="button" class="btn btn-secondary" data-dismiss="modal">Anuluj</button><button type="button" class="leo-modal-wishlist-bt btn btn-primary"><span class="leo-modal-wishlist-loading cssload-speeding-wheel"></span><span class="leo-modal-wishlist-bt-text">Ok</span></button></div></div></div></div><section class="off-canvas-nav-megamenu" data-megamenu-id="9184166521380958"><nav class="offcanvas-mainnav"><div class="off-canvas-button-megamenu"><span class="off-canvas-nav"></span>Zamknij</div><ul class="nav navbar-nav megamenu horizontal"><li data-menu-type="category" class="nav-item parent  dropdown   ">
+    <a class="nav-link dropdown-toggle has-category" data-toggle="dropdown" href="https://funkyshop.pl/pl/4-piwo-rzemieslnicze" target="_self">
+
+                    
+                    <span class="menu-title">Piwo rzemieślnicze</span>
+                                        
+            </a>
+        <b class="caret"></b>
+            <div class="dropdown-sub dropdown-menu" style="width:600px">
+            <div class="dropdown-menu-inner">
+                                    <div class="row">
+                                                    <div class="mega-col col-md-4">
+                                <div class="mega-col-inner">
+                                    <div class="leo-widget" data-id_widget="1613641002">
+    <div class="widget-links">
+		<div class="widget-inner">	
+		<div id="tabs1734881162" class="panel-group">
+			<ul class="nav-links">
+				  
+					<li><a href="https://funkyshop.pl/pl/2-funky-shop">wszystkie produkty</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/brand/2-funky-fluid">Funky Fluid</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/nowe-produkty">Nowości</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/index.php?controller=pricesdrop">Promocje</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/16-zestawy">Zestawy</a></li>
+							</ul>
+		</div>
+	</div>
+    </div>
+</div>                                </div>
+                            </div>
+                                                    <div class="mega-col col-md-4">
+                                <div class="mega-col-inner">
+                                    <div class="leo-widget" data-id_widget="1613641017">
+    <div class="widget-links">
+		<div class="widget-inner">	
+		<div id="tabs1728250055" class="panel-group">
+			<ul class="nav-links">
+				  
+					<li><a href="https://funkyshop.pl/pl/5-mocno-chmielone">Mocno chmielone</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/6-ciemne">Ciemne</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/7-kwasnedzikie">Kwaśne/dzikie</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/9-owocowe">Owocowe</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/10-klasyczne">Klasyczne</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/11-vintage">Vintage/barrel aged</a></li>
+							</ul>
+		</div>
+	</div>
+    </div>
+</div>                                </div>
+                            </div>
+                                                    <div class="mega-col col-md-4">
+                                <div class="mega-col-inner">
+                                    <div class="leo-widget" data-id_widget="1613641028">
+    <div class="widget-links">
+		<div class="widget-inner">	
+		<div id="tabs882229316" class="panel-group">
+			<ul class="nav-links">
+				  
+					<li><a href="https://funkyshop.pl/pl/2-oferta?q=Kraj+pochodzenia-Polska">Polska</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/2-oferta?q=Kraj+pochodzenia-Anglia">Anglia</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/2-piwa-rzemieslnicze?q=Kraj+pochodzenia-Belgia">Belgia</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/2-oferta?q=Kraj+pochodzenia-Szwecja">Szwecja</a></li>
+				  
+					<li><a href="https://funkyshop.pl/pl/2-oferta?q=Kraj+pochodzenia-USA">USA</a></li>
+							</ul>
+		</div>
+	</div>
+    </div>
+</div>                                </div>
+                            </div>
+                                            </div>
+                            </div>
+        </div>
+    </li><li data-menu-type="category" class="nav-item parent dropdown">
+    <a class="nav-link dropdown-toggle has-category" data-toggle="dropdown" href="https://funkyshop.pl/pl/3-piwo-bezalkoholowe" target="_self">
+                    
+                    <span class="menu-title">Piwo bezalkoholowe</span>
+                                	
+	    </a>
+    <b class="caret"></b>
+    <div class="dropdown-menu level1">
+    <div class="dropdown-menu-inner">
+        <div class="row">
+            <div class="col-sm-12 mega-col" data-colwidth="12" data-type="menu">
+                <div class="inner">
+                    <ul>
+                                                    <li data-menu-type="category" class="nav-item   ">
+            <a class="nav-link" href="https://funkyshop.pl/pl/14-zero-procent">
+            
+                            <span class="menu-title">0%</span>
+                                    
+                    </a>
+
+    </li>
+            
+                                                    <li data-menu-type="category" class="nav-item   ">
+            <a class="nav-link" href="https://funkyshop.pl/pl/15-ponad-00">
+            
+                            <span class="menu-title">Ponad 0,0%</span>
+                                    
+                    </a>
+
+    </li>
+            
+                                            </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+</li>    <li data-menu-type="category" class="nav-item  ">
+        <a class="nav-link has-category" href="https://funkyshop.pl/pl/18-cydry-miody-wina" target="_self">
+                            
+                            <span class="menu-title">Cydry/wina/miody pitne</span>
+                                                        </a>
+    </li>
+    <li data-menu-type="category" class="nav-item active">
+        <a class="nav-link has-category" href="https://funkyshop.pl/pl/17-szklomerch" target="_self">
+                            
+                            <span class="menu-title">Szkło / Merch</span>
+                                                        </a>
+    </li>
+    <li data-menu-type="category" class="nav-item pink ">
+        <a class="nav-link has-category" href="https://funkyshop.pl/pl/23-browar-miesiaca" target="_self">
+                            
+                            <span class="menu-title">Browar miesiąca</span>
+                                                        </a>
+    </li>
+    <li data-menu-type="controller" class="nav-item  ">
+        <a class="nav-link has-category" href="https://funkyshop.pl/pl/kontakt" target="_self">
+                            
+                            <span class="menu-title">Kontakt</span>
+                                                        </a>
+    </li>
+</ul></nav></section><div><div class="grecaptcha-badge" data-style="bottomright" style="width: 256px; height: 60px; display: block; transition: right 0.3s; position: fixed; bottom: 14px; right: -186px; box-shadow: gray 0px 0px 5px; border-radius: 2px; overflow: hidden;"><div class="grecaptcha-logo"><iframe title="reCAPTCHA" width="256" height="60" role="presentation" name="a-911zbqunsy6e" frameborder="0" scrolling="no" sandbox="allow-forms allow-popups allow-same-origin allow-scripts allow-top-navigation allow-modals allow-popups-to-escape-sandbox allow-storage-access-by-user-activation" src="https://www.google.com/recaptcha/api2/anchor?ar=1&amp;k=6LfV7hsrAAAAAFM2myNNgqZuypFI573dG2Jvvvju&amp;co=aHR0cHM6Ly9mdW5reXNob3AucGw6NDQz&amp;hl=en&amp;v=TnA7HacJFoBWt9hnlunBlYfK&amp;size=invisible&amp;anchor-ms=20000&amp;execute-ms=30000&amp;cb=ly31o3h9cs12"></iframe></div><div class="grecaptcha-error"></div><textarea id="g-recaptcha-response-100000" name="g-recaptcha-response" class="g-recaptcha-response" style="width: 250px; height: 40px; border: 1px solid rgb(193, 193, 193); margin: 10px 25px; padding: 0px; resize: none; display: none;"></textarea></div><iframe style="display: none;"></iframe></div><div class="modal leo-modal leo-modal-cart fade" tabindex="-1" role="dialog" aria-hidden="true">
+	<!--
+	<div class="vertical-alignment-helper">
+	-->
+	  <div class="modal-dialog" role="document">
+		<div class="modal-content">
+		  <div class="modal-header">
+			<button type="button" class="close" data-dismiss="modal" aria-label="Close">
+			  <span aria-hidden="true">×</span>
+			</button>
+			<p class="modal-title h6 text-xs-center leo-warning leo-alert">
+				<i class="material-icons">info_outline</i>				
+				Musisz podać ilość		
+			</p>
+			
+			<p class="modal-title h6 text-xs-center leo-info leo-alert">
+				<i class="material-icons">info_outline</i>				
+				Minimalna ilość zamówienia produktu<strong class="alert-min-qty"></strong>		
+			</p>	
+			
+			<p class="modal-title h6 text-xs-center leo-block leo-alert">				
+				<i class="material-icons">block</i>				
+				W magazynie brak wystarczającej ilości produktów	
+			</p>
+		  </div>
+		  <!--
+		  <div class="modal-body">
+			...
+		  </div>
+		  <div class="modal-footer">
+			
+			<button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+			<button type="button" class="btn btn-primary">Save changes</button>
+			
+		  </div>
+		  -->
+		</div>
+	  </div>
+	<!--
+	</div>
+	-->
+</div>
+<div class="leo-notification" style="width: 100%; top:0px; right:0%">
+</div>
+<div class="leo-temp leo-temp-success">
+	<div class="notification-wrapper">
+		<div class="notification notification-success">
+						<strong class="noti product-name"></strong>
+			<span class="noti noti-update">Produkt został zaktualizowany w koszyku</span>
+			<span class="noti noti-delete">Produkt został usunięty z Twojego koszyka</span>
+			<span class="noti noti-add"><strong class="noti-special"></strong> Produkt pomyślnie dodano do koszyka</span>
+			<span class="notification-close">X</span>
+			
+		</div>
+	</div>
+</div>
+<div class="leo-temp leo-temp-error">
+	<div class="notification-wrapper">
+		<div class="notification notification-error">
+						
+			<span class="noti noti-update">Błąd podczas aktualizacji</span>
+			<span class="noti noti-delete">Błąd podczas usuwania	</span>
+			<span class="noti noti-add">Nie możesz zamówić większej ilości tego produktu</span>
+			
+			<span class="notification-close">X</span>
+			
+		</div>
+	</div>
+</div>
+<div class="leo-temp leo-temp-warning">
+	<div class="notification-wrapper">
+		<div class="notification notification-warning">
+						<span class="noti noti-min">Minimalna ilość zamówienia produktu	 <strong class="noti-special"></strong></span>
+			<span class="noti noti-max">W magazynie brak wystarczającej ilości produktów</span>
+			
+			<span class="notification-close">X</span>
+			
+		</div>
+	</div>
+</div>
+<div class="leo-temp leo-temp-normal">
+	<div class="notification-wrapper">
+		<div class="notification notification-normal">
+						<span class="noti noti-check">Musisz podać ilość</span>
+			
+			<span class="notification-close">X</span>
+			
+		</div>
+	</div>
+</div>
+<div class="jconfirm jconfirm-light jconfirm-open"><div class="jconfirm-bg" style="opacity: 0.5; transition-duration: 0.2s; transition-timing-function: cubic-bezier(0.36, 0.55, 0.19, 1);"></div><div class="jconfirm-scrollpane"><div class="jconfirm-row"><div class="jconfirm-cell"><div class="jconfirm-holder" style="padding-top: 0px; padding-bottom: 0px;"><div class="jc-bs3-container"><div class="jc-bs3-row"><div class="jconfirm-box-container jconfirm-animated jconfirm-no-transition" style="transform: translate(0px, 0px); transition-duration: 0.2s; transition-timing-function: cubic-bezier(0.36, 0.55, 0.19, 1);"><div class="jconfirm-box jconfirm-hilight-shake jconfirm-type-default jconfirm-type-animated" role="dialog" aria-labelledby="jconfirm-box13134" tabindex="-1" style="width: 976px; transition-duration: 0.2s; transition-timing-function: cubic-bezier(0.36, 0.55, 0.19, 1); transition-property: all, margin;"><div class="jconfirm-closeIcon" style="display: none;">×</div><div class="jconfirm-title-c" style="display: none;"><span class="jconfirm-icon-c"></span><span class="jconfirm-title"></span></div><div class="jconfirm-content-pane no-scroll" style="transition-duration: 0.2s; transition-timing-function: cubic-bezier(0.36, 0.55, 0.19, 1); height: 228px; max-height: 618.312px;"><div class="jconfirm-content" id="jconfirm-box13134"><div><div id="pmcookie">
+	<div class="pmcookie-h1">Drogi użytkowniku</div>
+	<div class="pmcookie-h4">Poniżej możesz zmienić ustawienia plików cookies naszych i naszych partnerów. Korzystanie przez nas z plików cookie analitycznych oraz marketingowych wymaga Twojej zgody. W ramach cookies marketingowych wydzieliliśmy kategorię plików cookie związanych z wyświetlaniem reklam w związku z korzystaniem ze stron internetowych (reklamowe pliki cookie) oraz plików cookie pozwalających na docieranie do Ciebie ze spersonalizowaną reklamą w portalach społecznościowych (pliki cookie mediów społecznościowych). Więcej informacji o poszczególnych kategoriach plików cookie, które stosujemy w serwisie, znajdziesz poniżej. Jeżeli chcesz zaakceptować wszystkie pliki cookie, kliknij „Zaakceptuj wszystkie”. Jeżeli natomiast chcesz, żebyśmy stosowali tylko niezbędne pliki cookie, kliknij „Zapisz ustawienia i zamknij”. Aby zmieniać preferencje plików cookie, przesuń suwak przy wybranej kategorii. Masz prawo do wglądu w swoje ustawienia oraz do ich zmiany w dowolnym czasie. Korzystanie z plików cookie wiąże się z przetwarzaniem Twoich danych osobowych dotyczących Twojej aktywności w serwisie. Szczegółowe informacje o sposobie, w jaki my oraz nasi partnerzy używamy plików cookie oraz przetwarzamy Twoje dane, a także o przysługujących Ci prawach, znajdziesz w naszej Polityce Cookies.</div>
+</div>
+
+</div></div></div><div class="jconfirm-buttons pmjconfirm-buttons"><button type="button" class="btn pmcookie-show-all pm-show-more-color pmcookie-left">Ustawienia</button><button type="button" class="btn pmcookie-show-submit pm-submit-color">Zaakceptuj wszystkie</button><button type="button" class="btn pmcookie-show-submit pm-submit-required-color">Zatwierdź tylko wymagane</button></div><div class="jconfirm-clear"></div></div></div></div></div></div></div></div></div></div></body></html>

--- a/spec.md
+++ b/spec.md
@@ -1132,7 +1132,12 @@ test-БД, §3.2 «no `await` ⇒ no race», §3.3 визначення «extern
   (Piwne Mosty IdoSell SSR — `.product`, brewery/title з GA
   `view_item_list` metadata keyed by `data-product_id`, fallback на visible title
   `"{brewery}: {name} - puszka/butelka N ml"`; категорії `/pol_m_PRZEKASKI*` і
-  `/pol_m_SZKLO-I-MERCH*` є whole-page non-beer gate), домен `piwnemosty.pl`.
+  `/pol_m_SZKLO-I-MERCH*` є whole-page non-beer gate), домен `piwnemosty.pl`),
+  `funkyshop` (Funkyshop PrestaShop SSR — `article.product-miniature`, назва з
+  `.product-title`, brewery з `.manufacturer-product`, ABV із `.product-description-short`,
+  trailing package volume прибирається з name; glass/merch категорії `/pl/17-szklomerch`
+  і `/en/17-glassmerch` є whole-page non-beer gate; локально відкидаються set/glassware
+  products), домен `funkyshop.pl`.
   `registry.pickAdapter(url)`.
   Опційний `reRenderContainerSelector` —
   **звуження скоупу re-parse**, НЕ вмикач re-render (див. нижче). Як додати


### PR DESCRIPTION
## Summary

Funkyshop product grids are now supported by the browser extension, so users can see their beer status on `funkyshop.pl` alongside the existing supported shops.

The adapter parses the shop's PrestaShop cards, removes package-volume suffixes before matching, carries ABV from the product description, and skips the glass/merch category pages called out in ysilvestrov/warsaw-beer-bot#218. Captured live fixtures cover both the beer category and the glass/merch category, with conformance coverage ensuring the overlay re-badges after grid replacement.

Closes ysilvestrov/warsaw-beer-bot#218.

## Test Plan

- [x] `cd extension && npm test`
- [x] `cd extension && npm run typecheck`
- [x] `cd extension && npm run build`
- [x] `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-000000)
