### PR TITLE
fix(beerfreak): strip leading brewery run on brand_title/title divergence (#305)

### DIFF
--- a/docs/superpowers/plans/2026-07/2026-07-18-beerfreak-brand-title-divergence.md
+++ b/docs/superpowers/plans/2026-07/2026-07-18-beerfreak-brand-title-divergence.md
@@ -1,0 +1,218 @@
+# BeerFreak brand/title divergence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop BeerFreak duplicating the brewery into the beer name when `brand_title` renders differently than the title's leading brewery form (issue #305).
+
+**Architecture:** In `cleanName` (`extension/src/sites/beerfreak.ts`), keep the existing exact-prefix fast path untouched (it handles matching brands and slash collaborators); add a token-run fallback for the divergent case that strips leading title tokens which are brand-core tokens or brewery-descriptor words, leaving the beer name.
+
+**Tech Stack:** TypeScript (ESM), Vitest. Run commands from `extension/`.
+
+**Spec:** `docs/superpowers/specs/2026-07/2026-07-18-beerfreak-brand-title-divergence-design.md`
+
+---
+
+## Context for the implementer
+
+- All paths are under `extension/`. `npm test` = `vitest run`; run a subset with `npm test -- <path>`.
+- The bug: `cleanName(rawTitle, brewery)` strips the brewery from the title by an **exact case-insensitive prefix match** of `brand_title`. When the title's leading brewery form differs (e.g. brand `HOPPY HOG BREWERY` vs title `Hoppy Hog Family Brewery …`), the check fails and the whole title becomes the name.
+- Existing helpers in the file you will reuse (do NOT reimplement): `normalizedToken(token)` — lowercases and strips `( ) ,`; `stripLeadingCollaborator`, `BREWERY_NOISE_PREFIX_RE` (used only by the fast path).
+- Tests drive the public `beerfreak.parseCards` via the existing helper `docWithProducts([{ id, brand_title, title }])`. `cleanName` and the new helper are module-private — test them through `parseCards`.
+- Only two brands in the fixture actually diverge: `HOPPY HOG BREWERY` (title inserts `Family`) and `BROKREACJA BREWERY` (title localizes to `Browar Brokreacja`). Brands whose cleaned brand is a title prefix (Volta, Rebrew, SHO, PINTA) already work via the fast path and must not change.
+
+---
+
+## Task 1: Token-run fallback for divergent brand_title
+
+**Files:**
+- Modify: `extension/src/sites/beerfreak.ts`
+- Test: `extension/src/sites/beerfreak.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these tests inside the `describe('beerfreak adapter', …)` block in `extension/src/sites/beerfreak.test.ts`:
+
+```ts
+  it('strips the leading brewery run when brand_title diverges from the title form', () => {
+    const parsed = beerfreak.parseCards(docWithProducts([
+      { id: 20001, brand_title: 'HOPPY HOG BREWERY (Україна)', title: 'Hoppy Hog Family Brewery Tropical Veil NEIPA' },
+      { id: 20002, brand_title: 'BROKREACJA BREWERY (Польща)', title: 'Browar Brokreacja NAFCIARZ 19' },
+    ]));
+
+    expect(parsed).toContainEqual(expect.objectContaining({
+      brewery: 'HOPPY HOG BREWERY',
+      name: 'Tropical Veil NEIPA',
+    }));
+    expect(parsed).toContainEqual(expect.objectContaining({
+      brewery: 'BROKREACJA BREWERY',
+      name: 'NAFCIARZ 19',
+    }));
+  });
+
+  it('does not over-strip when the title tokens do not include a brand-core token', () => {
+    // brand-core "zzz" never appears in the title → no strip, full title kept as name
+    const parsed = beerfreak.parseCards(docWithProducts([
+      { id: 20003, brand_title: 'ZZZ BREWERY (Nowhere)', title: 'Family Reunion Imperial Stout' },
+    ]));
+
+    expect(parsed).toContainEqual(expect.objectContaining({
+      brewery: 'ZZZ BREWERY',
+      name: 'Family Reunion Imperial Stout',
+    }));
+  });
+
+  it('leaves exact-prefix brands and the SHO paren-alias case unchanged (regression)', () => {
+    const parsed = beerfreak.parseCards(docWithProducts([
+      { id: 20004, brand_title: 'VOLTA BREWERY (Україна)', title: 'Volta Brewery MODERN PILSNER' },
+      { id: 20005, brand_title: 'SHO BREWERY (Україна)', title: 'SHO Brewery (IIIO) Narcissus' },
+    ]));
+
+    expect(parsed).toContainEqual(expect.objectContaining({
+      brewery: 'VOLTA BREWERY',
+      name: 'MODERN PILSNER',
+    }));
+    expect(parsed).toContainEqual(expect.objectContaining({
+      brewery: 'SHO BREWERY',
+      name: '(IIIO) Narcissus',
+    }));
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- src/sites/beerfreak.test.ts -t "brewery run"`
+Expected: FAIL — the HOPPY HOG / BROKREACJA names still contain the duplicated brewery (e.g. `Hoppy Hog Family Brewery Tropical Veil NEIPA`). (The over-strip and regression tests may already pass; that is fine — the divergence test must fail.)
+
+- [ ] **Step 3: Add the descriptor set**
+
+In `extension/src/sites/beerfreak.ts`, add this constant next to the existing brewery-word sets (right after the `COLLABORATOR_TERMINAL_WORDS` declaration, around line 18):
+
+```ts
+// Words that appear as brewery descriptors in a title's leading brewery form
+// (structural forms + "family" for "<X> Family Brewery"). Lowercased; compared
+// with normalizedToken (which strips ( ) , ).
+const BREWERY_DESCRIPTORS = new Set([
+  'brewery', 'brewing', 'browar', 'brasserie', 'brouwerij', 'brauerei',
+  'pivovar', 'birrificio', 'company', 'co', 'co.', 'family',
+]);
+```
+
+- [ ] **Step 4: Add the token-run helper**
+
+In `extension/src/sites/beerfreak.ts`, add this function immediately **before** `cleanName`:
+
+```ts
+// Divergent brand_title: strip the leading brewery *run* from the title. Consume
+// leading tokens that are brand-core tokens (from brand_title, minus descriptors)
+// or brewery-descriptor words; the remainder is the beer name. Returns '' when no
+// brand token was matched (so a name that merely starts with a descriptor is not
+// eaten) or when nothing remains, letting the caller fall back to the full title.
+function stripLeadingBreweryRun(rawTitle: string, brewery: string): string {
+  const brandCore = new Set(
+    brewery.toLowerCase().split(/\s+/).filter((t) => t && !BREWERY_DESCRIPTORS.has(t)),
+  );
+  if (brandCore.size === 0) return '';
+
+  const tokens = rawTitle.replace(/\s+/g, ' ').trim().split(' ').filter(Boolean);
+  let i = 0;
+  let matchedBrand = false;
+  while (i < tokens.length) {
+    const t = normalizedToken(tokens[i]);
+    if (brandCore.has(t)) { matchedBrand = true; i += 1; continue; }
+    if (BREWERY_DESCRIPTORS.has(t)) { i += 1; continue; }
+    break;
+  }
+  if (!matchedBrand) return '';
+  return tokens.slice(i).join(' ').trim();
+}
+```
+
+- [ ] **Step 5: Wire the fallback into `cleanName`**
+
+Replace the existing `cleanName` function body in `extension/src/sites/beerfreak.ts`:
+
+```ts
+function cleanName(rawTitle: string, brewery: string): string {
+  const b = brewery.trim();
+  if (!b) return rawTitle.trim();
+
+  const prefix = rawTitle.slice(0, b.length);
+  if (prefix.toLowerCase() !== b.toLowerCase()) return rawTitle.trim();
+
+  return stripLeadingCollaborator(rawTitle.slice(b.length))
+    .replace(BREWERY_NOISE_PREFIX_RE, '')
+    .trim() || rawTitle.trim();
+}
+```
+
+with:
+
+```ts
+function cleanName(rawTitle: string, brewery: string): string {
+  const b = brewery.trim();
+  if (!b) return rawTitle.trim();
+
+  const prefix = rawTitle.slice(0, b.length);
+  if (prefix.toLowerCase() === b.toLowerCase()) {
+    // exact-prefix path (also handles leading slash collaborators)
+    return stripLeadingCollaborator(rawTitle.slice(b.length))
+      .replace(BREWERY_NOISE_PREFIX_RE, '')
+      .trim() || rawTitle.trim();
+  }
+  // divergent brand_title → token-run strip of the leading brewery form
+  return stripLeadingBreweryRun(rawTitle, b) || rawTitle.trim();
+}
+```
+
+- [ ] **Step 6: Run the new tests + full file to verify pass and no regressions**
+
+Run: `npm test -- src/sites/beerfreak.test.ts`
+Expected: PASS — the three new tests plus all pre-existing beerfreak tests. If a pre-existing test fails, STOP and report it (the fast path and brandless/collab paths must be byte-for-byte unchanged; investigate rather than editing other tests).
+
+- [ ] **Step 7: Typecheck**
+
+Run: `npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/sites/beerfreak.ts src/sites/beerfreak.test.ts
+git commit -m "fix(beerfreak): strip leading brewery run on brand_title/title divergence (#305)"
+```
+
+---
+
+## Task 2: Full suite, docs/spec gate, finalize
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full extension test suite**
+
+Run: `npm test`
+Expected: PASS — all files, no regressions.
+
+- [ ] **Step 2: Docs gate (CLAUDE.md extension rule)**
+
+This change is parser-internal — no new store, popup, checkbox, badge, or install/update flow. So `docs/extension-install-uk.md` does **not** need an update. Confirm this still holds; if any user-visible behavior changed, update that doc in this PR.
+
+- [ ] **Step 3: Spec sync check (CLAUDE.md OpenSpec rule)**
+
+Run `grep -in beerfreak spec.md`. The BeerFreak entry describes brand/slug metadata + slash-collaborator handling; confirm the new token-run fallback does not contradict it. If `spec.md` states the brewery/name derivation in a way this change makes stale, update that sentence in this PR; otherwise no change.
+
+- [ ] **Step 4: Final commit if any doc/spec update was needed**
+
+```bash
+git add -A && git commit -m "docs(beerfreak): sync spec for brand/title divergence fix (#305)"
+```
+
+(Skip if Steps 2-3 required no changes.)
+
+---
+
+## Self-review checklist (completed by plan author)
+
+- **Spec coverage:** exact-prefix fast path preserved (Step 5), token-run fallback with brand-core ∪ descriptor consumption + matched-brand guard + full-title fallback (Steps 3-5), divergent cases fixed + fast-path/over-strip regression covered (Step 1), out-of-scope brewery emission untouched, docs/spec gate (Task 2). ✓
+- **Placeholder scan:** all code is complete literals; no TBD/TODO. ✓
+- **Type consistency:** `BREWERY_DESCRIPTORS` and `stripLeadingBreweryRun(rawTitle, brewery)` named identically across Steps 3-5; `normalizedToken` is the existing helper. ✓
+```

--- a/docs/superpowers/specs/2026-07/2026-07-18-beerfreak-brand-title-divergence-design.md
+++ b/docs/superpowers/specs/2026-07/2026-07-18-beerfreak-brand-title-divergence-design.md
@@ -1,0 +1,139 @@
+# Extension/BeerFreak: fix brewery duplicated into name on brand/title divergence (#305)
+
+- **Date**: 2026-07-18
+- **Issues**: #305 (narrowed to this class during triage). Related: #295 (matcher — `Trillium / Macaroon Macaroon` moved there). Parent: #255.
+- **Files**: `extension/src/sites/beerfreak.ts`, `extension/src/sites/beerfreak.test.ts`.
+
+## Problem
+
+BeerFreak product metadata gives each card a `brand_title` and a `title`. The adapter emits
+`brewery = cleanBrewery(brand_title)` and derives the beer name via `cleanName`, which strips the
+brewery from the title using an **exact case-insensitive prefix match** of `brand_title` against
+`title`:
+
+```ts
+const prefix = rawTitle.slice(0, b.length);
+if (prefix.toLowerCase() !== b.toLowerCase()) return rawTitle.trim();  // <-- gives up, keeps whole title
+```
+
+`brand_title` is an uppercased, `(Country)`-suffixed, and often **divergent** form of the brewery,
+while `title` renders the brewery in its real display form. When the two differ, the exact-prefix
+check fails and `cleanName` returns the **entire title**, so the brewery ends up duplicated inside
+the beer name.
+
+Observed in the fixture (`extension/tests/fixtures/beerfreak.html`):
+
+| `brand_title` (→ `cleanBrewery`) | `title` | today's name |
+|---|---|---|
+| `HOPPY HOG BREWERY (Україна)` → `HOPPY HOG BREWERY` | `Hoppy Hog Family Brewery Tropical Veil NEIPA` | `Hoppy Hog Family Brewery Tropical Veil NEIPA` ✗ |
+| `BROKREACJA BREWERY (Польща)` → `BROKREACJA BREWERY` | `Browar Brokreacja NAFCIARZ 19` | `Browar Brokreacja NAFCIARZ 19` ✗ |
+
+Only two brands in the fixture are genuinely divergent: `HOPPY HOG BREWERY` (title inserts
+`Family`) and `BROKREACJA BREWERY` (title localizes to `Browar Brokreacja`). Brands whose cleaned
+`brand_title` *is* a prefix of the title head — Volta, Rebrew, Kyiv Local, La Superbe, Sparkle, and
+even `SHO BREWERY` / `SHO Brewery (IIIO) …` — already take the fast path correctly and must stay
+working, as must the slash-collaborator path (`PINTA/Folkingebrew …`).
+
+### Scope note (why #305 is narrow)
+
+Most of #305's original examples are **already fixed** in code by #213 (slash collaborators,
+2026-06-26) and #289 (bundle/series rejection, 2026-07-12), both of which postdate the failure
+captures (2026-06-19…28). Those are stale rows that clear once the held extension release ships.
+Verified against current code: `WORLD CUP SERIES - 8 SPECIAL BEER` and `Дегустаціний сет …` →
+`isBeerFreakBundle=true` (rejected); `Winter Break Variety Twelve Pack` → `isNonBeerName=true`
+(rejected). The only genuinely-live parser bug is the brand/title divergence above.
+`Trillium / Macaroon Macaroon` (beerrepublic) is a matcher concern → **#295**.
+
+## Design
+
+Fix is local to `cleanName` in `beerfreak.ts`. Keep the exact-prefix fast path; add a token-run
+fallback for the divergent case.
+
+```ts
+// Words that appear as brewery descriptors in a BeerFreak title's leading brewery
+// form (structural forms + "family" for "<X> Family Brewery"). Lowercased.
+const BREWERY_DESCRIPTORS = new Set([
+  'brewery', 'brewing', 'browar', 'brasserie', 'brouwerij', 'brauerei',
+  'pivovar', 'birrificio', 'company', 'co', 'co.', 'family',
+]);
+
+// Divergent brand_title: strip the leading brewery *run* from the title. Consume
+// leading tokens that are brand-core tokens (from brand_title, minus descriptors)
+// or brewery-descriptor words; the remainder is the beer name. Returns '' when no
+// brand token matched (so a name that merely starts with a descriptor is not eaten)
+// or when nothing remains, letting the caller fall back to the full title.
+function stripLeadingBreweryRun(rawTitle: string, brewery: string): string {
+  const brandCore = new Set(
+    brewery.toLowerCase().split(/\s+/).filter((t) => t && !BREWERY_DESCRIPTORS.has(t)),
+  );
+  if (brandCore.size === 0) return '';
+  const tokens = rawTitle.replace(/\s+/g, ' ').trim().split(' ').filter(Boolean);
+  let i = 0;
+  let matchedBrand = false;
+  while (i < tokens.length) {
+    const t = normalizedToken(tokens[i]); // existing helper: lowercases, strips ( ) ,
+    if (brandCore.has(t)) { matchedBrand = true; i += 1; continue; }
+    if (BREWERY_DESCRIPTORS.has(t)) { i += 1; continue; }
+    break;
+  }
+  if (!matchedBrand) return '';
+  return tokens.slice(i).join(' ').trim();
+}
+```
+
+`cleanName` becomes:
+
+```ts
+function cleanName(rawTitle: string, brewery: string): string {
+  const b = brewery.trim();
+  if (!b) return rawTitle.trim();
+
+  const prefix = rawTitle.slice(0, b.length);
+  if (prefix.toLowerCase() === b.toLowerCase()) {
+    // exact-prefix path (also handles leading slash collaborators)
+    return stripLeadingCollaborator(rawTitle.slice(b.length))
+      .replace(BREWERY_NOISE_PREFIX_RE, '')
+      .trim() || rawTitle.trim();
+  }
+  // divergent brand_title → token-run strip of the leading brewery form
+  return stripLeadingBreweryRun(rawTitle, b) || rawTitle.trim();
+}
+```
+
+### Behavior
+
+- `Hoppy Hog Family Brewery Tropical Veil NEIPA` (brand `HOPPY HOG BREWERY`) → strip
+  `Hoppy`(brand) `Hog`(brand) `Family`(desc) `Brewery`(desc) → `Tropical Veil NEIPA`.
+- `Browar Brokreacja NAFCIARZ 19` (brand `BROKREACJA BREWERY`) → strip `Browar`(desc)
+  `Brokreacja`(brand) → `NAFCIARZ 19`.
+- Exact-prefix brands (Volta/Rebrew/Kyiv Local, and `SHO Brewery (IIIO) …` → `(IIIO) Narcissus`)
+  and slash collabs (`PINTA/…`) take the fast path, unchanged.
+
+### Out of scope
+
+- The emitted **brewery** stays `cleanBrewery(brand_title)`; a brewery-form mismatch vs Untappd
+  (`HOPPY HOG BREWERY` vs `Hoppy Hog Family Brewery`) is a matcher/alias concern, not this PR.
+- Brandless / collaborator path (`splitBrandlessTitle`, #213) and bundle rejection (#289) unchanged.
+
+## Testing
+
+Extend `extension/src/sites/beerfreak.test.ts` (Vitest):
+
+- **Divergent brands fixed** (via `parseCards` over `beerfreak.html`, matching by `name`):
+  `Hoppy Hog Family Brewery Tropical Veil NEIPA` → `{ brewery: 'HOPPY HOG BREWERY', name: 'Tropical Veil NEIPA' }`;
+  `Browar Brokreacja NAFCIARZ 19` → `{ brewery: 'BROKREACJA BREWERY', name: 'NAFCIARZ 19' }`.
+- **No regression (fast path)**: an exact-prefix brand (`Volta Brewery MODERN PILSNER` → name
+  `MODERN PILSNER`), the paren-alias case (`SHO Brewery (IIIO) Narcissus` → name `(IIIO) Narcissus`),
+  and a slash collab (`PINTA/Folkingebrew Hazy Discovery Groningen` → collaborator handling
+  unchanged) still parse as before.
+- **Guard**: a title whose name legitimately starts with a descriptor but whose brand tokens are
+  absent from the head is not over-stripped (token-run returns '' → full-title fallback).
+
+Existing fixture suffices; no new fixture needed.
+
+## Success criteria
+
+- Divergent-brand BeerFreak cards emit a clean beer name with no duplicated brewery.
+- All existing `beerfreak.test.ts` cases still pass.
+- Change confined to `cleanName` + one new helper + one descriptor set; brewery emission and other
+  paths untouched.

--- a/extension/src/sites/beerfreak.test.ts
+++ b/extension/src/sites/beerfreak.test.ts
@@ -225,4 +225,47 @@ describe('beerfreak adapter', () => {
   it('does not define waitForGrid (SSR)', () => {
     expect(beerfreak.waitForGrid).toBeUndefined();
   });
+
+  it('strips the leading brewery run when brand_title diverges from the title form', () => {
+    const parsed = beerfreak.parseCards(docWithProducts([
+      { id: 20001, brand_title: 'HOPPY HOG BREWERY (Україна)', title: 'Hoppy Hog Family Brewery Tropical Veil NEIPA' },
+      { id: 20002, brand_title: 'BROKREACJA BREWERY (Польща)', title: 'Browar Brokreacja NAFCIARZ 19' },
+    ]));
+
+    expect(parsed).toContainEqual(expect.objectContaining({
+      brewery: 'HOPPY HOG BREWERY',
+      name: 'Tropical Veil NEIPA',
+    }));
+    expect(parsed).toContainEqual(expect.objectContaining({
+      brewery: 'BROKREACJA BREWERY',
+      name: 'NAFCIARZ 19',
+    }));
+  });
+
+  it('does not over-strip when the title tokens do not include a brand-core token', () => {
+    const parsed = beerfreak.parseCards(docWithProducts([
+      { id: 20003, brand_title: 'ZZZ BREWERY (Nowhere)', title: 'Family Reunion Imperial Stout' },
+    ]));
+
+    expect(parsed).toContainEqual(expect.objectContaining({
+      brewery: 'ZZZ BREWERY',
+      name: 'Family Reunion Imperial Stout',
+    }));
+  });
+
+  it('leaves exact-prefix brands and the SHO paren-alias case unchanged (regression)', () => {
+    const parsed = beerfreak.parseCards(docWithProducts([
+      { id: 20004, brand_title: 'VOLTA BREWERY (Україна)', title: 'Volta Brewery MODERN PILSNER' },
+      { id: 20005, brand_title: 'SHO BREWERY (Україна)', title: 'SHO Brewery (IIIO) Narcissus' },
+    ]));
+
+    expect(parsed).toContainEqual(expect.objectContaining({
+      brewery: 'VOLTA BREWERY',
+      name: 'MODERN PILSNER',
+    }));
+    expect(parsed).toContainEqual(expect.objectContaining({
+      brewery: 'SHO BREWERY',
+      name: '(IIIO) Narcissus',
+    }));
+  });
 });

--- a/extension/src/sites/beerfreak.ts
+++ b/extension/src/sites/beerfreak.ts
@@ -15,6 +15,13 @@ const BREWERY_NOISE_PREFIX_RE = /^(?:brewery|brewing|browar|brouwerij|brasserie)
 const LEADING_BREWERY_DESCRIPTORS = new Set(['brouwerij', 'brasserie', 'browar', 'pivovar', 'birrificio', 'brauerei']);
 const COLLABORATOR_COMPANY_WORDS = new Set(['beer', 'brewing']);
 const COLLABORATOR_TERMINAL_WORDS = new Set(['brewery', 'company', 'co', 'co.']);
+// Words that appear as brewery descriptors in a title's leading brewery form
+// (structural forms + "family" for "<X> Family Brewery"). Lowercased; compared
+// with normalizedToken (which strips ( ) , ).
+const BREWERY_DESCRIPTORS = new Set([
+  'brewery', 'brewing', 'browar', 'brasserie', 'brouwerij', 'brauerei',
+  'pivovar', 'birrificio', 'company', 'co', 'co.', 'family',
+]);
 const BEERFREAK_BUNDLE_RE = /(?:^|[^\p{L}\p{N}])(?:mix\s+pack|tasting\s+set|set|сет)(?=$|[^\p{L}\p{N}])/iu;
 const BEERFREAK_NUMBERED_SERIES_RE = /(?:^|[^\p{L}\p{N}])series\s*[-:]?\s*\d+\s+special\s+beers?(?=$|[^\p{L}\p{N}])/iu;
 const MAX_DETAIL_FETCHES_PER_PASS = 20;
@@ -36,16 +43,43 @@ function cleanBrewery(raw: string | null): string {
     .trim();
 }
 
+// Divergent brand_title: strip the leading brewery *run* from the title. Consume
+// leading tokens that are brand-core tokens (from brand_title, minus descriptors)
+// or brewery-descriptor words; the remainder is the beer name. Returns '' when no
+// brand token was matched (so a name that merely starts with a descriptor is not
+// eaten) or when nothing remains, letting the caller fall back to the full title.
+function stripLeadingBreweryRun(rawTitle: string, brewery: string): string {
+  const brandCore = new Set(
+    brewery.toLowerCase().split(/\s+/).filter((t) => t && !BREWERY_DESCRIPTORS.has(t)),
+  );
+  if (brandCore.size === 0) return '';
+
+  const tokens = rawTitle.replace(/\s+/g, ' ').trim().split(' ').filter(Boolean);
+  let i = 0;
+  let matchedBrand = false;
+  while (i < tokens.length) {
+    const t = normalizedToken(tokens[i]);
+    if (brandCore.has(t)) { matchedBrand = true; i += 1; continue; }
+    if (BREWERY_DESCRIPTORS.has(t)) { i += 1; continue; }
+    break;
+  }
+  if (!matchedBrand) return '';
+  return tokens.slice(i).join(' ').trim();
+}
+
 function cleanName(rawTitle: string, brewery: string): string {
   const b = brewery.trim();
   if (!b) return rawTitle.trim();
 
   const prefix = rawTitle.slice(0, b.length);
-  if (prefix.toLowerCase() !== b.toLowerCase()) return rawTitle.trim();
-
-  return stripLeadingCollaborator(rawTitle.slice(b.length))
-    .replace(BREWERY_NOISE_PREFIX_RE, '')
-    .trim() || rawTitle.trim();
+  if (prefix.toLowerCase() === b.toLowerCase()) {
+    // exact-prefix path (also handles leading slash collaborators)
+    return stripLeadingCollaborator(rawTitle.slice(b.length))
+      .replace(BREWERY_NOISE_PREFIX_RE, '')
+      .trim() || rawTitle.trim();
+  }
+  // divergent brand_title → token-run strip of the leading brewery form
+  return stripLeadingBreweryRun(rawTitle, b) || rawTitle.trim();
 }
 
 function normalizedToken(token: string): string {


### PR DESCRIPTION
## Summary
- BeerFreak's `brand_title` is an uppercased, `(Country)`-suffixed, often **divergent** form of the brewery, while the product `title` renders the brewery differently (`HOPPY HOG BREWERY` vs `Hoppy Hog Family Brewery …`, `BROKREACJA BREWERY` vs `Browar Brokreacja …`). `cleanName` stripped the brewery by an **exact prefix match**, so on divergence it kept the whole title → the brewery was duplicated into the beer name.
- Fix, localized to `cleanName`: keep the exact-prefix fast path (matching brands + slash collaborators, unchanged); add a **token-run fallback** (`stripLeadingBreweryRun`) that consumes leading title tokens which are brand-core tokens or brewery-descriptor words (`brewery/browar/family/…`), leaving the beer name. Guarded so a name that merely starts with a descriptor is never eaten (requires a matched brand token), with a full-title fallback.
- `Hoppy Hog Family Brewery Tropical Veil NEIPA` → name `Tropical Veil NEIPA`; `Browar Brokreacja NAFCIARZ 19` → `NAFCIARZ 19`.

## Scope
- **Narrowed** from #305's original list: the bundle/series and slash-collab examples were already fixed by #289/#213 (stale rows clearing with the held extension release); the `Trillium / Macaroon Macaroon` dup moved to #295 (matcher). Treating `family` as brewery noise server-side is filed separately as #309.
- Emitted **brewery** is unchanged (`brand_title`); a brewery-form mismatch vs Untappd stays a matcher/alias concern.

## Test Plan
- [x] `npm test` — 373/373 pass (3 new beerfreak tests: divergence fix, over-strip guard, fast-path/SHO regression)
- [x] `npm run typecheck` — clean
- [x] Fast path (Volta/SHO/PINTA collab) and brandless path unchanged — verified by existing tests
- [x] Parser-internal; no `docs/extension-install-uk.md` or `spec.md` change needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)