### PR TITLE
fix(ontap): reject parser-polluted tap identities

### DIFF
--- a/src/jobs/refresh-ontap.test.ts
+++ b/src/jobs/refresh-ontap.test.ts
@@ -148,6 +148,43 @@ describe('refreshOntap non-beer filtering', () => {
     expect(db.prepare("SELECT COUNT(*) AS n FROM match_links WHERE ontap_ref = 'N/A'").get())
       .toEqual({ n: 0 });
   });
+
+  test('drops ontap parser-polluted brewery-only and location rows before catalog writes', async () => {
+    const db = openDb(':memory:');
+    migrate(db);
+
+    const indexHtml = `
+      <div onclick="location.assign('https://polluted.ontap.pl/')">
+        <div class="panel-body">Polluted Pub 4 taps</div>
+      </div>
+    `;
+    const pubHtml = `
+      <html><head><meta property="og:title" content="Polluted Pub / ontap.pl"></head>
+      <body>
+        ${panel(1, 'Przetwórnia Chmielu Brewery', 'Przetwórnia Chmielu Brewery 5%', 'Pszeniczne')}
+        ${panel(2, 'Frankies Brewery', 'Frankies Brewery 4,5%', 'Svetlý Ležák')}
+        ${panel(3, 'W Brzesku Brewery', 'Žatecký Nealko 0%', 'Pilzner bezalkoholowy')}
+        ${panel(4, 'PINTA Brewery', 'PINTA Atak Chmielu 6%', 'West Coast IPA')}
+      </body></html>
+    `;
+    const http: Http = {
+      async get(url: string): Promise<string> {
+        if (url === 'https://ontap.pl/warszawa') return indexHtml;
+        if (url === 'https://polluted.ontap.pl/') return pubHtml;
+        throw new Error(`Unexpected URL ${url}`);
+      },
+    };
+
+    await refreshOntap({
+      db, log: silentLog, http, search: { search: async () => [] }, geocoder: async () => null,
+      lookupEnabled: false, cities: CITIES.filter((c) => c.slug === 'warszawa'),
+    });
+
+    const beers = db.prepare('SELECT brewery, name FROM beers ORDER BY id').all();
+    expect(beers).toEqual([
+      expect.objectContaining({ brewery: 'PINTA Brewery', name: 'PINTA Atak Chmielu' }),
+    ]);
+  });
 });
 
 function panel(

--- a/src/jobs/refresh-ontap.ts
+++ b/src/jobs/refresh-ontap.ts
@@ -5,7 +5,7 @@ import type { Geocoder } from '../sources/geocoder';
 import { parseOntapCityIndex, type IndexPub } from '../sources/ontap/index';
 import { CITIES, type City } from '../domain/cities';
 import { isOntapNonBeerTap } from '../sources/ontap/non-beer';
-import { isOntapEmptyTapRef, parsePubPage } from '../sources/ontap/pub';
+import { isOntapEmptyTapRef, normalizeOntapTapIdentity, parsePubPage } from '../sources/ontap/pub';
 import { upsertPub } from '../storage/pubs';
 import { createSnapshot, insertTaps } from '../storage/snapshots';
 import { upsertMatch } from '../storage/match_links';
@@ -96,8 +96,10 @@ export async function refreshOntap(deps: Deps): Promise<void> {
         const prepared = prepareCatalog(catalog);
         for (const t of taps) {
           if (isOntapEmptyTapRef(t.beer_ref)) continue;
-          const brewery = t.brewery_ref ?? t.beer_ref.split(/[—-]\s|:\s/)[0] ?? '';
-          const m = matchPrepared({ brewery, name: t.beer_ref, abv: t.abv }, prepared);
+          const identity = normalizeOntapTapIdentity(t.brewery_ref, t.beer_ref);
+          if (!identity) continue;
+          const { brewery, name } = identity;
+          const m = matchPrepared({ brewery, name, abv: t.abv }, prepared);
           let beerId: number;
           let isFreshOrphan = false;
           if (m) {
@@ -105,12 +107,12 @@ export async function refreshOntap(deps: Deps): Promise<void> {
             beerId = m.id;
           } else {
             beerId = upsertBeer(db, {
-              name: t.beer_ref,
+              name,
               brewery,
               style: t.style,
               abv: t.abv,
               rating_global: t.u_rating,
-              normalized_name: normalizeName(t.beer_ref),
+              normalized_name: normalizeName(name),
               normalized_brewery: normalizeBrewery(brewery),
             });
             upsertMatch(db, t.beer_ref, beerId, 1.0);

--- a/src/sources/ontap/pub.test.ts
+++ b/src/sources/ontap/pub.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { parsePubPage, extractBeerName, isOntapEmptyTapRef } from './pub';
+import { parsePubPage, extractBeerName, isOntapEmptyTapRef, normalizeOntapTapIdentity } from './pub';
 
 const html = fs.readFileSync(
   path.join(__dirname, '../../../tests/fixtures/ontap/beer-bones.html'),
@@ -74,6 +74,11 @@ describe('extractBeerName', () => {
     expect(extractBeerName('Salamander 6%', null)).toBe('Salamander');
   });
 
+  test('keeps anniversary degree marks that are part of the beer name', () => {
+    expect(extractBeerName('Birra Menabrea Brewery La 150° Bionda 4,8%', 'Birra Menabrea Brewery'))
+      .toBe('La 150° Bionda');
+  });
+
   test('strips brewery prefix when present', () => {
     expect(extractBeerName('Harpagan Brewery Buzdygan Rozkoszy 24°·8,5%', 'Harpagan Brewery'))
       .toBe('Buzdygan Rozkoszy');
@@ -92,5 +97,34 @@ describe('extractBeerName', () => {
 
   test('returns empty string when only brewery is present', () => {
     expect(extractBeerName('Pinta', 'Pinta')).toBe('');
+  });
+});
+
+describe('normalizeOntapTapIdentity', () => {
+  test('drops blank tap names before catalog writes', () => {
+    expect(normalizeOntapTapIdentity('Some Brewery', '')).toBeNull();
+    expect(normalizeOntapTapIdentity('Some Brewery', '   ')).toBeNull();
+  });
+
+  test('strips cider category and duplicate brewery prefix from Chyliczki names', () => {
+    expect(normalizeOntapTapIdentity('Chyliczki', 'Cydr Chyliczki - Japoński Sad'))
+      .toEqual({ brewery: 'Chyliczki', name: 'Japoński Sad' });
+  });
+
+  test('maps Cydr Dzik generic rows to the real cidery and product name', () => {
+    expect(normalizeOntapTapIdentity('CYDR DZIK', 'polski cydr'))
+      .toEqual({ brewery: 'Cydrownia', name: 'Dzik' });
+  });
+
+  test('drops brewery-only rows and known location/category brewery pollution', () => {
+    expect(normalizeOntapTapIdentity('Przetwórnia Chmielu Brewery', 'Przetwórnia Chmielu')).toBeNull();
+    expect(normalizeOntapTapIdentity('Frankies Brewery', 'Frankies')).toBeNull();
+    expect(normalizeOntapTapIdentity('W Brzesku Brewery', 'Žatecký Nealko')).toBeNull();
+    expect(normalizeOntapTapIdentity('vaisiu sultys', 'Cydr Gruszkowy')).toBeNull();
+  });
+
+  test('keeps unknown brewery/name shapes unchanged', () => {
+    expect(normalizeOntapTapIdentity('Unknown Brewery', 'Some New Beer'))
+      .toEqual({ brewery: 'Unknown Brewery', name: 'Some New Beer' });
   });
 });

--- a/src/sources/ontap/pub.ts
+++ b/src/sources/ontap/pub.ts
@@ -26,24 +26,86 @@ export function isOntapEmptyTapRef(beerRef: string): boolean {
   return beerRef.trim().toUpperCase() === 'N/A';
 }
 
+function escapeRegExp(raw: string): string {
+  return raw.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function compact(raw: string): string {
+  return raw.replace(/ /g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+function normalized(raw: string): string {
+  return compact(raw).toLowerCase();
+}
+
+function breweryCore(raw: string): string {
+  return compact(raw)
+    .replace(/\s+(?:brewery|browar|brasserie|brouwerij|brauerei|pivovar|birrificio)$/iu, '')
+    .trim();
+}
+
+function breweryPrefixes(breweryRef: string | null): string[] {
+  const brewery = compact(breweryRef ?? '');
+  return brewery ? [brewery] : [];
+}
+
 // Strip ABV/strength suffix and brewery prefix from h4 text.
 // h4Text typically looks like "Brewery Name BeerName 24°·8,5%" — we want
 // just "BeerName" so the matcher sees a canonical key.
 export function extractBeerName(h4Text: string, brewery_ref: string | null): string {
-  let s = h4Text;
-  // Truncate at the first ABV/strength pattern: "16°", "8.5%", "24°·5%".
-  const m = s.match(/^(.*?)\s+\d+(?:[.,]\d+)?\s*[°%]/);
-  if (m) s = m[1];
+  let s = compact(h4Text);
+  // Remove trailing strength only. Some beer names contain degree marks
+  // ("La 150° Bionda"), so truncating at the first ° corrupts the name.
+  s = s
+    .replace(/\s+(?:\d{1,2}(?:[.,]\d+)?\s*°\s*[·•]\s*)?\d+(?:[.,]\d+)?\s*%(?:\s*[—-].*)?$/u, '')
+    .replace(/\s+\d{1,2}(?:[.,]\d+)?\s*°$/u, '')
+    .trim();
   // Drop a leading brewery prefix when present.
-  if (brewery_ref) {
-    const brl = brewery_ref.toLowerCase();
-    if (s.toLowerCase().startsWith(brl + ' ')) {
-      s = s.slice(brl.length + 1);
+  for (const prefix of breweryPrefixes(brewery_ref)) {
+    const brl = prefix.toLowerCase();
+    if (s.toLowerCase().startsWith(`${brl} `)) {
+      s = s.slice(prefix.length + 1);
+      break;
     } else if (s.toLowerCase() === brl) {
       s = '';
+      break;
     }
   }
   return s.trim();
+}
+
+const POLLUTED_BREWERIES = new Set([
+  // Exact parser-polluted production sentinels from #235. Keep this narrow:
+  // returning null here means refreshOntap will skip catalog/enrich writes.
+  'w brzesku brewery',
+  'vaisiu sultys',
+]);
+
+export function normalizeOntapTapIdentity(
+  breweryRef: string | null,
+  beerRef: string,
+): { brewery: string; name: string } | null {
+  const brewery = compact(breweryRef ?? '');
+  let name = compact(beerRef);
+  if (!name) return null;
+
+  const breweryNorm = normalized(brewery);
+  if (POLLUTED_BREWERIES.has(breweryNorm)) return null;
+
+  const core = breweryCore(brewery);
+  if (core && normalized(name) === normalized(core)) return null;
+
+  if (breweryNorm === 'cydr dzik' && normalized(name) === 'polski cydr') {
+    return { brewery: 'Cydrownia', name: 'Dzik' };
+  }
+
+  if (core) {
+    const ciderPrefix = new RegExp(`^(?:cydr|cider)\\s+${escapeRegExp(core)}\\s*[-–—:]\\s*`, 'iu');
+    const stripped = name.replace(ciderPrefix, '').trim();
+    if (stripped) name = stripped;
+  }
+
+  return { brewery, name };
 }
 
 export function parsePubPage(html: string): ParsedPubPage {
@@ -93,7 +155,8 @@ export function parsePubPage(html: string): ParsedPubPage {
 
     const subtitle = row.find('span.cml_shadow > b').first().text()
       .replace(/ /g, ' ').replace(/\s+/g, ' ').trim();
-    const beer_ref = extractBeerName(h4Text, brewery_ref) || h4Text;
+    const extractedBeerName = extractBeerName(h4Text, brewery_ref);
+    const beer_ref = extractedBeerName || (brewery_ref ? '' : h4Text);
     const style = subtitle || null;
 
     let ibu: number | null = null;


### PR DESCRIPTION
## Summary
Ontap ingest now rejects the parser-polluted tap identities that were becoming permanent orphan beers: brewery-only rows, known location/category brewery values, duplicate cider prefixes, and the generic Cydr Dzik listing. It also preserves anniversary degree marks inside names like `La 150° Bionda` while still trimming trailing strength/style suffixes.

Raw tap refs stay unchanged for snapshot and `match_links` joins; only the identity sent to matching/catalog upsert is cleaned or dropped.

Fixes #235.

## Validation
- `npm run typecheck`
- `npm test` (103 files, 1030 tests)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)
