### PR TITLE
fix(extension): clean Funkyshop orphan identities

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed Funkyshop parsing on English/home grids: product detail fallback now fills missing breweries, can/deposit rows are ignored, and trailing volume/format text is removed from beer names before matching.
 - Fixed Piwne Mosty parsing so out-of-stock placeholders such as "Chwilowy brak:(" and "Wypite" are ignored instead of being sent as brewery or beer names.
 - Extension now shows global Untappd ratings (⭐) on supported shops even without a token; the popup states "Не авторизовано" and links to token setup. Personal ✅/rating badges still require a token.
 

--- a/extension/src/content/index.test.ts
+++ b/extension/src/content/index.test.ts
@@ -69,6 +69,24 @@ describe('runOverlay', () => {
     expect(sendMatch).toHaveBeenCalledWith([{ brewery: 'FUNKY FLUID', name: 'Ambrosia 9.0', abv: 7.3 }]);
   });
 
+  it('uses the hydrated brewery identity for matching and cache writes', async () => {
+    vi.mocked(chrome.storage.local.set).mockClear();
+    const card: Card = { el: cardEl(), brewery: '', name: 'Aloha' };
+    const adapter = {
+      ...adapterFor([card]),
+      loadCardDetails: vi.fn(async (cards: Card[]) => {
+        cards[0].brewery = 'Funky Fluid';
+      }),
+    };
+    const sendMatch = vi.fn(async () => [drunkResult('Funky Fluid', 'Aloha')]);
+
+    await runOverlay(document, adapter, sendMatch);
+
+    expect(sendMatch).toHaveBeenCalledWith([{ brewery: 'Funky Fluid', name: 'Aloha' }]);
+    const storageSet = vi.mocked(chrome.storage.local.set).mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    expect(Object.keys(storageSet)).toEqual([`mc2:${normalizeKey('Funky Fluid', 'Aloha')}`]);
+  });
+
   it('awaits waitForGrid before parsing when the adapter defines it', async () => {
     const order: string[] = [];
     const card: Card = { el: cardEl(), brewery: 'B', name: 'N' };

--- a/extension/src/content/index.test.ts
+++ b/extension/src/content/index.test.ts
@@ -87,6 +87,21 @@ describe('runOverlay', () => {
     expect(Object.keys(storageSet)).toEqual([`mc2:${normalizeKey('Funky Fluid', 'Aloha')}`]);
   });
 
+  it('does not match cards skipped during detail loading', async () => {
+    const card: Card = { el: cardEl(), brewery: '', name: 'Aloha' };
+    const adapter = {
+      ...adapterFor([card]),
+      loadCardDetails: vi.fn(async (cards: Card[]) => {
+        cards[0].skip = true;
+      }),
+    };
+    const sendMatch = vi.fn(async () => [] as MatchResult[]);
+
+    await runOverlay(document, adapter, sendMatch);
+
+    expect(sendMatch).not.toHaveBeenCalled();
+  });
+
   it('awaits waitForGrid before parsing when the adapter defines it', async () => {
     const order: string[] = [];
     const card: Card = { el: cardEl(), brewery: 'B', name: 'N' };

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -35,13 +35,16 @@ export async function runOverlay(
 
     if (adapter.loadCardDetails) await adapter.loadCardDetails(misses.map((m) => m.card));
 
-    const rawMisses: { el: HTMLElement; key: string; raw: RawBeer }[] = misses.map(({ el, card }) => ({
-      el,
-      key: normalizeKey(card.brewery, card.name),
-      raw: card.abv !== undefined
-        ? { brewery: card.brewery, name: card.name, abv: card.abv }
-        : { brewery: card.brewery, name: card.name },
-    }));
+    const rawMisses: { el: HTMLElement; key: string; raw: RawBeer }[] = misses
+      .filter(({ card }) => !card.skip)
+      .map(({ el, card }) => ({
+        el,
+        key: normalizeKey(card.brewery, card.name),
+        raw: card.abv !== undefined
+          ? { brewery: card.brewery, name: card.name, abv: card.abv }
+          : { brewery: card.brewery, name: card.name },
+      }));
+    if (rawMisses.length === 0) return;
 
     let results: MatchResult[];
     try {

--- a/extension/src/content/index.ts
+++ b/extension/src/content/index.ts
@@ -35,9 +35,9 @@ export async function runOverlay(
 
     if (adapter.loadCardDetails) await adapter.loadCardDetails(misses.map((m) => m.card));
 
-    const rawMisses: { el: HTMLElement; key: string; raw: RawBeer }[] = misses.map(({ el, key, card }) => ({
+    const rawMisses: { el: HTMLElement; key: string; raw: RawBeer }[] = misses.map(({ el, card }) => ({
       el,
-      key,
+      key: normalizeKey(card.brewery, card.name),
       raw: card.abv !== undefined
         ? { brewery: card.brewery, name: card.name, abv: card.abv }
         : { brewery: card.brewery, name: card.name },

--- a/extension/src/sites/funkyshop.test.ts
+++ b/extension/src/sites/funkyshop.test.ts
@@ -144,4 +144,29 @@ describe('funkyshop adapter', () => {
     expect(cards[0]).toMatchObject({ brewery: '', name: 'Aloha', skip: true });
     fetchSpy.mockRestore();
   });
+
+  it('shares one detail fetch across cards with the same product URL', async () => {
+    const cards = parse(`
+      <article class="product-miniature">
+        <p class="h3 product-title"><a href="https://funkyshop.pl/en/funky-shop/shared.html">Aloha 500ml</a></p>
+        <div class="product-description-short">Fruited Sour, 4.5%</div>
+      </article>
+      <article class="product-miniature">
+        <p class="h3 product-title"><a href="https://funkyshop.pl/en/funky-shop/shared.html">Free Classy 500ml</a></p>
+        <div class="product-description-short">West Coast IPA, 6%</div>
+      </article>
+    `);
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      text: async () => '<a class="manufacturer-product">Funky Fluid</a>',
+    } as Response);
+
+    await funkyshop.loadCardDetails?.(cards);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(cards.map((card) => card.brewery)).toEqual(['Funky Fluid', 'Funky Fluid']);
+    expect(cards.map((card) => card.skip)).toEqual([undefined, undefined]);
+    fetchSpy.mockRestore();
+  });
 });

--- a/extension/src/sites/funkyshop.test.ts
+++ b/extension/src/sites/funkyshop.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { funkyshop } from './funkyshop';
@@ -55,5 +55,74 @@ describe('funkyshop adapter', () => {
 
   it('drops glass and merch products from the non-beer fixture', () => {
     expect(parse(nonBeerHtml)).toEqual([]);
+  });
+
+  it('strips trailing volume plus can format from product names', () => {
+    const cards = parse(`
+      <article class="product-miniature">
+        <p class="h3 product-title"><a href="/en/funky-shop/free-classy.html">Free Classy 500ml (can)</a></p>
+        <a class="manufacturer-product">Funky Fluid</a>
+        <div class="product-description-short">West Coast IPA, 6%</div>
+      </article>
+    `);
+
+    expect(cards).toContainEqual(expect.objectContaining({
+      brewery: 'Funky Fluid',
+      name: 'Free Classy',
+      abv: 6,
+    }));
+  });
+
+  it('strips trailing volume plus product-detail parentheses from names', () => {
+    const cards = parse(`
+      <article class="product-miniature">
+        <p class="h3 product-title"><a href="/en/funky-shop/gelato.html">Gelato XTREME: Jungle Juice Slushy XXL 500ml (6th Anniversary 450 North collab)</a></p>
+        <a class="manufacturer-product">Funky Fluid</a>
+        <div class="product-description-short">Multifruit XTREME Ice Cream Sour, 8%</div>
+      </article>
+    `);
+
+    expect(cards).toContainEqual(expect.objectContaining({
+      brewery: 'Funky Fluid',
+      name: 'Gelato XTREME: Jungle Juice Slushy XXL',
+      abv: 8,
+    }));
+  });
+
+  it('drops can deposit fee rows from mixed product grids', () => {
+    const cards = parse(`
+      <article class="product-miniature">
+        <p class="h3 product-title"><a href="/en/funky-shop/can-deposit.html">Can Deposit</a></p>
+        <div class="product-description-short">Deposit fee</div>
+      </article>
+    `);
+
+    expect(cards).toEqual([]);
+  });
+
+  it('hydrates missing brewery from the product detail page', async () => {
+    const cards = parse(`
+      <article class="product-miniature">
+        <p class="h3 product-title"><a href="https://funkyshop.pl/en/funky-shop/aloha.html">Aloha 500ml</a></p>
+        <div class="product-description-short">Fruited Sour, 4.5%</div>
+      </article>
+    `);
+
+    expect(cards[0]).toMatchObject({ brewery: '', name: 'Aloha' });
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      text: async () => `
+        <html><body>
+          <a class="manufacturer-product">Funky Fluid</a>
+        </body></html>
+      `,
+    } as Response);
+
+    await funkyshop.loadCardDetails?.(cards);
+
+    expect(fetchSpy).toHaveBeenCalledWith('https://funkyshop.pl/en/funky-shop/aloha.html', { credentials: 'include' });
+    expect(cards[0]).toMatchObject({ brewery: 'Funky Fluid', name: 'Aloha', abv: 4.5 });
+    fetchSpy.mockRestore();
   });
 });

--- a/extension/src/sites/funkyshop.test.ts
+++ b/extension/src/sites/funkyshop.test.ts
@@ -125,4 +125,23 @@ describe('funkyshop adapter', () => {
     expect(cards[0]).toMatchObject({ brewery: 'Funky Fluid', name: 'Aloha', abv: 4.5 });
     fetchSpy.mockRestore();
   });
+
+  it('skips cards when a missing brewery cannot be hydrated', async () => {
+    const cards = parse(`
+      <article class="product-miniature">
+        <p class="h3 product-title"><a href="https://funkyshop.pl/en/funky-shop/missing-brewery.html">Aloha 500ml</a></p>
+        <div class="product-description-short">Fruited Sour, 4.5%</div>
+      </article>
+    `);
+
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      text: async () => '',
+    } as Response);
+
+    await funkyshop.loadCardDetails?.(cards);
+
+    expect(cards[0]).toMatchObject({ brewery: '', name: 'Aloha', skip: true });
+    fetchSpy.mockRestore();
+  });
 });

--- a/extension/src/sites/funkyshop.ts
+++ b/extension/src/sites/funkyshop.ts
@@ -92,7 +92,11 @@ export const funkyshop: SiteAdapter = {
       const url = detailUrls.get(card.el);
       if (!url) return;
       const brewery = await loadBrewery(url);
-      if (brewery) card.brewery = brewery;
+      if (brewery) {
+        card.brewery = brewery;
+      } else {
+        card.skip = true;
+      }
     }));
   },
 };

--- a/extension/src/sites/funkyshop.ts
+++ b/extension/src/sites/funkyshop.ts
@@ -3,9 +3,12 @@ import { isNonBeerName } from './non-beer';
 
 const CARD_SELECTOR = 'article.product-miniature';
 const NON_BEER_PAGE_RE = /\/(?:pl\/17-szklomerch|en\/17-glassmerch)(?:[/?#]|$)/i;
-const NON_BEER_TITLE_RE = /(?:\bset\b|szklank|kufel|pokal|glass|merch|rastal|sahm)/iu;
-const VOLUME_SUFFIX_RE = /\s+(?:\(?\d+\s*x\s*)?\d+(?:[.,]\d+)?\s*(?:ml|l)\)?\s*$/i;
+const NON_BEER_TITLE_RE = /(?:\bset\b|szklank|kufel|pokal|glass|merch|rastal|sahm|\bcan\s+deposit\b|\bdeposit\s+fee\b)/iu;
+const VOLUME_SUFFIX_RE = /\s+(?:\(?\d+\s*x\s*)?\d+(?:[.,]\d+)?\s*(?:ml|l)\)?(?:\s*\([^)]*\))?\s*$/i;
 const ABV_RE = /(\d+(?:[.,]\d+)?)\s*%/u;
+const MAX_DETAIL_FETCHES_PER_PASS = 20;
+const detailUrls = new WeakMap<HTMLElement, string>();
+const breweryByUrl = new Map<string, Promise<string | undefined>>();
 
 function text(el: Element | null | undefined): string {
   return el?.textContent?.replace(/\s+/g, ' ').trim() ?? '';
@@ -27,6 +30,32 @@ function isNonBeerTitle(rawName: string, description: string): boolean {
   return isNonBeerName(rawName) || NON_BEER_TITLE_RE.test(rawName) || NON_BEER_TITLE_RE.test(description);
 }
 
+function absoluteUrl(raw: string | null | undefined): string | undefined {
+  if (!raw) return undefined;
+  try {
+    return new URL(raw, 'https://funkyshop.pl').href;
+  } catch {
+    return undefined;
+  }
+}
+
+function loadBrewery(url: string): Promise<string | undefined> {
+  const cached = breweryByUrl.get(url);
+  if (cached) return cached;
+  if (typeof fetch !== 'function') return Promise.resolve(undefined);
+
+  const promise = fetch(url, { credentials: 'include' })
+    .then(async (res) => {
+      if (!res.ok) return undefined;
+      const html = await res.text();
+      const doc = new DOMParser().parseFromString(html, 'text/html');
+      return text(doc.querySelector('.manufacturer-product')) || undefined;
+    })
+    .catch(() => undefined);
+  breweryByUrl.set(url, promise);
+  return promise;
+}
+
 export const funkyshop: SiteAdapter = {
   id: 'funkyshop',
   hostMatch: (url) => url.hostname === 'funkyshop.pl' || url.hostname.endsWith('.funkyshop.pl'),
@@ -46,9 +75,24 @@ export const funkyshop: SiteAdapter = {
       if (!name) continue;
 
       const abv = parseAbv(description);
+      const url = absoluteUrl(el.querySelector<HTMLAnchorElement>('.product-title a')?.getAttribute('href'));
+      if (!brewery && url) detailUrls.set(el, url);
       cards.push(abv == null ? { el, brewery, name } : { el, brewery, name, abv });
     }
 
     return cards;
+  },
+
+  async loadCardDetails(cards) {
+    const limited = cards
+      .filter((card) => !card.brewery && detailUrls.has(card.el))
+      .slice(0, MAX_DETAIL_FETCHES_PER_PASS);
+
+    await Promise.all(limited.map(async (card) => {
+      const url = detailUrls.get(card.el);
+      if (!url) return;
+      const brewery = await loadBrewery(url);
+      if (brewery) card.brewery = brewery;
+    }));
   },
 };

--- a/extension/src/sites/types.ts
+++ b/extension/src/sites/types.ts
@@ -3,6 +3,7 @@ export interface Card {
   brewery: string;
   name: string;
   abv?: number;
+  skip?: boolean;
 }
 
 export interface SiteAdapter {

--- a/spec.md
+++ b/spec.md
@@ -1200,10 +1200,10 @@ test-БД, §3.2 «no `await` ⇒ no race», §3.3 визначення «extern
   `"{brewery}: {name} - puszka/butelka N ml"`; категорії `/pol_m_PRZEKASKI*` і
   `/pol_m_SZKLO-I-MERCH*` є whole-page non-beer gate), домен `piwnemosty.pl`),
   `funkyshop` (Funkyshop PrestaShop SSR — `article.product-miniature`, назва з
-  `.product-title`, brewery з `.manufacturer-product`, ABV із `.product-description-short`,
-  trailing package volume прибирається з name; glass/merch категорії `/pl/17-szklomerch`
-  і `/en/17-glassmerch` є whole-page non-beer gate; локально відкидаються set/glassware
-  products), домен `funkyshop.pl`.
+  `.product-title`, brewery з `.manufacturer-product` або bounded detail-page fallback,
+  ABV із `.product-description-short`, trailing package volume/format прибирається з name;
+  glass/merch категорії `/pl/17-szklomerch` і `/en/17-glassmerch` є whole-page non-beer
+  gate; локально відкидаються set/glassware/deposit products), домен `funkyshop.pl`.
   `registry.pickAdapter(url)`.
   Опційний `reRenderContainerSelector` —
   **звуження скоупу re-parse**, НЕ вмикач re-render (див. нижче). Як додати


### PR DESCRIPTION
## Summary

Funkyshop product grids no longer send clean beers to matching with empty or polluted identities. The adapter now strips trailing package/format text, filters can-deposit fee rows, and hydrates missing breweries from the product detail page before matching.

The overlay cache now keys hydrated cards by the post-detail brewery/name identity, so a recovered Funkyshop brewery is not cached under an empty-brewery key. Cards whose Funkyshop brewery still cannot be recovered are skipped instead of creating empty-brewery orphan rows.

## Related

Related: #255

## Validation

- `npm test -- src/sites/funkyshop.test.ts src/content/index.test.ts src/sites/conformance.test.ts` (67 passed)
- `npm run typecheck`
- `npm test` in `extension/` (350 passed)
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
