### PR TITLE
fix(ontap): normalize cider producer identities

### DIFF
--- a/src/jobs/refresh-ontap.test.ts
+++ b/src/jobs/refresh-ontap.test.ts
@@ -185,6 +185,46 @@ describe('refreshOntap non-beer filtering', () => {
       expect.objectContaining({ brewery: 'PINTA Brewery', name: 'PINTA Atak Chmielu' }),
     ]);
   });
+
+  test('writes normalized cider producer identities instead of ontap product-line breweries', async () => {
+    const db = openDb(':memory:');
+    migrate(db);
+
+    const indexHtml = `
+      <div onclick="location.assign('https://cider.ontap.pl/')">
+        <div class="panel-body">Cider Pub 2 taps</div>
+      </div>
+    `;
+    const pubHtml = `
+      <html><head><meta property="og:title" content="Cider Pub / ontap.pl"></head>
+      <body>
+        ${panel(1, 'CYDR DZIK Brewery', 'Cydr Jabłko 4,5%', 'Cydr Jabłkowy')}
+        ${panel(2, 'Cydr Flirt Tradycynis', 'Cydr malina i skórka pomarańczowa 5%', 'Cydr z gruszką')}
+      </body></html>
+    `;
+    const http: Http = {
+      async get(url: string): Promise<string> {
+        if (url === 'https://ontap.pl/warszawa') return indexHtml;
+        if (url === 'https://cider.ontap.pl/') return pubHtml;
+        throw new Error(`Unexpected URL ${url}`);
+      },
+    };
+
+    await refreshOntap({
+      db, log: silentLog, http, search: { search: async () => [] }, geocoder: async () => null,
+      lookupEnabled: false, cities: CITIES.filter((c) => c.slug === 'warszawa'),
+    });
+
+    const beers = db.prepare('SELECT brewery, name, style FROM beers ORDER BY id').all();
+    expect(beers).toEqual([
+      { brewery: 'Cydrownia', name: 'Dzik Jabłko', style: 'Cydr Jabłkowy' },
+      {
+        brewery: 'Kauno Alus',
+        name: 'Tradycynis Cydr Flirt malina i skórka pomarańczowa',
+        style: 'Cydr z gruszką',
+      },
+    ]);
+  });
 });
 
 function panel(

--- a/src/sources/ontap/pub.test.ts
+++ b/src/sources/ontap/pub.test.ts
@@ -116,6 +116,25 @@ describe('normalizeOntapTapIdentity', () => {
       .toEqual({ brewery: 'Cydrownia', name: 'Dzik' });
   });
 
+  test('maps Cydr Dzik fruit rows to the real cidery and product name', () => {
+    expect(normalizeOntapTapIdentity('CYDR DZIK Brewery', 'Cydr Jabłko'))
+      .toEqual({ brewery: 'Cydrownia', name: 'Dzik Jabłko' });
+    expect(normalizeOntapTapIdentity('CYDR DZIK Brewery', 'Jabłko'))
+      .toEqual({ brewery: 'Cydrownia', name: 'Dzik Jabłko' });
+    expect(normalizeOntapTapIdentity('CYDR DZIK', 'Cydr Gruszka'))
+      .toEqual({ brewery: 'Cydrownia', name: 'Dzik Gruszka' });
+  });
+
+  test('does not invent a Cydr Dzik product name from a bare cider label', () => {
+    expect(normalizeOntapTapIdentity('CYDR DZIK Brewery', 'Cydr'))
+      .toEqual({ brewery: 'CYDR DZIK Brewery', name: 'Cydr' });
+  });
+
+  test('maps Cydr Flirt Tradycynis rows to Kauno Alus product names', () => {
+    expect(normalizeOntapTapIdentity('Cydr Flirt Tradycynis', 'Cydr malina i skórka pomarańczowa'))
+      .toEqual({ brewery: 'Kauno Alus', name: 'Tradycynis Cydr Flirt malina i skórka pomarańczowa' });
+  });
+
   test('drops brewery-only rows and known location/category brewery pollution', () => {
     expect(normalizeOntapTapIdentity('Przetwórnia Chmielu Brewery', 'Przetwórnia Chmielu')).toBeNull();
     expect(normalizeOntapTapIdentity('Frankies Brewery', 'Frankies')).toBeNull();

--- a/src/sources/ontap/pub.ts
+++ b/src/sources/ontap/pub.ts
@@ -44,6 +44,10 @@ function breweryCore(raw: string): string {
     .trim();
 }
 
+function stripLeadingCider(raw: string): string {
+  return compact(raw).replace(/^(?:cydr|cider)(?:\s+|$)/iu, '').trim();
+}
+
 function breweryPrefixes(breweryRef: string | null): string[] {
   const brewery = compact(breweryRef ?? '');
   return brewery ? [brewery] : [];
@@ -95,8 +99,19 @@ export function normalizeOntapTapIdentity(
   const core = breweryCore(brewery);
   if (core && normalized(name) === normalized(core)) return null;
 
-  if (breweryNorm === 'cydr dzik' && normalized(name) === 'polski cydr') {
-    return { brewery: 'Cydrownia', name: 'Dzik' };
+  if (breweryNorm === 'cydr dzik' || breweryNorm === 'cydr dzik brewery') {
+    if (normalized(name) === 'polski cydr') return { brewery: 'Cydrownia', name: 'Dzik' };
+    const ciderName = stripLeadingCider(name);
+    if (!ciderName) return { brewery, name };
+    return { brewery: 'Cydrownia', name: `Dzik ${ciderName}` };
+  }
+
+  if (breweryNorm === 'cydr flirt tradycynis') {
+    const ciderName = stripLeadingCider(name);
+    return {
+      brewery: 'Kauno Alus',
+      name: ciderName ? `Tradycynis Cydr Flirt ${ciderName}` : 'Tradycynis Cydr Flirt',
+    };
   }
 
   if (core) {


### PR DESCRIPTION
## Summary
Cider rows where ontap puts a product line into the brewery slot now enter the catalog under the producer identity needed for Untappd lookup. The confirmed `CYDR DZIK` variants normalize to `Cydrownia / Dzik ...`, and the confirmed `Cydr Flirt Tradycynis` variant normalizes to `Kauno Alus / Tradycynis Cydr Flirt ...` instead of preserving the misleading ontap brewery text.

The change stays in the existing ontap identity-normalization layer rather than changing the DOM selector, because live ontap HTML already contains those product-line values in `.brewery`.

## Validation
- `npm test -- src/sources/ontap/pub.test.ts src/jobs/refresh-ontap.test.ts`
- `npm run typecheck`
- `npm test`

Related: #249

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
