### PR TITLE
fix(extension): reject BeerFreak bundle listings

### DIFF
--- a/docs/superpowers/plans/2026-07-12-beerfreak-bundle-filtering.md
+++ b/docs/superpowers/plans/2026-07-12-beerfreak-bundle-filtering.md
@@ -1,0 +1,168 @@
+# BeerFreak Bundle Filtering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop BeerFreak tasting sets and multi-beer packs from entering matching and orphan enrichment as individual beers.
+
+**Architecture:** Add a private, BeerFreak-specific title predicate in the existing adapter and apply it at the current early non-beer gate. Keep the shared non-beer helper unchanged so other adapters retain their current behavior.
+
+**Tech Stack:** TypeScript, Vitest, DOMParser/jsdom, Vite browser-extension build
+
+---
+
+### Task 1: Reject BeerFreak bundle title shapes
+
+**Files:**
+- Modify: `extension/src/sites/beerfreak.test.ts`
+- Modify: `extension/src/sites/beerfreak.ts`
+
+- [ ] **Step 1: Write failing tests for reported and stated bundle patterns**
+
+Add this focused test after the existing brandless-title tests in
+`extension/src/sites/beerfreak.test.ts`:
+
+```ts
+it('drops BeerFreak tasting sets and multi-beer packs', () => {
+  const parsed = beerfreak.parseCards(docWithProducts([
+    { id: 29993, brand_title: 'FUNKY FLUID (Польща)', title: 'WORLD CUP SERIES - 5 SPECIAL BEER' },
+    { id: 31072, brand_title: 'ГОНІР - HONIR BREWERY (Україна)', title: 'Дегустаціний сет від Honir Brewery' },
+    { id: 31073, brand_title: 'Example Brewery', title: 'Example Brewery Mix Pack' },
+    { id: 31074, brand_title: 'Example Brewery', title: 'Example Brewery Tasting Set' },
+  ]));
+
+  expect(parsed).toEqual([]);
+});
+```
+
+Add a separate false-positive guard:
+
+```ts
+it('keeps legitimate BeerFreak beers with incidental set-like substrings', () => {
+  const parsed = beerfreak.parseCards(docWithProducts([
+    { id: 31075, brand_title: 'Sunset Brew', title: 'Sunset Brew Sunset Boulevard' },
+    { id: 31076, brand_title: 'Reset Brewing', title: 'Reset Brewing Reset IPA' },
+    { id: 31077, brand_title: 'Series Brewing', title: 'Series Brewing Special Beer' },
+  ]));
+
+  expect(parsed.map(({ brewery, name }) => ({ brewery, name }))).toEqual([
+    { brewery: 'Sunset Brew', name: 'Sunset Boulevard' },
+    { brewery: 'Reset Brewing', name: 'Reset IPA' },
+    { brewery: 'Series Brewing', name: 'Special Beer' },
+  ]);
+});
+```
+
+- [ ] **Step 2: Run the focused test to verify RED**
+
+Run from `extension/`:
+
+```bash
+npm test -- src/sites/beerfreak.test.ts
+```
+
+Expected: the new bundle test fails because the reported products are returned as
+cards; the false-positive guard passes.
+
+- [ ] **Step 3: Implement the minimal BeerFreak-local predicate**
+
+In `extension/src/sites/beerfreak.ts`, add boundary-aware expressions near the other
+adapter constants:
+
+```ts
+const BEERFREAK_BUNDLE_RE = /(?:^|[^\p{L}\p{N}])(?:mix\s+pack|tasting\s+set|set|сет)(?=$|[^\p{L}\p{N}])/iu;
+const BEERFREAK_NUMBERED_SERIES_RE = /(?:^|[^\p{L}\p{N}])series\s*[-:]?\s*\d+\s+special\s+beers?(?=$|[^\p{L}\p{N}])/iu;
+```
+
+Add the private predicate:
+
+```ts
+function isBeerfreakBundleTitle(rawTitle: string): boolean {
+  return BEERFREAK_BUNDLE_RE.test(rawTitle) || BEERFREAK_NUMBERED_SERIES_RE.test(rawTitle);
+}
+```
+
+Extend the existing early gate in `parseCards`:
+
+```ts
+if (isNonBeerName(rawTitle) || isBeerfreakBundleTitle(rawTitle)) continue;
+```
+
+Do not export the predicate and do not modify `extension/src/sites/non-beer.ts`.
+
+- [ ] **Step 4: Run the focused test to verify GREEN**
+
+Run from `extension/`:
+
+```bash
+npm test -- src/sites/beerfreak.test.ts
+```
+
+Expected: all BeerFreak tests pass, including both new tests.
+
+- [ ] **Step 5: Commit the parser and regression tests**
+
+```bash
+git add extension/src/sites/beerfreak.ts extension/src/sites/beerfreak.test.ts
+git commit -m "fix(extension): reject BeerFreak bundle listings"
+```
+
+### Task 2: Document and verify the extension change
+
+**Files:**
+- Modify: `spec.md`
+- Modify: `extension/CHANGELOG.md`
+
+- [ ] **Step 1: Update the browser-extension specification**
+
+In `spec.md` section 6, extend the BeerFreak adapter description so it explicitly says
+that tasting sets, mix packs, and numbered multi-beer series are rejected locally.
+Keep the wording within the existing BeerFreak parenthetical; do not change other
+adapter descriptions.
+
+- [ ] **Step 2: Update the extension changelog**
+
+Under `## [0.11.0] - 2026-07-10` in `extension/CHANGELOG.md`, add:
+
+```md
+- Fixed BeerFreak filtering so tasting sets, mix packs, and numbered multi-beer series are ignored instead of being matched as individual beers.
+```
+
+- [ ] **Step 3: Run complete verification**
+
+Run from `extension/`:
+
+```bash
+npm test
+npm run typecheck
+npm run build
+```
+
+Expected: the full Vitest suite passes, TypeScript reports no errors, and Vite plus the
+postbuild packaging step complete successfully.
+
+Run from the worktree root:
+
+```bash
+git diff --check
+```
+
+Expected: no output and exit status 0.
+
+- [ ] **Step 4: Commit documentation**
+
+```bash
+git add spec.md extension/CHANGELOG.md
+git commit -m "docs(extension): record BeerFreak bundle filtering"
+```
+
+- [ ] **Step 5: Inspect final scope**
+
+Run from the worktree root:
+
+```bash
+git status --short
+git diff --stat origin/main...HEAD
+```
+
+Expected: the worktree is clean and the diff contains only the approved design, this
+plan, BeerFreak adapter/tests, `spec.md`, and the extension changelog.

--- a/docs/superpowers/specs/2026-07-12-beerfreak-bundle-filtering-design.md
+++ b/docs/superpowers/specs/2026-07-12-beerfreak-bundle-filtering-design.md
@@ -1,0 +1,60 @@
+# BeerFreak Bundle Filtering Design
+
+**Issue:** #284  
+**Date:** 2026-07-12
+
+## Problem
+
+The BeerFreak adapter emits some bundle products as individual beers. In particular,
+the reported `WORLD CUP SERIES - 5 SPECIAL BEER` and `Дегустаціний сет від Honir
+Brewery` listings reach orphan enrichment even though neither represents one Untappd
+beer.
+
+The adapter already applies the shared `isNonBeerName` filter, but the shared patterns
+do not cover these BeerFreak-specific title forms.
+
+## Scope
+
+Add BeerFreak-local bundle detection. Do not change the shared non-beer helper or the
+behavior of other shop adapters.
+
+The filter must recognize:
+
+- standalone `set` and Cyrillic `сет` bundle wording, including Ukrainian tasting-set
+  titles;
+- `mix pack` wording;
+- numbered multi-beer series/special-beer constructions such as
+  `SERIES - 5 SPECIAL BEER`.
+
+Matching must be case-insensitive and boundary-aware. Incidental substrings inside a
+legitimate beer name must not cause rejection.
+
+## Design
+
+Add a small private BeerFreak title predicate alongside the adapter's existing parsing
+helpers. `parseCards` will reject a product when either the shared `isNonBeerName`
+helper or the BeerFreak-local predicate classifies its raw metadata/DOM title as a
+bundle.
+
+Filtering occurs before brewery/name parsing and before detail URLs are registered.
+Rejected products therefore never become cards, never trigger ABV detail fetches, and
+never reach matching or orphan enrichment.
+
+No registry, manifest, API, storage, or matcher changes are required.
+
+## Testing
+
+Use focused BeerFreak adapter tests with minimal product-card HTML and embedded product
+metadata. Tests will first reproduce the reported English and Ukrainian examples, then
+cover `mix pack` and boundary-sensitive false-positive guards for legitimate beer
+titles.
+
+Run the focused BeerFreak test file during the red/green cycle. After implementation,
+run the full extension test suite, typecheck/build commands defined by the extension,
+and `git diff --check`.
+
+## Documentation
+
+Update `spec.md` section 6 to state that BeerFreak locally rejects tasting sets and
+multi-beer packs. Update `extension/CHANGELOG.md` in the same change, as required for
+browser-extension modifications.

--- a/docs/superpowers/specs/2026-07-12-beerfreak-bundle-filtering-design.md
+++ b/docs/superpowers/specs/2026-07-12-beerfreak-bundle-filtering-design.md
@@ -1,6 +1,6 @@
 # BeerFreak Bundle Filtering Design
 
-**Issue:** #284  
+**Issue:** #284
 **Date:** 2026-07-12
 
 ## Problem

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [0.11.0] - 2026-07-10
 
 - Extension now shows global Untappd ratings (⭐) on supported shops even without a token; the popup shows a "Not connected" note and links to token setup. Personal ✅/rating badges still require a token.
+- Fixed BeerFreak filtering so tasting sets, mix packs, and numbered multi-beer series are ignored instead of being matched as individual beers.
 - Fixed Funkyshop parsing on English/home grids: product detail fallback now fills missing breweries, can/deposit rows are ignored, and trailing volume/format text is removed from beer names before matching.
 - Fixed Piwne Mosty parsing so out-of-stock placeholders such as "Chwilowy brak:(" and "Wypite" are ignored instead of being sent as brewery or beer names.
 

--- a/extension/src/sites/beerfreak.test.ts
+++ b/extension/src/sites/beerfreak.test.ts
@@ -145,6 +145,31 @@ describe('beerfreak adapter', () => {
     }));
   });
 
+  it('drops BeerFreak tasting sets and multi-beer packs', () => {
+    const parsed = beerfreak.parseCards(docWithProducts([
+      { id: 29993, brand_title: 'FUNKY FLUID (Польща)', title: 'WORLD CUP SERIES - 5 SPECIAL BEER' },
+      { id: 31072, brand_title: 'ГОНІР - HONIR BREWERY (Україна)', title: 'Дегустаціний сет від Honir Brewery' },
+      { id: 31073, brand_title: 'Example Brewery', title: 'Example Brewery Mix Pack' },
+      { id: 31074, brand_title: 'Example Brewery', title: 'Example Brewery Tasting Set' },
+    ]));
+
+    expect(parsed).toEqual([]);
+  });
+
+  it('keeps legitimate BeerFreak beers with incidental set-like substrings', () => {
+    const parsed = beerfreak.parseCards(docWithProducts([
+      { id: 31075, brand_title: 'Sunset Brew', title: 'Sunset Boulevard' },
+      { id: 31076, brand_title: 'Reset Brewing', title: 'Reset IPA' },
+      { id: 31077, brand_title: 'Series Brewing', title: 'Special Beer' },
+    ]));
+
+    expect(parsed.map(({ brewery, name }) => ({ brewery, name }))).toEqual([
+      { brewery: 'Sunset Brew', name: 'Sunset Boulevard' },
+      { brewery: 'Reset Brewing', name: 'Reset IPA' },
+      { brewery: 'Series Brewing', name: 'Special Beer' },
+    ]);
+  });
+
   it('extracts a brewery prefix from Beerfreak titles when metadata has no brand', () => {
     const parsed = beerfreak.parseCards(docWithProducts([
       { id: 10112, brand_title: null, title: 'Brouwerij De Dolle Brouwers Oerbier' },

--- a/extension/src/sites/beerfreak.test.ts
+++ b/extension/src/sites/beerfreak.test.ts
@@ -158,9 +158,9 @@ describe('beerfreak adapter', () => {
 
   it('keeps legitimate BeerFreak beers with incidental set-like substrings', () => {
     const parsed = beerfreak.parseCards(docWithProducts([
-      { id: 31075, brand_title: 'Sunset Brew', title: 'Sunset Boulevard' },
-      { id: 31076, brand_title: 'Reset Brewing', title: 'Reset IPA' },
-      { id: 31077, brand_title: 'Series Brewing', title: 'Special Beer' },
+      { id: 31075, brand_title: 'Sunset Brew', title: 'Sunset Brew Sunset Boulevard' },
+      { id: 31076, brand_title: 'Reset Brewing', title: 'Reset Brewing Reset IPA' },
+      { id: 31077, brand_title: 'Series Brewing', title: 'Series Brewing Special Beer' },
     ]));
 
     expect(parsed.map(({ brewery, name }) => ({ brewery, name }))).toEqual([

--- a/extension/src/sites/beerfreak.ts
+++ b/extension/src/sites/beerfreak.ts
@@ -15,12 +15,18 @@ const BREWERY_NOISE_PREFIX_RE = /^(?:brewery|brewing|browar|brouwerij|brasserie)
 const LEADING_BREWERY_DESCRIPTORS = new Set(['brouwerij', 'brasserie', 'browar', 'pivovar', 'birrificio', 'brauerei']);
 const COLLABORATOR_COMPANY_WORDS = new Set(['beer', 'brewing']);
 const COLLABORATOR_TERMINAL_WORDS = new Set(['brewery', 'company', 'co', 'co.']);
+const BEERFREAK_BUNDLE_RE = /(?:^|[^\p{L}\p{N}])(?:mix\s+pack|tasting\s+set|set|сет)(?=$|[^\p{L}\p{N}])/iu;
+const BEERFREAK_NUMBERED_SERIES_RE = /(?:^|[^\p{L}\p{N}])series\s*[-:]?\s*\d+\s+special\s+beers?(?=$|[^\p{L}\p{N}])/iu;
 const MAX_DETAIL_FETCHES_PER_PASS = 20;
 const detailUrls = new WeakMap<HTMLElement, string>();
 const abvByUrl = new Map<string, Promise<number | undefined>>();
 
 function text(el: Element | null): string {
   return el?.textContent?.replace(/\s+/g, ' ').trim() ?? '';
+}
+
+function isBeerFreakBundle(rawTitle: string): boolean {
+  return BEERFREAK_BUNDLE_RE.test(rawTitle) || BEERFREAK_NUMBERED_SERIES_RE.test(rawTitle);
 }
 
 function cleanBrewery(raw: string | null): string {
@@ -175,7 +181,7 @@ export const beerfreak: SiteAdapter = {
       const product = Number.isFinite(id) ? meta.get(id) : undefined;
       const rawTitle = product?.title ?? text(el.querySelector('.catalogCard-title a'));
       if (!rawTitle) continue;
-      if (isNonBeerName(rawTitle)) continue;
+      if (isNonBeerName(rawTitle) || isBeerFreakBundle(rawTitle)) continue;
 
       const parsed = product
         ? product.brand_title == null

--- a/spec.md
+++ b/spec.md
@@ -1213,7 +1213,8 @@ test-БД, §3.2 «no `await` ⇒ no race», §3.3 визначення «extern
   `[data-information-type="brand-name"]`, назва `a.product__title`; `°` у тайтлі це
   Плато, не ABV → `abv` опускається; має `waitForGrid`), `beerfreak` (Horoshop SSR —
   `.catalogCard`, brewery/name з embedded `products` metadata, домен
-  `beerfreak.org`), `bierloods22` (Bierloods22 SSR — `.product-block`,
+  `beerfreak.org`; локально відхиляє tasting sets, mix packs і numbered multi-beer
+  series), `bierloods22` (Bierloods22 SSR — `.product-block`,
   пивоварня з **brand-префіксу** `a.title[title]` (`"{brand} {title}"` → `brand = attr − text`;
   кількість ` - `-сегментів brand'у задає межу пивоварні, тож пивоварні з внутрішнім ` - `
   типу `Kykao - Handcrafted` парсяться правильно; порожній brand → фолбек split по першому


### PR DESCRIPTION
## Summary

BeerFreak tasting sets and multi-beer packs no longer appear as individual beers or create orphan-enrichment noise. The adapter now recognizes the reported English and Ukrainian bundle forms locally, with Unicode-aware boundaries that preserve legitimate names such as Sunset and Reset.

Fixes #284.

## Validation

- 33 extension test files passed (355 tests), including both reported listings and false-positive guards.
- TypeScript typecheck and the production extension build/package completed successfully.
- `git diff --check origin/main...HEAD` passed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
