### PR TITLE
release(extension): cut 0.12.0 — Flasker/BeerFreak parser fixes + no-token ratings

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
-## [0.11.0] - 2026-07-10
+## [0.12.0] - 2026-07-18
 
+- Improved Flasker brewery detection: listings where the brewery isn't the first word of the title — or appears only in a product tag or the brand strip — now identify the correct brewery for dozens more breweries, instead of guessing the first word, so more beers match and badge correctly.
+- Fixed BeerFreak beer names that duplicated the brewery (e.g. "Hoppy Hog Family Brewery Hoppy Hog …") when the shop's brand label and product title used different brewery wordings; the brewery is no longer repeated inside the beer name.
 - Extension now shows global Untappd ratings (⭐) on supported shops even without a token; the popup shows a "Not connected" note and links to token setup. Personal ✅/rating badges still require a token.
 - Fixed BeerFreak filtering so tasting sets, mix packs, and numbered multi-beer series are ignored instead of being matched as individual beers.
 - Fixed Funkyshop parsing on English/home grids: product detail fallback now fills missing breweries, can/deposit rows are ignored, and trailing volume/format text is removed from beer names before matching.

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "warsaw-beer-extension",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "warsaw-beer-extension",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "devDependencies": {
         "@crxjs/vite-plugin": "^2.7.1",
         "@types/chrome": "^0.0.270",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "warsaw-beer-extension",
   "private": true,
-  "version": "0.11.0",
+  "version": "0.12.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Cuts extension **0.12.0**.

### ⚠️ Note: this supersedes a never-published 0.11.0
0.11.0 was cut in git (#261) but **never written to prod `extension_releases` and never broadcast** — the last release actually shipped to users is **0.10.0** (2026-06-30). So 0.12.0 consolidates *all* user-facing changes since 0.10.0, otherwise the broadcast (which pulls only the `## [0.12.0]` section) would silently drop the 0.11.0 features from users still on 0.10.0.

### User-facing changes bundled
- **#304** Flasker generalized brewery/name split via generated registry — correct brewery for dozens more listings.
- **#305** BeerFreak brand_title/title divergence — brewery no longer duplicated into the beer name.
- Anonymous no-token ⭐ ratings, BeerFreak bundle filtering (#289), Funkyshop + Piwne Mosty parsing fixes (from the 0.11.0 cut).

### Also merged since 0.10.0 (not user-facing)
- **#103** dev-toolchain bump (vite 5→8 / vitest 2→4) — dev-only.

### Verification
- 373 extension tests green (vitest 4), typecheck clean.
- `npm run package` builds dist + zip; `RELEASE_NOTES.txt` extracts the consolidated 0.12.0 section correctly.

After merge: run `npm run release` from repo root to write the prod DB row + stage the zip, then forward the zip to the bot → 📣.

🤖 Generated with [Claude Code](https://claude.com/claude-code)