### PR TITLE
release(extension): scope 0.12.0 notes to delta since CWS-shipped 0.11.0

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Changelog
 
-## [0.12.0] - 2026-07-18
+## [0.12.0] - 2026-07-19
 
 - Improved Flasker brewery detection: listings where the brewery isn't the first word of the title — or appears only in a product tag or the brand strip — now identify the correct brewery for dozens more breweries, instead of guessing the first word, so more beers match and badge correctly.
 - Fixed BeerFreak beer names that duplicated the brewery (e.g. "Hoppy Hog Family Brewery Hoppy Hog …") when the shop's brand label and product title used different brewery wordings; the brewery is no longer repeated inside the beer name.
-- Extension now shows global Untappd ratings (⭐) on supported shops even without a token; the popup shows a "Not connected" note and links to token setup. Personal ✅/rating badges still require a token.
 - Fixed BeerFreak filtering so tasting sets, mix packs, and numbered multi-beer series are ignored instead of being matched as individual beers.
+
+## [0.11.0] - 2026-07-10
+
+- Extension now shows global Untappd ratings (⭐) on supported shops even without a token; the popup shows a "Not connected" note and links to token setup. Personal ✅/rating badges still require a token.
 - Fixed Funkyshop parsing on English/home grids: product detail fallback now fills missing breweries, can/deposit rows are ignored, and trailing volume/format text is removed from beer names before matching.
 - Fixed Piwne Mosty parsing so out-of-stock placeholders such as "Chwilowy brak:(" and "Wypite" are ignored instead of being sent as brewery or beer names.
 


### PR DESCRIPTION
Follow-up correction to #312.

**Context I got wrong in #312:** I judged 0.11.0 "never published" from the bot channel alone (its `extension_releases` table tops out at 0.10.0). But **0.11.0 shipped via the Chrome Web Store**, which is now the primary channel — the bot channel is a backup, currently at 0.10.0.

So consolidating everything since 0.10.0 into 0.12.0 was wrong: CWS users on 0.11 would get release notes re-announcing features they already have.

**This PR:**
- Restores `## [0.11.0]` as its own shipped section (no-token ⭐ ratings, Funkyshop + Piwne Mosty parsing fixes).
- Scopes `## [0.12.0]` to the true delta since 0.11:
  - #304 Flasker generalized brewery/name split
  - #305 BeerFreak brand_title/title divergence
  - #289 BeerFreak bundle filtering (confirmed not in the CWS 0.11 build)

Changelog-only; version stays 0.12.0. `RELEASE_NOTES.txt` now extracts just the three delta lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)