### PR TITLE
fix(matcher): strip spec labels from normalized names

### DIFF
--- a/src/domain/normalize.test.ts
+++ b/src/domain/normalize.test.ts
@@ -17,6 +17,8 @@ test('normalizes brewery the same way, no style stripping', () => {
 test('strips numeric tokens (ABV / strength / years)', () => {
   // Real ontap-style raw string after baseNormalize splits punctuation.
   expect(normalizeName('Buzdygan Rozkoszy 24°·8,5%')).toBe('buzdygan rozkoszy');
+  expect(normalizeName('NoLo – Hemperor <0,5% alc <0,5%')).toBe('nolo hemperor');
+  expect(normalizeName('Light Lager 4.5% ABV 20 IBU')).toBe('light');
   // Year-only tokens — vintages of the same beer collapse to one key.
   expect(normalizeName('Buzdygan Rozkoszy 2026')).toBe('buzdygan rozkoszy');
   expect(normalizeName('Buzdygan Rozkoszy 2024')).toBe('buzdygan rozkoszy');

--- a/src/domain/normalize.ts
+++ b/src/domain/normalize.ts
@@ -4,6 +4,7 @@ const STYLE_WORDS = new Set([
   'pils', 'pilsner', 'lager', 'stout', 'porter', 'weizen', 'wheat',
   'saison', 'sour', 'gose', 'lambic', 'barleywine', 'bock',
 ]);
+const SPEC_LABEL_WORDS = new Set(['alc', 'abv', 'ibu']);
 export const BREWERY_NOISE = new Set([
   // English / Polish
   'browar', 'browary', 'brewery', 'brewing', 'co', 'company', 'contracts',
@@ -80,7 +81,7 @@ export function stripLegalForm(s: string): string {
 export function normalizeName(s: string): string {
   const tokens = baseNormalize(preserveDecimalIdentifiers(s))
     .split(' ')
-    .filter((t) => t && !STYLE_WORDS.has(t) && !isNumericNoise(t));
+    .filter((t) => t && !STYLE_WORDS.has(t) && !SPEC_LABEL_WORDS.has(t) && !isNumericNoise(t));
   return tokens.join(' ');
 }
 


### PR DESCRIPTION
## Summary
Noisy ABV/spec tails no longer make query-found Untappd candidates fail the downstream name match. Inputs like `NoLo – Hemperor <0,5% alc <0,5%` now normalize to the same name as the catalog candidate, so the fuzzy matcher does not reject the exact beer over a leftover `alc` token.

The change keeps the existing numeric ABV/year stripping path and only adds the spec-label words `alc`, `abv`, and `ibu` to beer-name normalization, matching the search-query cleanup already used for Algolia.

Fixes #240.

## Validation
- `npm run typecheck`
- `npm test`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
