### PR TITLE
feat(docs): add changelog page to GitHub Pages site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,7 +3,7 @@ name: Deploy privacy policy to Pages
 on:
   push:
     branches: [main]
-    paths: ['site/**', 'docs/extension-install-*.md', 'scripts/render-docs.ts', '.github/workflows/pages.yml']
+    paths: ['site/**', 'docs/extension-install-*.md', 'extension/CHANGELOG.md', 'scripts/render-docs.ts', '.github/workflows/pages.yml']
   workflow_dispatch:
 
 permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ extension/warsaw-beer-overlay-*.zip
 # Scratch folder for the current task (see CLAUDE.md ./tmp/ policy)
 tmp/
 
-# Generated on GitHub Pages from docs/extension-install-*.md (see scripts/render-docs.ts)
+# Generated on GitHub Pages from docs/extension-install-*.md + extension/CHANGELOG.md (see scripts/render-docs.ts)
 site/install/
 site/install-uk/
+site/changelog/

--- a/docs/superpowers/plans/2026-07/2026-07-19-changelog-page.md
+++ b/docs/superpowers/plans/2026-07/2026-07-19-changelog-page.md
@@ -1,0 +1,58 @@
+# Changelog page on GitHub Pages — implementation plan
+
+Spec: `docs/superpowers/specs/2026-07/2026-07-19-changelog-page-design.md`
+
+## Task 1 — Generalize `renderPage` (TDD)
+
+`scripts/render-docs.ts` / `scripts/render-docs.test.ts`.
+
+Make `RenderOptions`:
+- `title?: string` — optional, defaults to `'Warsaw Beer Overlay — Setup'` (preserves
+  existing install-guide output and the current test).
+- `altLang?`, `altHref?` — optional. The nav renders the alternate-language link **only
+  when both are provided**; otherwise the nav contains just the "← Home" link.
+
+Steps (red → green):
+1. Add tests to `render-docs.test.ts`:
+   - custom `title` appears in `<title>` when provided;
+   - when `altLang`/`altHref` are omitted, output has the "← Home" link but no
+     alternate-language link (assert `українською` / `Read in English` absent, and no
+     second nav `<a>`); the existing "with alt link" cases stay green.
+2. Update `renderPage`: parametrize `<title>`; build the nav link list conditionally.
+3. Run `npx vitest run scripts/render-docs.test.ts` → green.
+
+## Task 2 — Add the changelog render target
+
+`scripts/render-docs.ts` `main()`.
+
+Add a third target: `extension/CHANGELOG.md` → `site/changelog/index.html`, with
+`lang: 'en'`, `title: 'Warsaw Beer Overlay — Changelog'`, `homeHref: '../'`, and no
+`altLang`/`altHref`. Install-guide targets pass `title: 'Warsaw Beer Overlay — Setup'`
+explicitly (or rely on the default).
+
+Verify: `npm run render-docs` writes `site/changelog/index.html`; open it / grep for a
+known changelog line (e.g. `0.12.0`) and confirm no alternate-language nav link.
+
+## Task 3 — Link from the landing page
+
+`site/index.html`: add `<li>📝 <a href="changelog/">Changelog</a></li>` to `ul.links`
+(after the two install-guide links).
+
+## Task 4 — CI trigger
+
+`.github/workflows/pages.yml`: add `extension/CHANGELOG.md` to `on.push.paths`.
+
+## Verification
+
+- `npx vitest run scripts/render-docs.test.ts` green.
+- `npm run render-docs` regenerates `site/install/`, `site/install-uk/`, and the new
+  `site/changelog/` with no diff to the install pages beyond expected.
+- `site/changelog/index.html` is self-contained (no external asset refs) and contains
+  the rendered changelog with the "← Home" link and no alt-language link.
+- Landing page links to `changelog/`.
+
+## Notes
+
+- Docs-only + build-script change; no `spec.md` (product spec) change needed. This is a
+  user-facing site page but not an `extension/**` runtime change, so
+  `docs/extension-install-uk.md` does not require an update.

--- a/docs/superpowers/specs/2026-07/2026-07-19-changelog-page-design.md
+++ b/docs/superpowers/specs/2026-07/2026-07-19-changelog-page-design.md
@@ -1,0 +1,63 @@
+# Changelog page on GitHub Pages — design
+
+**Date:** 2026-07-19
+**Status:** approved
+
+## Problem
+
+The Chrome Web Store has no per-version "release notes" / "What's new" field, so CWS
+users get silent auto-updates with no way to see what changed. We already host a static
+docs site on GitHub Pages (`site/`, deployed via `.github/workflows/pages.yml` after
+`npm run render-docs`). Add a public changelog page there so users have an out-of-band
+place to read what changed per version.
+
+## Approach
+
+Render `extension/CHANGELOG.md` verbatim into a new static page using the existing
+`scripts/render-docs.ts` (marked → self-contained HTML) pipeline. The CHANGELOG is the
+single source of truth and is already user-facing prose, so the page self-maintains on
+every release with no extra step.
+
+## Changes
+
+### `scripts/render-docs.ts`
+The current `renderPage` assumes every page is a bilingual install guide: it hardcodes
+the `<title>` ("Warsaw Beer Overlay — Setup") and always emits an alternate-language nav
+link ("Read in English" / "Читати українською"). The changelog is EN-only with a
+different title, so generalize two `RenderOptions` fields:
+
+- `title: string` — page `<title>`. Install guides pass "Warsaw Beer Overlay — Setup";
+  changelog passes "Warsaw Beer Overlay — Changelog".
+- alt-language link optional — make `altLang`/`altHref` optional. When omitted, the nav
+  renders only the "← Home" link (no alt-language link).
+
+Add a third render target: `extension/CHANGELOG.md` → `site/changelog/index.html`
+(`lang: 'en'`, `homeHref: '../'`, no alt link).
+
+The two install-guide targets keep identical output (they still pass `title` +
+`altLang`/`altHref`).
+
+### `site/index.html`
+Add one link to the existing `ul.links` list:
+`📝 <a href="changelog/">Changelog</a>` (placed after the install guides, before or near
+the privacy link).
+
+### `.github/workflows/pages.yml`
+Add `extension/CHANGELOG.md` to the `on.push.paths` list so the page redeploys when the
+changelog changes.
+
+## Testing
+
+Extend the existing `render-docs` test (`scripts/render-docs.test.ts`) to cover the two
+new behaviors:
+- `renderPage` uses a custom `title` when provided.
+- `renderPage` omits the alternate-language nav link when `altLang`/`altHref` are not
+  provided (and still renders the "← Home" link).
+
+Existing install-guide rendering (title + both nav links) stays covered.
+
+## Out of scope (YAGNI)
+
+- No changelog links injected into the install-guide markdown.
+- No per-version anchors / deep-linking.
+- No Ukrainian translation of the changelog (EN-only, like the privacy policy).

--- a/scripts/render-docs.test.ts
+++ b/scripts/render-docs.test.ts
@@ -32,4 +32,37 @@ describe('renderPage', () => {
     expect(html).not.toMatch(/<link[^>]+href="http/);
     expect(html).not.toMatch(/<script[^>]+src=/);
   });
+
+  it('defaults the document title to the setup guide title', () => {
+    expect(html).toContain('<title>Warsaw Beer Overlay — Setup</title>');
+  });
+});
+
+describe('renderPage — single-language page (e.g. changelog)', () => {
+  const html = renderPage({
+    markdown: '# Changelog\n\n## [0.12.0]\n\n- A change.',
+    lang: 'en',
+    title: 'Warsaw Beer Overlay — Changelog',
+    homeHref: '../',
+  });
+
+  it('uses the provided title', () => {
+    expect(html).toContain('<title>Warsaw Beer Overlay — Changelog</title>');
+  });
+
+  it('links back to the landing page', () => {
+    expect(html).toContain('href="../"');
+  });
+
+  it('omits the alternate-language nav link when no alt language is given', () => {
+    expect(html.toLowerCase()).not.toContain('українською');
+    expect(html).not.toContain('Read in English');
+    // Only the "← Home" link should be in the nav.
+    const nav = html.slice(html.indexOf('<nav>'), html.indexOf('</nav>'));
+    expect(nav.match(/<a /g) ?? []).toHaveLength(1);
+  });
+
+  it('renders the markdown body to HTML', () => {
+    expect(html).toContain('<h1>Changelog</h1>');
+  });
 });

--- a/scripts/render-docs.ts
+++ b/scripts/render-docs.ts
@@ -5,10 +5,15 @@ import { marked } from 'marked';
 export interface RenderOptions {
   markdown: string;
   lang: 'en' | 'uk';
-  altLang: 'en' | 'uk';
-  altHref: string;
   homeHref: string;
+  /** Document <title>. Defaults to the install-guide title. */
+  title?: string;
+  /** Alternate-language link. Rendered only when both are provided. */
+  altLang?: 'en' | 'uk';
+  altHref?: string;
 }
+
+const DEFAULT_TITLE = 'Warsaw Beer Overlay — Setup';
 
 const ALT_LABEL: Record<'en' | 'uk', string> = {
   en: 'Read in English',
@@ -35,18 +40,21 @@ const STYLE = `
 
 export function renderPage(opts: RenderOptions): string {
   const body = marked.parse(opts.markdown, { async: false }) as string;
+  const navLinks = [`<a href="${opts.homeHref}">${HOME_LABEL[opts.lang]}</a>`];
+  if (opts.altLang && opts.altHref) {
+    navLinks.push(`<a href="${opts.altHref}">${ALT_LABEL[opts.altLang]}</a>`);
+  }
   return `<!doctype html>
 <html lang="${opts.lang}">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Warsaw Beer Overlay — Setup</title>
+    <title>${opts.title ?? DEFAULT_TITLE}</title>
     <style>${STYLE}</style>
   </head>
   <body>
     <nav>
-      <a href="${opts.homeHref}">${HOME_LABEL[opts.lang]}</a>
-      <a href="${opts.altHref}">${ALT_LABEL[opts.altLang]}</a>
+      ${navLinks.join('\n      ')}
     </nav>
     ${body}
   </body>
@@ -55,20 +63,26 @@ export function renderPage(opts: RenderOptions): string {
 }
 
 // CLI: npx tsx scripts/render-docs.ts
-// Renders both extension install guides (docs/extension-install-*.md) to
-// static self-contained HTML pages under site/ for GitHub Pages hosting.
+// Renders the extension install guides (docs/extension-install-*.md) and the
+// changelog (extension/CHANGELOG.md) to static self-contained HTML pages under
+// site/ for GitHub Pages hosting.
 function main(): void {
   const root = join(__dirname, '..');
-  const targets = [
+  const setupTitle = 'Warsaw Beer Overlay — Setup';
+  const targets: (RenderOptions & { src: string; out: string })[] = [
     { src: 'docs/extension-install-en.md', out: 'site/install/index.html',
-      lang: 'en' as const, altLang: 'uk' as const, altHref: '../install-uk/' },
+      lang: 'en', title: setupTitle, altLang: 'uk', altHref: '../install-uk/',
+      homeHref: '../', markdown: '' },
     { src: 'docs/extension-install-uk.md', out: 'site/install-uk/index.html',
-      lang: 'uk' as const, altLang: 'en' as const, altHref: '../install/' },
+      lang: 'uk', title: setupTitle, altLang: 'en', altHref: '../install/',
+      homeHref: '../', markdown: '' },
+    { src: 'extension/CHANGELOG.md', out: 'site/changelog/index.html',
+      lang: 'en', title: 'Warsaw Beer Overlay — Changelog', homeHref: '../',
+      markdown: '' },
   ];
   for (const t of targets) {
     const markdown = readFileSync(join(root, t.src), 'utf8');
-    const html = renderPage({ markdown, lang: t.lang, altLang: t.altLang,
-      altHref: t.altHref, homeHref: '../' });
+    const html = renderPage({ ...t, markdown });
     const outPath = join(root, t.out);
     mkdirSync(dirname(outPath), { recursive: true });
     writeFileSync(outPath, html);

--- a/site/index.html
+++ b/site/index.html
@@ -42,6 +42,7 @@
     <ul class="links">
       <li>📥 <a href="install/">Install &amp; setup guide (English)</a></li>
       <li>📥 <a href="install-uk/">Інструкція встановлення (українською)</a></li>
+      <li>📝 <a href="changelog/">Changelog</a></li>
       <li>🔒 <a href="privacy/">Privacy policy</a></li>
       <li>💻 <a href="https://github.com/ysilvestrov/warsaw-beer-bot">Source on GitHub</a></li>
     </ul>


### PR DESCRIPTION
Adds a public **Changelog** page to the GitHub Pages site, since the Chrome Web Store has no release-notes / "What's new" field — CWS users get silent auto-updates with no changelog. Now there's an out-of-band place to see what changed per version.

### Approach
Render `extension/CHANGELOG.md` (the single source of truth) to `site/changelog/index.html` via the existing `scripts/render-docs.ts` (marked → self-contained HTML) pipeline. Self-maintains on every release.

### Changes
- **`render-docs.ts`**: parametrize `<title>`; make the alternate-language nav link optional (the changelog is EN-only → shows only "← Home"); add the changelog render target. Install-guide output is unchanged.
- **`site/index.html`**: add a `📝 Changelog` link.
- **`pages.yml`**: redeploy when `extension/CHANGELOG.md` changes.
- **`.gitignore`**: `site/changelog/` is generated at CI time, like the install pages.

### Tests / verification
- Extended `render-docs.test.ts` (custom title; nav omits alt-lang link when not provided). 10/10 green, full typecheck clean.
- `npm run render-docs` produces `site/changelog/index.html`: correct title, contains 0.12.0, only the "← Home" nav link, self-contained (no external asset refs).

Spec: `docs/superpowers/specs/2026-07/2026-07-19-changelog-page-design.md`
Plan: `docs/superpowers/plans/2026-07/2026-07-19-changelog-page.md`

Docs-only + build-script change; no `spec.md` or `docs/extension-install-uk.md` update needed (no `extension/**` runtime change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)