### PR TITLE
fix(extension): strengthen Flasker brewery identity

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed Flasker parsing for more metadata-backed breweries and product families, including Copper Head, Lost Philosopher, and DE ZWARTE REGEL listings that previously fell back to first-word brewery guesses.
 - Added Funkyshop (funkyshop.pl) shop support. Glass/merch category pages are skipped so non-beer products are not matched.
 - Added Piwne Mosty (piwnemosty.pl) shop support. Snack and glass/merch category pages are skipped so non-beer products are not matched.
 

--- a/extension/src/sites/flasker.test.ts
+++ b/extension/src/sites/flasker.test.ts
@@ -73,6 +73,10 @@ describe('parseTitle', () => {
       { productTags: ['Imperial Stout'] },
       { productUrl: 'https://example.com/product/mad-mystery-beer/' },
       { productUrl: 'not a URL' },
+      {
+        productTags: ['Imperial Stout'],
+        productUrl: 'https://flasker.com.ua/product/unknown-mystery-beer-5-330ml/',
+      },
     ]) {
       expect(parseTitle('Mystery Beer 5% 330ml', evidence))
         .toEqual({ brewery: 'Mystery', name: 'Beer', abv: 5 });

--- a/extension/src/sites/flasker.test.ts
+++ b/extension/src/sites/flasker.test.ts
@@ -91,6 +91,35 @@ describe('parseTitle', () => {
     })).toEqual({ brewery: 'Mad Brew', name: 'Galaxy Juice', abv: 6 });
   });
 
+  it('keeps Lost Philosopher names under Mad Brew when tags identify the brewery', () => {
+    expect(parseTitle('The Lost Philosopher X 330ml', {
+      productTags: ['mad brew'],
+    })).toEqual({ brewery: 'Mad Brew', name: 'The Lost Philosopher X' });
+
+    expect(parseTitle('The Lost Philosopher Xmas Eve 10% [2025] 330ml', {
+      productTags: ['mad brew'],
+    })).toEqual({ brewery: 'Mad Brew', name: 'The Lost Philosopher Xmas Eve', abv: 10 });
+  });
+
+  it('uses the explicit Copper Head rule instead of splitting the first word', () => {
+    expect(parseTitle('Copper Head Royal Cookie 9% 0.33l', {
+      productTags: ['COPPER HEAD'],
+    })).toEqual({ brewery: 'Copper Head. Beer Workshop', name: 'Royal Cookie', abv: 9 });
+  });
+
+  it('uses Hoppy Hog product slugs when tags are missing', () => {
+    expect(parseTitle('Hoppy Hog Charred Memory IS 10% 330ml', {
+      productUrl: 'https://flasker.com.ua/product/hoppy-hog-charred-memory-is-10-330ml/',
+    })).toEqual({ brewery: 'Hoppy Hog Family Brewery', name: 'Charred Memory IS', abv: 10 });
+  });
+
+  it('uses known Mad Brew product-family slugs over misleading generic tags', () => {
+    expect(parseTitle('DE ZWARTE REGEL: Tweede Kring 6.5% 0.33', {
+      productTags: ['Vibrant Pour'],
+      productUrl: 'https://flasker.com.ua/product/предреліз-de-zwarte-regel-tweede-kring-6-5-0-33/',
+    })).toEqual({ brewery: 'Mad Brew', name: 'DE ZWARTE REGEL: Tweede Kring', abv: 6.5 });
+  });
+
   it('no abv → volume marks the head end', () => {
     expect(parseTitle('Orval {2025} 330ml')).toEqual({ brewery: 'Orval', name: '{2025}' });
   });
@@ -244,6 +273,31 @@ describe('flasker adapter', () => {
       brewery: 'Mad Brew',
       name: 'Barely Beer',
       abv: 0,
+    });
+  });
+
+  it('uses fixture metadata for known malformed Flasker identities', () => {
+    expect(findCard('flasker.table.html', 'The Lost Philosopher X')).toMatchObject({
+      brewery: 'Mad Brew',
+      name: 'The Lost Philosopher X',
+    });
+
+    expect(findCard('flasker.html', 'Royal Cookie')).toMatchObject({
+      brewery: 'Copper Head. Beer Workshop',
+      name: 'Royal Cookie',
+      abv: 9,
+    });
+
+    expect(findCard('flasker.table.html', 'DE ZWARTE REGEL: Tweede Kring')).toMatchObject({
+      brewery: 'Mad Brew',
+      name: 'DE ZWARTE REGEL: Tweede Kring',
+      abv: 6.5,
+    });
+
+    expect(findCard('flasker.table.html', 'Amber Ritual Hop Benediction')).toMatchObject({
+      brewery: 'VibrantPour',
+      name: 'Amber Ritual Hop Benediction',
+      abv: 8,
     });
   });
 

--- a/extension/src/sites/flasker.ts
+++ b/extension/src/sites/flasker.ts
@@ -35,6 +35,7 @@ interface BreweryRule {
   canonical: string;
   tags: string[];
   slugPrefixes: string[];
+  familySlugPrefixes?: string[];
   titleAliases: string[];
 }
 
@@ -49,7 +50,19 @@ const BREWERY_RULES: BreweryRule[] = [
     canonical: 'Mad Brew',
     tags: ['mad brew'],
     slugPrefixes: ['mad-brew-', 'mad-'],
+    familySlugPrefixes: [
+      'lost-philosopher-',
+      'the-lost-philosopher-',
+      'de-zwarte-regel-',
+      'предреліз-de-zwarte-regel-',
+    ],
     titleAliases: ['Mad Brew'],
+  },
+  {
+    canonical: 'Copper Head. Beer Workshop',
+    tags: ['copper head'],
+    slugPrefixes: ['copper-head-'],
+    titleAliases: ['Copper Head'],
   },
   {
     canonical: 'Flasker',
@@ -89,11 +102,18 @@ function uniqueRule(rules: BreweryRule[]): BreweryRule | null {
 }
 
 function resolveBreweryRule(evidence: FlaskerEvidence): BreweryRule | null {
+  const slug = productSlug(evidence.productUrl);
+  if (slug) {
+    const familyRules = BREWERY_RULES.filter((rule) =>
+      rule.familySlugPrefixes?.some((prefix) => slug.startsWith(prefix)),
+    );
+    if (familyRules.length > 0) return uniqueRule(familyRules);
+  }
+
   const tags = new Set((evidence.productTags ?? []).map(normalizeTag));
   const tagRules = BREWERY_RULES.filter((rule) => rule.tags.some((tag) => tags.has(tag)));
   if (tagRules.length > 0) return uniqueRule(tagRules);
 
-  const slug = productSlug(evidence.productUrl);
   if (!slug) return null;
   return uniqueRule(BREWERY_RULES.filter((rule) => rule.slugPrefixes.some((prefix) => slug.startsWith(prefix))));
 }

--- a/spec.md
+++ b/spec.md
@@ -1124,7 +1124,7 @@ test-БД, §3.2 «no `await` ⇒ no race», §3.3 визначення «extern
   домен `hoptimaal.com`), `flasker` (Flasker WooCommerce SSR — `li.product`/`h2.woocommerce-loop-product__title`
   (archive), `tr[data-title]` (Barn2 product table), `li.wc-block-grid__product` (block
   grid); brewery з explicit allowlist Flasker product-tag/product-slug metadata
-  (tag > slug), fallback — existing title parser (зазвичай перше слово, з відомою
+  (known product-family slug overrides > tag > brewery slug), fallback — existing title parser (зазвичай перше слово, з відомою
   обробкою two-word/parenthetical cases); відомий display-prefix brewery
   видаляється з name, leading `ПРЕДРЕЛІЗ`/`ПРЕДРЕДІЗ`/`ПРОБНИК:` labels теж;
   volume-gate: пиво завжди містить об'єм в ml/л/l, non-beer без об'єму


### PR DESCRIPTION
## Summary

Flasker listings that previously fell back to first-word brewery guesses now use explicit shop metadata for the affected brewery families. Lost Philosopher, Copper Head, Hoppy Hog slug-only rows, and DE ZWARTE REGEL entries resolve to the intended brewery/name pairs instead of malformed identities like `The — Lost Philosopher X` or `Copper — Head Royal Cookie`.

The fix stays narrow: it extends Flasker's local rule table with fixture-backed tags and product-family slug prefixes, without adding broad fuzzy brewery inference.

Closes #207.

## Validation

- `cd extension && npm test -- flasker.test.ts` -> 52 passed
- `cd extension && npm test` -> 328 passed
- `cd extension && npm run typecheck` -> passed
- `cd extension && npm run build` -> passed
- `git diff --check` -> clean

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)
