### PR TITLE
fix(matcher): stop over-constrained Untappd queries (#270 + #271)

### DIFF
--- a/docs/superpowers/plans/2026-07/2026-07-15-matcher-query-overconstraint-236-followups.md
+++ b/docs/superpowers/plans/2026-07/2026-07-15-matcher-query-overconstraint-236-followups.md
@@ -1,0 +1,313 @@
+# Matcher query over-constraint fixes (#270 + #271) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop `cleanSearchQuery`/`lookupBeer` from building over-constrained Untappd/Algolia queries that AND-zero the search, per issues #270 (destructive split + dedup) and #271 (bare adjunct tails, narrowed to the safe delimiter-list slice).
+
+**Architecture:** Two independent changes. (1) Rewrite the pure `cleanSearchQuery` in `src/domain/normalize.ts`: split brewery and name separately (never split a name on ` x `), and replace global fold-dedup with edge-run-only dedup (strip leading/trailing name tokens that duplicate a brewery brand token; keep mid-name duplicates). (2) Add a single, whole-lookup head-retry in `src/domain/untappd-lookup.ts` that fires only when the search returned zero candidates and the name has a `,`/`#N` flavour-list tail, recursing with the head. A read-only prod dry-run script measures the query-shape change before merge.
+
+**Tech Stack:** TypeScript, Vitest (`npm test` → `vitest run`), better-sqlite3 (read-only prod replay), tsx.
+
+**Spec:** `docs/superpowers/specs/2026-07/2026-07-15-matcher-query-overconstraint-236-followups-design.md`
+
+**Worktree/branch note for subagents:** Before committing in any task, run `git rev-parse --show-toplevel` and `git branch --show-current` and confirm you are in the intended worktree on the feature branch (NOT the main checkout). Report the toplevel path in your summary.
+
+---
+
+## Task 1: #270 — rewrite `cleanSearchQuery` (edge-run dedup, no name ` x ` split)
+
+**Files:**
+- Modify: `src/domain/normalize.ts:144-161` (`cleanSearchQuery`)
+- Test: `src/domain/normalize.test.ts` (add cases to the existing `describe('cleanSearchQuery', …)` block, ~line 173-225)
+
+- [ ] **Step 1: Add failing tests for the #270 cases**
+
+Add these tests inside the existing `describe('cleanSearchQuery', () => { … })` block in `src/domain/normalize.test.ts` (append before the closing `});` at line 225):
+
+```ts
+  test('#270 31133: mid-name tokens repeating the brewery are kept, lone leading "x" dropped', () => {
+    // Was destroyed to "Magic Road Upside Down: to" — Road/Upside dropped as dup-of-brewery.
+    expect(
+      cleanSearchQuery('Browar Magic Road', 'x Upside Down: Road to Upside'),
+    ).toBe('Magic Road Upside Down: Road to Upside');
+  });
+  test('#270: mid-name token duplicating the brewery is kept (not deduped away)', () => {
+    // OLD global dedup dropped the second "Milk" (part of the beer name) -> "Milk Coffee Stout".
+    // NEW edge-run dedup keeps the mid-name "Milk"; a repeated identical Algolia term is harmless.
+    expect(cleanSearchQuery('Milk Brewery', 'Coffee x Milk Stout')).toBe('Milk Coffee Milk Stout');
+  });
+  test('#270 31135: leading collab "x" dropped, rest of the name intact (regression guard)', () => {
+    expect(cleanSearchQuery('Nepo Brewing', 'x Uncharted: Top-Tier')).toBe(
+      'Nepo Uncharted: Top-Tier',
+    );
+  });
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+Run: `npx vitest run src/domain/normalize.test.ts -t "#270"`
+Expected: FAIL — 31133 currently returns `Magic Road Upside Down: to` (Road/Upside dropped by global dedup); the `Milk Brewery` case currently returns `Milk Coffee Stout` (second `Milk` deduped). The 31135 guard may already pass on the old code (it survived incidentally) — that is fine.
+
+- [ ] **Step 3: Rewrite `cleanSearchQuery`**
+
+Replace the entire body of `cleanSearchQuery` (lines 144-161) in `src/domain/normalize.ts` with:
+
+```ts
+export function cleanSearchQuery(brewery: string, name: string): string {
+  const cleanBrewery = stripSearchNoise(stripLegalForm(brewery));
+  const cleanName = stripSearchNoise(name);
+
+  // Brewery brand tokens: split collab separators (defensive — detaches glued junk like
+  // "collab/"), then whitespace; drop BREWERY_NOISE and empty folds; dedup by fold.
+  const brandTokens: string[] = [];
+  const brandFolds = new Set<string>();
+  for (const tok of cleanBrewery.split(COLLAB_SEP).join(' ').split(/\s+/)) {
+    const f = foldToken(tok);
+    if (!f || BREWERY_NOISE.has(f) || brandFolds.has(f)) continue;
+    brandFolds.add(f);
+    brandTokens.push(tok);
+  }
+
+  // Name tokens: whitespace split, "/" -> space (unambiguous collab slash); drop lone collab
+  // connectors ("x"), empty folds, and BREWERY_NOISE anywhere. The name is NEVER split on " x "
+  // (#270): a name beginning "x <partner>:" is a shop artifact, not a collab-brewery separator.
+  const nameTokens: string[] = [];
+  for (const tok of cleanName.replace(/\//g, ' ').split(/\s+/)) {
+    const f = foldToken(tok);
+    if (!f || f === 'x' || BREWERY_NOISE.has(f)) continue;
+    nameTokens.push(tok);
+  }
+
+  // Strip only the leading and trailing runs of name tokens that duplicate a brewery brand token
+  // (the "name restates the brewery" case: #126 leading, #155 trailing). Mid-name duplicates are
+  // KEPT (#270 "Road"/"Upside") — Algolia collapses a repeated identical term to one, so keeping
+  // them is harmless while dropping them destroyed the beer name.
+  let start = 0;
+  let end = nameTokens.length;
+  while (start < end && brandFolds.has(foldToken(nameTokens[start]))) start++;
+  while (end > start && brandFolds.has(foldToken(nameTokens[end - 1]))) end--;
+
+  const out = [...brandTokens, ...nameTokens.slice(start, end)];
+  // Last resort: never emit an empty query.
+  return out.length ? out.join(' ') : (cleanName || cleanBrewery || name.trim());
+}
+```
+
+- [ ] **Step 4: Run the full normalize suite (new + existing regression tests)**
+
+Run: `npx vitest run src/domain/normalize.test.ts`
+Expected: PASS — all new #270 tests pass AND every pre-existing `cleanSearchQuery` test still passes, specifically:
+- `#126 Track` → `TRACK Taking Shape`
+- `#155 Trzech Kumpli` → `TRZECH KUMPLI Porter Bałtycki Żytnio-Orkiszowy` (trailing dedup preserved)
+- `Alpha x Beta` / `Some Beer` → `Alpha Beta Some Beer`
+- `Funky Fluid` / `Mosaic (collab Yakima Chief` → `Funky Fluid Mosaic Yakima Chief` (mid-name `collab` noise dropped)
+- all fallback tests (`Brewing Co`/`Company` → `Company`, `''`/`(only)` → `(only)`)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/domain/normalize.ts src/domain/normalize.test.ts
+git commit -m "fix(matcher): edge-run dedup + no name x-split in cleanSearchQuery (#270)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: #271 — narrowed head-retry in `lookupBeer`
+
+**Files:**
+- Modify: `src/domain/untappd-lookup.ts` (add `headBeforeTail` helper near line 32; thread `headRetried` param into `lookupBeer` at line 164; add the retry fallback before the final `return { kind: 'not_found', … }` at line 316)
+- Test: `src/domain/untappd-lookup.test.ts` (append to the existing `describe('lookupBeer', …)` block)
+
+- [ ] **Step 1: Write failing tests for the head-retry gates**
+
+Append these tests inside the existing `describe('lookupBeer', () => { … })` block in `src/domain/untappd-lookup.test.ts`:
+
+```ts
+  test('#271 head-retry: zero candidates + comma/#N tail retries with the head and matches', async () => {
+    const search = fakeSearch((q) =>
+      q === 'Pinta Fantazja'
+        ? [{ bid: 7000, beer_name: 'Fantazja', brewery_name: 'Pinta', style: 'Sour', abv: 5, global_rating: 3.7 }]
+        : [],
+    );
+    const out = await lookupBeer({ brewery: 'Pinta', name: 'Fantazja #1, Pastry Sour z Guavą, Mango', search });
+    expect(out.kind).toBe('matched');
+    if (out.kind !== 'matched') return;
+    expect(out.result.bid).toBe(7000);
+  });
+
+  test('#271: no head-retry when the full query already returned candidates (even if unmatched)', async () => {
+    let calls = 0;
+    const search = fakeSearch(() => {
+      calls++;
+      return [{ bid: 9, beer_name: 'Whatever', brewery_name: 'Other Brewery', style: 'IPA', abv: 5, global_rating: 3 }];
+    });
+    const out = await lookupBeer({ brewery: 'Pinta', name: 'Fantazja #1, Mango', search });
+    expect(out.kind).toBe('not_found');
+    expect(calls).toBe(1); // brewery gate rejected the candidate; retry must NOT fire
+  });
+
+  test('#271: no head-retry for a dash-only tail (excluded delimiter)', async () => {
+    let calls = 0;
+    const search = fakeSearch(() => { calls++; return []; });
+    const out = await lookupBeer({ brewery: 'Pinta', name: 'Imperial Stout - Barrel Aged', search });
+    expect(out.kind).toBe('not_found');
+    expect(calls).toBe(1); // no comma/#N delimiter → no head-retry
+  });
+
+  test('#271: single-retry guard — head-retry does not recurse forever', async () => {
+    let calls = 0;
+    const search = fakeSearch(() => { calls++; return []; });
+    const out = await lookupBeer({ brewery: 'Pinta', name: 'Fantazja, Mango, Guava', search });
+    expect(out.kind).toBe('not_found');
+    expect(calls).toBe(2); // original pass + exactly one head-retry pass
+  });
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+Run: `npx vitest run src/domain/untappd-lookup.test.ts -t "#271"`
+Expected: FAIL — the first test returns `not_found` (no retry exists yet); the single-retry test sees `calls === 1`.
+
+- [ ] **Step 3: Add the `headBeforeTail` helper**
+
+Insert this helper in `src/domain/untappd-lookup.ts` immediately after the `brewerySearchParts` function (after line 42):
+
+```ts
+// #271: the head of a name up to the first bare adjunct/flavour-LIST delimiter — a comma or
+// " #<n>". Deliberately EXCLUDES the " - " dash (often a real sub-edition) and any token cap, both
+// of which risk truncating a legitimate name. Returns null when there is no such delimiter or the
+// head is empty / equal to the whole name.
+const TAIL_LIST_DELIMITER = /,|\s#\d/;
+function headBeforeTail(name: string): string | null {
+  const m = TAIL_LIST_DELIMITER.exec(name);
+  if (!m) return null;
+  const head = name.slice(0, m.index).trim();
+  return head && head !== name.trim() ? head : null;
+}
+```
+
+- [ ] **Step 4: Thread the `headRetried` guard param into `lookupBeer`**
+
+Change the signature at line 164 from:
+
+```ts
+export async function lookupBeer(args: LookupArgs): Promise<LookupOutcome> {
+```
+
+to:
+
+```ts
+export async function lookupBeer(args: LookupArgs, headRetried = false): Promise<LookupOutcome> {
+```
+
+- [ ] **Step 5: Add the retry fallback before the final not_found return**
+
+Replace the final `return { kind: 'not_found', searchUrls: triedUrls, candidates: seenCandidates };` (line 316) with:
+
+```ts
+  // #271 fallback: the search returned zero candidates across every brewery part — a genuine
+  // query-zeroing (a matcher rejection would leave seenCandidates non-empty and is NOT retried).
+  // If the name has a comma/#N flavour-list tail, retry the WHOLE lookup once with the head only,
+  // so the tail cannot AND-zero the Algolia search. Matching then evaluates the head (brewery gate
+  // unchanged) — this is what lets a short Untappd name match. Single retry (headRetried guard).
+  if (!headRetried && seenCandidates.length === 0) {
+    const head = headBeforeTail(name);
+    if (head) {
+      const retry = await lookupBeer({ ...args, name: head }, true);
+      if (retry.kind === 'not_found') {
+        return {
+          kind: 'not_found',
+          searchUrls: [...triedUrls, ...retry.searchUrls],
+          candidates: retry.candidates,
+        };
+      }
+      return retry;
+    }
+  }
+  return { kind: 'not_found', searchUrls: triedUrls, candidates: seenCandidates };
+```
+
+- [ ] **Step 6: Run the lookup suite (new + existing)**
+
+Run: `npx vitest run src/domain/untappd-lookup.test.ts`
+Expected: PASS — all four #271 tests pass and every pre-existing `lookupBeer` test still passes.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/domain/untappd-lookup.ts src/domain/untappd-lookup.test.ts
+git commit -m "fix(matcher): head-retry for comma/#N flavour-list tails (#271, narrowed)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: prod dry-run replay — measure query-shape change (validation, read-only)
+
+**Files:**
+- Create: `./tmp/dryrun-270.ts` (ephemeral scratch — NOT committed; `./tmp/` is gitignored)
+
+- [ ] **Step 1: Write the read-only replay script**
+
+Create `./tmp/dryrun-270.ts`:
+
+```ts
+// Read-only replay of matcher_bug enrich_failures through the NEW cleanSearchQuery.
+// Compares against the OLD query decoded from search_url (approximate: search_url stores the last
+// tried part's URL, and for collab breweries uses a single part, so `before` is a best-effort
+// baseline). Purpose: surface how many queries change shape and flag suspicious shortening.
+import Database from 'better-sqlite3';
+import { cleanSearchQuery } from '../src/domain/normalize';
+
+const db = new Database('/var/lib/warsaw-beer-bot/bot.db', { readonly: true });
+const rows = db.prepare(
+  "SELECT beer_id, brewery, name, search_url FROM enrich_failures WHERE review_class='matcher_bug'",
+).all() as { beer_id: number; brewery: string; name: string; search_url: string }[];
+
+function oldQuery(searchUrl: string): string {
+  try { return decodeURIComponent(new URL(searchUrl).searchParams.get('q') ?? ''); }
+  catch { return ''; }
+}
+
+let changed = 0;
+let newlyEmpty = 0;
+const diffs: string[] = [];
+for (const r of rows) {
+  const before = oldQuery(r.search_url);
+  const after = cleanSearchQuery(r.brewery, r.name);
+  if (before !== after) {
+    changed++;
+    if (!after.trim()) newlyEmpty++;
+    diffs.push(`#${r.beer_id}\n  brewery: ${r.brewery}\n  name:    ${r.name}\n  before:  ${before}\n  after:   ${after}`);
+  }
+}
+console.log(`rows=${rows.length} changed=${changed} newly-empty=${newlyEmpty}`);
+console.log('---');
+console.log(diffs.join('\n\n'));
+db.close();
+```
+
+- [ ] **Step 2: Run the replay and capture the report**
+
+Run: `npx tsx ./tmp/dryrun-270.ts | tee ./tmp/dryrun-270.out`
+Expected: prints `rows=<~279> changed=<N> newly-empty=<M>` followed by per-row before→after diffs.
+
+- [ ] **Step 3: Review the diff for regressions**
+
+Manually inspect `./tmp/dryrun-270.out`. Confirm:
+- `newly-empty` is **0** (no query became empty — the fallback guarantees non-empty, so any non-zero here is a bug to investigate).
+- The 31133/31135 rows (if present) now preserve their mid-name tokens.
+- No row shows a *suspicious* shortening where a real beer-name token was dropped mid-name (edge-run dedup should only trim leading/trailing brewery duplicates).
+
+Report the `changed`/`newly-empty` counts and any suspicious rows in the task summary. Do **not** commit anything from `./tmp/` (gitignored scratch).
+
+---
+
+## Notes for the executor
+
+- After Tasks 1-3, run the **full** suite once: `npm test` — expected all green.
+- `./tmp/` is ephemeral scratch (gitignored); leave the dry-run artefacts for review but never `git add` them.
+- Head-retry (#271) is deliberately narrowed; the deferred remainder (bare-space tails, token-cap, dash) is documented in the spec's "Out of scope / follow-ups".

--- a/docs/superpowers/specs/2026-07/2026-07-15-matcher-query-overconstraint-236-followups-design.md
+++ b/docs/superpowers/specs/2026-07/2026-07-15-matcher-query-overconstraint-236-followups-design.md
@@ -1,0 +1,132 @@
+# Matcher: fix over-constrained Untappd/Algolia queries (#270 + #271)
+
+- **Date**: 2026-07-15
+- **Issues**: #270 (COLLAB_SEP over-split + fold-dedup destroys name tokens), #271 (bare adjunct/flavour tails over-constrain the search) — both follow-ups from #236.
+- **Files**: `src/domain/normalize.ts`, `src/domain/untappd-lookup.ts`, `src/domain/normalize.test.ts`, new lookup test, `./tmp/` dry-run script.
+
+## Problem
+
+Untappd search runs through Algolia, which **ANDs every term** in the query. Any spurious
+token zeroes the result set. Two distinct classes of spurious tokens survive today:
+
+### #270 — destructive split + dedup in `cleanSearchQuery`
+`cleanSearchQuery(brewery, name)` collapses `COLLAB_SEP` (`/`, ` x `, ` & `) on the **combined**
+`"${cleanBrewery} ${cleanName}"` string, then fold-dedups every token globally. Two intertwined
+defects:
+
+- **(a) combined-split.** A beer *name* that begins with or contains ` x ` (a shop "collab-with"
+  artifact) is split as if it were a collab **brewery** separator. The ` x ` split belongs to the
+  brewery field only (already handled upstream by `brewerySearchParts`).
+- **(b) global fold-dedup.** A name token is dropped whenever its fold repeats *any* brewery token,
+  even when that token is part of the core beer name (mid-name, not a leading brewery-restatement).
+
+Evidence (2026-07-11 code):
+- **31133** brewery `Browar Magic Road` / name `x Upside Down: Road to Upside` → query
+  `Magic Road Upside Down: to` — `Road` and `Upside` dropped as dup-of-brewery, the beer name is
+  destroyed (candidate `Magic Road — Road To Upside` never found).
+- **31135** `Nepo Brewing` / `x Uncharted: Top-Tier` → `Nepo Uncharted: Top-Tier` (survives, but the
+  leading `x` handling is incidental).
+
+The global dedup exists for #126 (a name that restates the brewery: `Track Brewing Co` /
+`Track Brewing Company Taking Shape`). The fix must preserve #126 while stopping the #270 destruction.
+
+### #271 — bare adjunct/flavour tails
+`stripSearchNoise` only drops adjunct lists inside `[...]`/`(...)`. When the shop writes the flavour
+tail as **bare** text after a comma / `#N` / dash, every descriptor becomes an AND term and zeroes
+the search. The #239 fix deliberately left these alone — a naive strip risks truncating legitimate
+names (`X - Imperial Edition`).
+
+Evidence:
+- **31170** `Owocowa Fantazja #1 - Pastry Sour z Guavą, Mango, Maliną, Gruszką`
+- **30780** `Jungle boogie mango ananas`
+- **30109** `WA Gossip Cervejaria Escafandrista 12`
+
+## Non-goals
+
+- We do **not** try to identify and drop the collab *partner* brewery from a name (`Upside Down` in
+  31133). That residual over-constraint is a separate, harder class; #270 here only stops the query
+  from being *destroyed* (name tokens preserved) and fixes the mis-split.
+- We do **not** add a general heuristic that strips bare tails unconditionally (the risky path the
+  issue warns against). #271 is handled strictly as a fallback that cannot worsen a working match.
+
+## Design
+
+### Part A — `cleanSearchQuery` (`src/domain/normalize.ts`), deterministic (#270)
+
+**A1. Connector handling.** Split the brewery and the name **separately** instead of collapsing
+`COLLAB_SEP` on the combined string. Instead:
+- Brewery arg is already a single collab part (`brewerySearchParts` split upstream); still split it
+  on `COLLAB_SEP` defensively (detaches glued junk like `collab/`), then whitespace, dropping
+  `BREWERY_NOISE`.
+- Name: tokenize on whitespace, replace `/` with a space (unambiguous collab slash), and drop
+  **lone connector tokens** whose fold is `x` or `&`. The name is **never** split on ` x `.
+- Result: `x Upside Down: Road to Upside` is no longer cut at ` x ` — only the lone leading `x`
+  disappears; `Upside Down: Road to Upside` survives into the query.
+
+**A2. Leading-run dedup (replaces global fold-dedup).** This is the core change:
+- Emit brewery tokens first (deduped among themselves by fold, dropping `BREWERY_NOISE`).
+- For the name, strip **only the leading contiguous run** of tokens whose fold matches a brewery
+  token or `BREWERY_NOISE`. Stop at the first name token that is **not** in the brewery set; keep all
+  remaining name tokens verbatim — no further dedup of the name against the brewery.
+- Identical-token AND terms that survive (e.g. `Road` in both brewery and mid-name) are harmless:
+  Algolia treats a repeated identical term as the single term.
+
+Worked cases:
+- #126 `Track Brewing Co` / `Track Brewing Company Taking Shape`: leading run `Track`(brewery),
+  `Brewing`(noise), `Company`(noise), then `Taking`(not in brewery → stop) → name kept `Taking Shape`
+  → query `Track Taking Shape`. ✓ (preserved)
+- #270 31133 `Browar Magic Road` / `x Upside Down: Road to Upside`: lone `x` dropped; name leading
+  token `Upside` not in brewery → stop immediately → no name tokens dropped → `Road`/`Upside`
+  preserved. ✓ (fixed)
+
+**A3. Fallback** (`out.length ? … : (cleanName || cleanBrewery || name.trim())`) unchanged.
+
+### Part B — head-retry in `lookupBeer` (`src/domain/untappd-lookup.ts`) (#271)
+
+In the per-part loop, after `results = await args.search.search(query)`:
+
+- If `results.length === 0` **and** the name has a trimmable tail, run **one** additional search with
+  the head only, and adopt its results if non-empty.
+- **Tail delimiter**: first occurrence of `, ` (comma), ` #\d` (hash-number), or ` - `/` — ` (dash).
+  `head` = the name substring up to (excluding) that delimiter.
+- **Gate**: retry only when `results === 0` and `headQuery !== query` (a tail actually existed and
+  was removed). This makes it a strict fallback — if the full query already returned candidates, no
+  retry happens; if the head query also returns 0, nothing changes.
+- **Safety invariant (documented in code)**: the head query only widens the candidate **search**.
+  All downstream match gates — brewery gate, `nameKeys`, `fuzzyTargets` — continue to use the **full
+  original name**. A candidate surfaced only by the head must still match the full name to be
+  returned, so head-retry cannot introduce a false match.
+- **Cost / traffic**: +1 HTTP search on the subset of orphans that (a) returned 0 and (b) have a
+  tail. It goes through `args.search`, so it inherits the Untappd circuit breaker, Webshare proxy,
+  and backoff automatically. `triedUrls` records the head query URL too (for `enrich_failures`).
+
+### Part C — Validation
+
+1. **Unit tests (Vitest), required by CLAUDE.md.**
+   - `normalize.test.ts` for `cleanSearchQuery`: 31133 (`Road`/`Upside` preserved), 31135 (leading
+     `x` dropped, rest intact), #126 regression (`Track Taking Shape`), and a plain non-collab case.
+   - New lookup test for head-retry: mock `BeerSearch` returning `[]` for the full query and a
+     candidate for the head; assert the second search fires with the head; assert that a head
+     candidate which does **not** match the full name yields `not_found` (safety invariant); assert
+     no retry when the full query already returns results.
+2. **Prod dry-run replay (`./tmp/`, read-only).** Script reads `matcher_bug` rows from
+   `enrich_failures` on the read-only prod DB, runs each through old vs new `cleanSearchQuery`, and
+   reports: count now producing a non-empty / changed query, per-row before→after diffs, and any row
+   whose query got **shorter in a suspicious way** (regression watch). Manual review of the diff
+   before merge. (Head-retry itself is not replayed against live Untappd; its behaviour is covered by
+   the mocked unit test.)
+
+## Risks
+
+- **A2 heuristic edge**: a beer whose name legitimately *starts* with a brewery token loses that
+  leading token (same as current behaviour — the brewery already contributes it). Acceptable; the
+  dry-run diff surfaces any surprising shortening.
+- **B dash delimiter**: ` - ` can appear in real names (`X - Imperial Edition`). Safe here because
+  retry only fires after the full query returned 0, and matching still gates on the full name.
+- **Traffic**: head-retry adds Untappd calls on a failing subset. Bounded; inherits breaker/proxy.
+  Validate observed call volume against the breaker budget after deploy (per hot-loop discipline).
+
+## Out of scope / follow-ups
+
+- Collab-partner identification/removal from names (residual #270/#271 over-constraint).
+- Broader query-noise classes tracked in #229 / #254.

--- a/docs/superpowers/specs/2026-07/2026-07-15-matcher-query-overconstraint-236-followups-design.md
+++ b/docs/superpowers/specs/2026-07/2026-07-15-matcher-query-overconstraint-236-followups-design.md
@@ -63,42 +63,65 @@ Evidence:
 - Result: `x Upside Down: Road to Upside` is no longer cut at ` x ` — only the lone leading `x`
   disappears; `Upside Down: Road to Upside` survives into the query.
 
-**A2. Leading-run dedup (replaces global fold-dedup).** This is the core change:
-- Emit brewery tokens first (deduped among themselves by fold, dropping `BREWERY_NOISE`).
-- For the name, strip **only the leading contiguous run** of tokens whose fold matches a brewery
-  token or `BREWERY_NOISE`. Stop at the first name token that is **not** in the brewery set; keep all
-  remaining name tokens verbatim — no further dedup of the name against the brewery.
-- Identical-token AND terms that survive (e.g. `Road` in both brewery and mid-name) are harmless:
-  Algolia treats a repeated identical term as the single term.
+**A2. Edge-run dedup (replaces global fold-dedup).** This is the core change. Define
+`breweryFolds` = the folds of brewery **brand** tokens (brewery tokens that survive `BREWERY_NOISE`
+removal). Build the name token list from A1, then:
+- Drop any name token whose fold is in `BREWERY_NOISE` **anywhere** (pure noise: `collab`, `brewing`,
+  `co`, …) and any token whose fold is empty (bare punctuation like `–`).
+- From the remaining name tokens, strip the **leading** contiguous run and the **trailing**
+  contiguous run whose fold is in `breweryFolds`. Stop each run at the first token not in
+  `breweryFolds`. **Keep every mid-name token**, even if it duplicates a brewery brand token.
+- Emit brewery brand tokens (deduped among themselves by fold), then the surviving name tokens, in
+  original raw form. Identical AND terms that survive (e.g. `Road` in both brewery and mid-name) are
+  harmless — Algolia treats a repeated identical term as the single term.
+
+Why leading **and** trailing (not leading-only): existing #155 test relies on trailing removal —
+`TRZECH KUMPLI Brewery` / `Porter Bałtycki Żytnio-Orkiszowy Trzech Kumpli` → the trailing
+`Trzech Kumpli` must drop, yielding `TRZECH KUMPLI Porter Bałtycki Żytnio-Orkiszowy`.
 
 Worked cases:
-- #126 `Track Brewing Co` / `Track Brewing Company Taking Shape`: leading run `Track`(brewery),
-  `Brewing`(noise), `Company`(noise), then `Taking`(not in brewery → stop) → name kept `Taking Shape`
-  → query `Track Taking Shape`. ✓ (preserved)
-- #270 31133 `Browar Magic Road` / `x Upside Down: Road to Upside`: lone `x` dropped; name leading
-  token `Upside` not in brewery → stop immediately → no name tokens dropped → `Road`/`Upside`
-  preserved. ✓ (fixed)
+- #126 `Track Brewing Co` / `Track Brewing Company Taking Shape`: noise drops `Brewing`,`Company`;
+  leading run `Track`(brand) → drop, `Taking`(not brand → stop) → name `Taking Shape` →
+  query `TRACK Taking Shape`. ✓ (preserved)
+- #155 `TRZECH KUMPLI Brewery` / `Porter Bałtycki Żytnio-Orkiszowy Trzech Kumpli`: trailing run
+  `Kumpli`,`Trzech` → drop, `Żytnio-Orkiszowy`(not brand → stop) → `TRZECH KUMPLI Porter Bałtycki
+  Żytnio-Orkiszowy`. ✓ (preserved)
+- #270 31133 `Browar Magic Road` / `x Upside Down: Road to Upside`: lone `x` dropped; brand folds
+  `{magic, road}`; leading `Upside`(not brand → stop), trailing `Upside`(not brand → stop), so no
+  edge trim; mid-name `Road` kept → name `Upside Down: Road to Upside` → `Road`/`Upside` preserved. ✓ (fixed)
 
 **A3. Fallback** (`out.length ? … : (cleanName || cleanBrewery || name.trim())`) unchanged.
 
-### Part B — head-retry in `lookupBeer` (`src/domain/untappd-lookup.ts`) (#271)
+### Part B — head-retry in `lookupBeer` (`src/domain/untappd-lookup.ts`) (#271, NARROWED)
 
-In the per-part loop, after `results = await args.search.search(query)`:
+> **Design-defect correction (2026-07-15).** The original "retry the search but keep matching on the
+> full name" idea does not work: the matcher (`fuzzyTargets`/`nameKeys`/coverage) requires **every**
+> input-name token to be covered by the candidate. When the shop name carries a long flavour tail
+> (`Space Pop I - Blackberry, Lemon, Marshmallow`) and the Untappd beer is the short head
+> (`Space Pop I`), a candidate found via a head-only search is still **rejected** by the full-name
+> gates. So the retry must **match on the head too** — which reintroduces false-match risk. Two of the
+> three issue examples (30780 `Jungle boogie mango ananas`, 30109 `WA Gossip …`) have **no delimiter**
+> and would need a token-cap, which is riskier still. Decision: implement only the **safe delimiter-list
+> slice** now; defer bare-space tails, token-cap, and the ` - ` dash to a follow-up.
 
-- If `results.length === 0` **and** the name has a trimmable tail, run **one** additional search with
-  the head only, and adopt its results if non-empty.
-- **Tail delimiter**: first occurrence of `, ` (comma), ` #\d` (hash-number), or ` - `/` — ` (dash).
-  `head` = the name substring up to (excluding) that delimiter.
-- **Gate**: retry only when `results === 0` and `headQuery !== query` (a tail actually existed and
-  was removed). This makes it a strict fallback — if the full query already returned candidates, no
-  retry happens; if the head query also returns 0, nothing changes.
-- **Safety invariant (documented in code)**: the head query only widens the candidate **search**.
-  All downstream match gates — brewery gate, `nameKeys`, `fuzzyTargets` — continue to use the **full
-  original name**. A candidate surfaced only by the head must still match the full name to be
-  returned, so head-retry cannot introduce a false match.
-- **Cost / traffic**: +1 HTTP search on the subset of orphans that (a) returned 0 and (b) have a
-  tail. It goes through `args.search`, so it inherits the Untappd circuit breaker, Webshare proxy,
-  and backoff automatically. `triedUrls` records the head query URL too (for `enrich_failures`).
+Implemented behaviour — a single, whole-lookup head-retry gated to fire only when the search returned
+**nothing at all**:
+
+- After the per-part loop, if `seenCandidates.length === 0` (every part's search returned zero
+  results — a genuine query-zeroing, not a matcher rejection) **and** the name has a **delimiter-list
+  tail**, recurse `lookupBeer` once with `name = head`.
+- **Tail delimiter (narrowed)**: the first ` #\d` (hash-number) or `,` (comma). `head` = the name
+  substring before it, trimmed. **Excluded**: ` - `/` — ` dash (often a real sub-edition) and any
+  token-cap (would truncate legitimate multiword names). If no such delimiter, no retry.
+- **Matching uses the head**: recursion re-runs the whole pipeline with the head as the name, so the
+  brewery gate + name gates evaluate the head — this is what lets the short Untappd name match.
+- **Guards**: single retry only (private `headRetried` flag threaded through recursion — infinite-loop
+  guard); `head` must be non-empty and `!== name`; brewery gate still applies unchanged in the retry.
+- **Outcome merge**: on retry `not_found`, merge `searchUrls`/`candidates` from both passes for
+  `enrich_failures` debugging; on `matched`/`blocked`/`transient`, return the retry outcome directly.
+- **Cost / traffic**: one extra whole-lookup pass on the subset of orphans that surfaced zero
+  candidates *and* have a delimiter tail. All searches go through `args.search`, inheriting the Untappd
+  circuit breaker, Webshare proxy, and backoff automatically.
 
 ### Part C — Validation
 
@@ -106,9 +129,10 @@ In the per-part loop, after `results = await args.search.search(query)`:
    - `normalize.test.ts` for `cleanSearchQuery`: 31133 (`Road`/`Upside` preserved), 31135 (leading
      `x` dropped, rest intact), #126 regression (`Track Taking Shape`), and a plain non-collab case.
    - New lookup test for head-retry: mock `BeerSearch` returning `[]` for the full query and a
-     candidate for the head; assert the second search fires with the head; assert that a head
-     candidate which does **not** match the full name yields `not_found` (safety invariant); assert
-     no retry when the full query already returns results.
+     matching candidate for the head query (`31170`-style `Owocowa Fantazja #1 - …` → head
+     `Owocowa Fantazja`); assert the retry fires and returns `matched`. Assert **no** retry when the
+     full query already returned candidates (even if unmatched). Assert **no** retry for a
+     dash-only tail (`X - Imperial Edition`). Assert single-retry guard (no infinite loop).
 2. **Prod dry-run replay (`./tmp/`, read-only).** Script reads `matcher_bug` rows from
    `enrich_failures` on the read-only prod DB, runs each through old vs new `cleanSearchQuery`, and
    reports: count now producing a non-empty / changed query, per-row before→after diffs, and any row
@@ -118,15 +142,23 @@ In the per-part loop, after `results = await args.search.search(query)`:
 
 ## Risks
 
-- **A2 heuristic edge**: a beer whose name legitimately *starts* with a brewery token loses that
-  leading token (same as current behaviour — the brewery already contributes it). Acceptable; the
-  dry-run diff surfaces any surprising shortening.
-- **B dash delimiter**: ` - ` can appear in real names (`X - Imperial Edition`). Safe here because
-  retry only fires after the full query returned 0, and matching still gates on the full name.
-- **Traffic**: head-retry adds Untappd calls on a failing subset. Bounded; inherits breaker/proxy.
-  Validate observed call volume against the breaker budget after deploy (per hot-loop discipline).
+- **A2 heuristic edge**: a beer whose name legitimately *starts or ends* with a brewery brand token
+  loses that edge token (same as current behaviour — the brewery already contributes it). Acceptable;
+  the dry-run diff surfaces any surprising shortening.
+- **B false-match risk**: matching on the head is more permissive, so a real product differentiator
+  in the tail could let the head match a different beer of the same brewery. Mitigated by: gating on
+  **zero candidates** (search found literally nothing), keeping the brewery gate, excluding the ` - `
+  dash and token-cap, and restricting to `,`/`#N` flavour-list tails. Residual risk accepted for the
+  narrowed slice; watch the dry-run diff and post-deploy match quality.
+- **Traffic**: head-retry adds one whole-lookup pass on a failing subset. Bounded; inherits
+  breaker/proxy. Validate observed call volume against the breaker budget after deploy (hot-loop
+  discipline).
 
 ## Out of scope / follow-ups
 
+- **#271 remainder (deferred to its own cycle)**: bare space-separated adjunct tails (30780
+  `Jungle boogie mango ananas`, 30109 `WA Gossip …`), the token-cap strategy, and the ` - ` dash
+  delimiter. These need head-matching with stronger false-match guards — a proper design, not a
+  bolt-on here.
 - Collab-partner identification/removal from names (residual #270/#271 over-constraint).
 - Broader query-noise classes tracked in #229 / #254.

--- a/src/domain/normalize.test.ts
+++ b/src/domain/normalize.test.ts
@@ -222,6 +222,22 @@ describe('cleanSearchQuery', () => {
   test('uses the raw name only as a last resort when all cleaned input is empty', () => {
     expect(cleanSearchQuery('', '(only)')).toBe('(only)');
   });
+  test('#270 31133: mid-name tokens repeating the brewery are kept, lone leading "x" dropped', () => {
+    // Was destroyed to "Magic Road Upside Down: to" — Road/Upside dropped as dup-of-brewery.
+    expect(
+      cleanSearchQuery('Browar Magic Road', 'x Upside Down: Road to Upside'),
+    ).toBe('Magic Road Upside Down: Road to Upside');
+  });
+  test('#270: mid-name token duplicating the brewery is kept (not deduped away)', () => {
+    // OLD global dedup dropped the second "Milk" (part of the beer name) -> "Milk Coffee Stout".
+    // NEW edge-run dedup keeps the mid-name "Milk"; a repeated identical Algolia term is harmless.
+    expect(cleanSearchQuery('Milk Brewery', 'Coffee x Milk Stout')).toBe('Milk Coffee Milk Stout');
+  });
+  test('#270 31135: leading collab "x" dropped, rest of the name intact (regression guard)', () => {
+    expect(cleanSearchQuery('Nepo Brewing', 'x Uncharted: Top-Tier')).toBe(
+      'Nepo Uncharted: Top-Tier',
+    );
+  });
 });
 
 describe('stripSearchNoise', () => {

--- a/src/domain/normalize.ts
+++ b/src/domain/normalize.ts
@@ -142,20 +142,40 @@ export function stripSearchNoise(s: string): string {
 }
 
 export function cleanSearchQuery(brewery: string, name: string): string {
-  const seen = new Set<string>();
-  const out: string[] = [];
   const cleanBrewery = stripSearchNoise(stripLegalForm(brewery));
   const cleanName = stripSearchNoise(name);
-  // Collapse COLLAB_SEP ("/", " x ", " & ") first so a bare collab connector ("x")
-  // never leaks into the query (as stripBreweryNoise did before tokenizing).
-  const combined = `${cleanBrewery} ${cleanName}`.split(COLLAB_SEP).join(' ');
-  for (const tok of combined.split(/\s+/)) {
+
+  // Brewery brand tokens: split collab separators (defensive — detaches glued junk like
+  // "collab/"), then whitespace; drop BREWERY_NOISE and empty folds; dedup by fold.
+  const brandTokens: string[] = [];
+  const brandFolds = new Set<string>();
+  for (const tok of cleanBrewery.split(COLLAB_SEP).join(' ').split(/\s+/)) {
     const f = foldToken(tok);
-    if (!f || BREWERY_NOISE.has(f) || seen.has(f)) continue;
-    seen.add(f);
-    out.push(tok);
+    if (!f || BREWERY_NOISE.has(f) || brandFolds.has(f)) continue;
+    brandFolds.add(f);
+    brandTokens.push(tok);
   }
-  // Prefer cleaned name/brewery; use the raw name only as a last resort when structural
-  // cleaning removes everything and no cleaned brewery survives, so the query is non-empty.
+
+  // Name tokens: whitespace split, "/" -> space (unambiguous collab slash); drop lone collab
+  // connectors ("x"), empty folds, and BREWERY_NOISE anywhere. The name is NEVER split on " x "
+  // (#270): a name beginning "x <partner>:" is a shop artifact, not a collab-brewery separator.
+  const nameTokens: string[] = [];
+  for (const tok of cleanName.replace(/\//g, ' ').split(/\s+/)) {
+    const f = foldToken(tok);
+    if (!f || f === 'x' || BREWERY_NOISE.has(f)) continue;
+    nameTokens.push(tok);
+  }
+
+  // Strip only the leading and trailing runs of name tokens that duplicate a brewery brand token
+  // (the "name restates the brewery" case: #126 leading, #155 trailing). Mid-name duplicates are
+  // KEPT (#270 "Road"/"Upside") — Algolia collapses a repeated identical term to one, so keeping
+  // them is harmless while dropping them destroyed the beer name.
+  let start = 0;
+  let end = nameTokens.length;
+  while (start < end && brandFolds.has(foldToken(nameTokens[start]))) start++;
+  while (end > start && brandFolds.has(foldToken(nameTokens[end - 1]))) end--;
+
+  const out = [...brandTokens, ...nameTokens.slice(start, end)];
+  // Last resort: never emit an empty query.
   return out.length ? out.join(' ') : (cleanName || cleanBrewery || name.trim());
 }

--- a/src/domain/untappd-lookup.test.ts
+++ b/src/domain/untappd-lookup.test.ts
@@ -472,4 +472,43 @@ describe('lookupBeer', () => {
       expect(out.result.bid).toBe(candidate.bid);
     });
   });
+
+  test('#271 head-retry: zero candidates + comma/#N tail retries with the head and matches', async () => {
+    const search = fakeSearch((q) =>
+      q === 'Pinta Fantazja'
+        ? [{ bid: 7000, beer_name: 'Fantazja', brewery_name: 'Pinta', style: 'Sour', abv: 5, global_rating: 3.7 }]
+        : [],
+    );
+    const out = await lookupBeer({ brewery: 'Pinta', name: 'Fantazja #1, Pastry Sour z Guavą, Mango', search });
+    expect(out.kind).toBe('matched');
+    if (out.kind !== 'matched') return;
+    expect(out.result.bid).toBe(7000);
+  });
+
+  test('#271: no head-retry when the full query already returned candidates (even if unmatched)', async () => {
+    let calls = 0;
+    const search = fakeSearch(() => {
+      calls++;
+      return [{ bid: 9, beer_name: 'Whatever', brewery_name: 'Other Brewery', style: 'IPA', abv: 5, global_rating: 3 }];
+    });
+    const out = await lookupBeer({ brewery: 'Pinta', name: 'Fantazja #1, Mango', search });
+    expect(out.kind).toBe('not_found');
+    expect(calls).toBe(1); // brewery gate rejected the candidate; retry must NOT fire
+  });
+
+  test('#271: no head-retry for a dash-only tail (excluded delimiter)', async () => {
+    let calls = 0;
+    const search = fakeSearch(() => { calls++; return []; });
+    const out = await lookupBeer({ brewery: 'Pinta', name: 'Imperial Stout - Barrel Aged', search });
+    expect(out.kind).toBe('not_found');
+    expect(calls).toBe(1); // no comma/#N delimiter → no head-retry
+  });
+
+  test('#271: single-retry guard — head-retry does not recurse forever', async () => {
+    let calls = 0;
+    const search = fakeSearch(() => { calls++; return []; });
+    const out = await lookupBeer({ brewery: 'Pinta', name: 'Fantazja, Mango, Guava', search });
+    expect(out.kind).toBe('not_found');
+    expect(calls).toBe(2); // original pass + exactly one head-retry pass
+  });
 });

--- a/src/domain/untappd-lookup.ts
+++ b/src/domain/untappd-lookup.ts
@@ -41,6 +41,18 @@ function brewerySearchParts(brewery: string): string[] {
   return parts.length > 1 ? parts : [brewery];
 }
 
+// #271: the head of a name up to the first bare adjunct/flavour-LIST delimiter — a comma or
+// " #<n>". Deliberately EXCLUDES the " - " dash (often a real sub-edition) and any token cap, both
+// of which risk truncating a legitimate name. Returns null when there is no such delimiter or the
+// head is empty / equal to the whole name.
+const TAIL_LIST_DELIMITER = /,|\s#\d/;
+function headBeforeTail(name: string): string | null {
+  const m = TAIL_LIST_DELIMITER.exec(name);
+  if (!m) return null;
+  const head = name.slice(0, m.index).trim();
+  return head && head !== name.trim() ? head : null;
+}
+
 function fuzzyTargets(name: string, brewery: string): FuzzyTarget[] {
   const breweryNorm = normalizeBrewery(brewery);
   const targets = new Map<string, FuzzyTarget>();
@@ -161,7 +173,7 @@ function swappedBrandNameScore(
   return null;
 }
 
-export async function lookupBeer(args: LookupArgs): Promise<LookupOutcome> {
+export async function lookupBeer(args: LookupArgs, headRetried = false): Promise<LookupOutcome> {
   const { brewery, name, abv = null } = args;
   const inputBreweryAliases = breweryAliases(brewery);
   const targetNames = fuzzyTargets(name, brewery);
@@ -313,5 +325,24 @@ export async function lookupBeer(args: LookupArgs): Promise<LookupOutcome> {
     // No name match in this search part — fall through to the next part.
   }
 
+  // #271 fallback: the search returned zero candidates across every brewery part — a genuine
+  // query-zeroing (a matcher rejection would leave seenCandidates non-empty and is NOT retried).
+  // If the name has a comma/#N flavour-list tail, retry the WHOLE lookup once with the head only,
+  // so the tail cannot AND-zero the Algolia search. Matching then evaluates the head (brewery gate
+  // unchanged) — this is what lets a short Untappd name match. Single retry (headRetried guard).
+  if (!headRetried && seenCandidates.length === 0) {
+    const head = headBeforeTail(name);
+    if (head) {
+      const retry = await lookupBeer({ ...args, name: head }, true);
+      if (retry.kind === 'not_found') {
+        return {
+          kind: 'not_found',
+          searchUrls: [...triedUrls, ...retry.searchUrls],
+          candidates: retry.candidates,
+        };
+      }
+      return retry;
+    }
+  }
   return { kind: 'not_found', searchUrls: triedUrls, candidates: seenCandidates };
 }


### PR DESCRIPTION
## Summary
Two follow-ups from #236 that stop `cleanSearchQuery`/`lookupBeer` from building Untappd/Algolia queries that AND-zero the search.

- **#270** — `cleanSearchQuery` no longer (a) splits a beer *name* on ` x ` (a `x <partner>` shop artifact was being treated as a collab-brewery separator) nor (b) globally fold-dedups, which destroyed mid-name tokens that happen to repeat a brewery token. Now: brewery and name are tokenized separately, and only the **leading/trailing** name runs that duplicate a brewery brand token are stripped (preserves #126 leading + #155 trailing restatement); mid-name duplicates are kept (Algolia collapses identical terms). Fixes 31133 `Magic Road Upside Down: to` → `… Upside Down: Road to Upside`.
- **#271 (narrowed)** — `lookupBeer` gets a single whole-lookup **head-retry**: only when the search returned **zero candidates** and the name has a `,`/`#N` flavour-list tail, it retries once with the head (matching then evaluates the head, brewery gate intact). Deliberately **excludes** the ` - ` dash and any token-cap (too risky — deferred to a follow-up in the spec).

Spec: `docs/superpowers/specs/2026-07/2026-07-15-matcher-query-overconstraint-236-followups-design.md`
Plan: `docs/superpowers/plans/2026-07/2026-07-15-matcher-query-overconstraint-236-followups.md`

## Validation
- Unit tests (TDD): 3 new `cleanSearchQuery` cases (+ all pre-existing #126/#155 guards pass), 4 new `lookupBeer` head-retry cases (fires/gates/dash-excluded/single-retry).
- Full suite: **1188/1188** green; `tsc --noEmit` clean.
- **Read-only prod dry-run** over 279 `matcher_bug` `enrich_failures` rows (new vs current-main `cleanSearchQuery`, production first-brewery-part): **6 rows changed, 0 newly-empty, 0 rows where any token was dropped** — every change strictly *restores* a real beer-name token that global-dedup had destroyed (e.g. `Kwak` in "Pauwel Kwak", second `WINE` in "BARLEY WINE", `Schlenkerla`, plus the 31133 target).

## Test Plan
- [ ] AI PR review pass
- [ ] Post-deploy: watch head-retry call volume vs the Untappd breaker budget; review match-quality on the `,`/`#N` class

Closes #270