### PR TITLE
fix(extension): ignore Piwne Mosty OOS placeholders

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fixed Piwne Mosty parsing so out-of-stock placeholders such as "Chwilowy brak:(" and "Wypite" are ignored instead of being sent as brewery or beer names.
+
 ## [0.10.0] - 2026-06-30
 
 - Fixed Flasker parsing for more metadata-backed breweries and product families, including Copper Head, Lost Philosopher, and DE ZWARTE REGEL listings that previously fell back to first-word brewery guesses.

--- a/extension/src/sites/piwnemosty.test.ts
+++ b/extension/src/sites/piwnemosty.test.ts
@@ -24,6 +24,36 @@ function withVisibleTitle(source: string, productId: string, title: string): str
   return doc.documentElement.outerHTML;
 }
 
+function productHtml({
+  id,
+  title,
+  brand,
+}: {
+  id: string;
+  title: string;
+  brand: string;
+}): string {
+  return `
+    <div id="search" class="products">
+      <div class="product" data-product_id="${id}">
+        <a class="product__name" title="${title}">${title}</a>
+      </div>
+    </div>
+    <script>
+      gtag("event", "view_item_list", {
+        "items": [
+          {
+            "item_id": "${id}",
+            "item_name": "${title}",
+            "item_brand": "${brand}",
+            "item_category": "Piwo"
+          }
+        ]
+      });
+    </script>
+  `;
+}
+
 let cards: ReturnType<typeof piwnemosty.parseCards>;
 beforeAll(() => {
   cards = piwnemosty.parseCards(new DOMParser().parseFromString(html, 'text/html'));
@@ -72,6 +102,91 @@ describe('piwnemosty adapter', () => {
         name: 'x Upside Down: Road to Upside',
       }),
     );
+  });
+
+  it('skips cards that only contain out-of-stock placeholders', () => {
+    const doc = new DOMParser().parseFromString(
+      productHtml({
+        id: '31622',
+        title: 'Wypite',
+        brand: 'Chwilowy Brak:( Brewery',
+      }),
+      'text/html',
+    );
+
+    expect(piwnemosty.parseCards(doc)).toEqual([]);
+  });
+
+  it('strips out-of-stock placeholders while keeping the real beer title', () => {
+    const doc = new DOMParser().parseFromString(
+      productHtml({
+        id: '30931',
+        title: 'Guinness Chwilowy brak:(',
+        brand: '-',
+      }),
+      'text/html',
+    );
+
+    expect(piwnemosty.parseCards(doc)).toEqual([
+      expect.objectContaining({
+        brewery: '',
+        name: 'Guinness',
+      }),
+    ]);
+  });
+
+  it('strips multiple out-of-stock placeholders from a real beer title', () => {
+    const doc = new DOMParser().parseFromString(
+      productHtml({
+        id: '30933',
+        title: 'Guinness Chwilowy brak:( Wypite',
+        brand: '-',
+      }),
+      'text/html',
+    );
+
+    expect(piwnemosty.parseCards(doc)).toEqual([
+      expect.objectContaining({
+        brewery: '',
+        name: 'Guinness',
+      }),
+    ]);
+  });
+
+  it('keeps an exact Brewery brand when it did not come from an out-of-stock placeholder', () => {
+    const doc = new DOMParser().parseFromString(
+      productHtml({
+        id: '30934',
+        title: 'Brewery: House Lager',
+        brand: 'Brewery',
+      }),
+      'text/html',
+    );
+
+    expect(piwnemosty.parseCards(doc)).toEqual([
+      expect.objectContaining({
+        brewery: 'Brewery',
+        name: 'House Lager',
+      }),
+    ]);
+  });
+
+  it('keeps valid titles that only contain one out-of-stock marker word', () => {
+    const doc = new DOMParser().parseFromString(
+      productHtml({
+        id: '30932',
+        title: 'Chwilowy Porter: Brak Point',
+        brand: 'Browar Chwilowy',
+      }),
+      'text/html',
+    );
+
+    expect(piwnemosty.parseCards(doc)).toEqual([
+      expect.objectContaining({
+        brewery: 'Browar Chwilowy',
+        name: 'Porter: Brak Point',
+      }),
+    ]);
   });
 
   it('treats the issue-listed snack and merch categories as whole non-beer pages', () => {

--- a/extension/src/sites/piwnemosty.ts
+++ b/extension/src/sites/piwnemosty.ts
@@ -14,6 +14,8 @@ const NON_BEER_PAGE_RE = /\/pol_m_(?:PRZEKASKI|SZKLO-I-MERCH)(?:[-_/]|$)/i;
 const NON_BEER_TITLE_RE = /\b(?:bon podarunkowy|chipsy|orzeszki|paluchy|plecak|shaker|szkło|t-shirt|torba)\b/i;
 const PACKAGING_SUFFIX_RE = /\s+-\s+(?:butelka|puszka)\s+\d+\s*ml\s*$/i;
 const BROWAR_PREFIX_RE = /^browar\s+/i;
+const OUT_OF_STOCK_MARKER_RE = /\bchwilowy\s+brak\s*:?\s*\(?|\bwypite\b/gi;
+const PLACEHOLDER_BREWERY_RE = /^-$/;
 
 function text(el: Element | null | undefined): string {
   return el?.textContent?.replace(/\s+/g, ' ').trim() ?? '';
@@ -25,6 +27,23 @@ function normalize(raw: string): string {
 
 function brandName(raw: string): string {
   return raw.replace(BROWAR_PREFIX_RE, '').trim();
+}
+
+function tidy(raw: string): string {
+  return raw.replace(/\s+/g, ' ').replace(/^[\s:()\-]+|[\s:()\-]+$/g, '').trim();
+}
+
+function stripOutOfStockMarkers(raw: string): string {
+  const stripped = raw.replace(OUT_OF_STOCK_MARKER_RE, ' ');
+  return stripped === raw ? raw.replace(/\s+/g, ' ').trim() : tidy(stripped);
+}
+
+function cleanBrewery(raw: string | undefined): string {
+  const value = raw ?? '';
+  const stripped = value.replace(OUT_OF_STOCK_MARKER_RE, ' ');
+  const brewery = stripped === value ? value.replace(/\s+/g, ' ').trim() : tidy(stripped);
+  if (stripped !== value && /^brewery$/i.test(brewery)) return '';
+  return PLACEHOLDER_BREWERY_RE.test(brewery) ? '' : brewery;
 }
 
 function itemMetadata(root: ParentNode): Map<string, ItemMeta> {
@@ -49,7 +68,7 @@ function itemMetadata(root: ParentNode): Map<string, ItemMeta> {
 }
 
 function cleanTitle(rawTitle: string, brewery: string): string {
-  const title = rawTitle.replace(PACKAGING_SUFFIX_RE, '').trim();
+  const title = stripOutOfStockMarkers(rawTitle).replace(PACKAGING_SUFFIX_RE, '').trim();
   const colon = title.indexOf(':');
   if (colon < 0) return title;
 
@@ -68,10 +87,10 @@ function cleanTitle(rawTitle: string, brewery: string): string {
 }
 
 function splitVisibleTitle(rawTitle: string): { brewery: string; name: string } {
-  const title = rawTitle.replace(PACKAGING_SUFFIX_RE, '').trim();
+  const title = stripOutOfStockMarkers(rawTitle).replace(PACKAGING_SUFFIX_RE, '').trim();
   const colon = title.indexOf(':');
   if (colon < 0) return { brewery: '', name: title };
-  const brewery = title.slice(0, colon).trim();
+  const brewery = cleanBrewery(title.slice(0, colon));
   return { brewery, name: cleanTitle(title, brewery) };
 }
 
@@ -100,11 +119,12 @@ export const piwnemosty: SiteAdapter = {
       const id = el.getAttribute('data-product_id') ?? '';
       const item = meta.get(id);
       const rawTitle = item?.item_name?.trim() || text(el.querySelector('.product__name'));
-      if (!rawTitle || isNonBeerCard(rawTitle, item)) continue;
+      const title = stripOutOfStockMarkers(rawTitle);
+      if (!title || isNonBeerCard(title, item)) continue;
 
-      const visible = splitVisibleTitle(rawTitle);
-      const brewery = item?.item_brand?.trim() || visible.brewery;
-      const name = cleanTitle(rawTitle, brewery);
+      const visible = splitVisibleTitle(title);
+      const brewery = cleanBrewery(item?.item_brand) || visible.brewery;
+      const name = cleanTitle(title, brewery);
       if (!name) continue;
 
       cards.push({ el, brewery, name });


### PR DESCRIPTION
## Summary

Piwne Mosty out-of-stock labels no longer become fake beer identities. Cards that only contain placeholders such as `Chwilowy brak:(` or `Wypite` are skipped, while titles that still contain a real beer name keep that name after the placeholder is stripped.

The parser also treats a bare `-` or placeholder-only brand as missing brewery data instead of sending it to `/match`.

Fixes #248.

## Validation

- `npm test -- src/sites/piwnemosty.test.ts`
- `npm test`
- `npm run typecheck`
- `npm run build`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5_Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
