### PR TITLE
test(render-docs): smoke-test the real file-render path

### DIFF
--- a/scripts/render-docs.test.ts
+++ b/scripts/render-docs.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { renderPage } from './render-docs';
+import { join } from 'node:path';
+import { renderPage, renderDocs } from './render-docs';
 
 describe('renderPage', () => {
   const html = renderPage({
@@ -64,5 +65,30 @@ describe('renderPage — single-language page (e.g. changelog)', () => {
 
   it('renders the markdown body to HTML', () => {
     expect(html).toContain('<h1>Changelog</h1>');
+  });
+});
+
+// Smoke test the real file-reading path against the actual repo sources, so a
+// malformed changelog / install guide fails a PR rather than the Pages deploy.
+describe('renderDocs (real repo files)', () => {
+  const repoRoot = join(__dirname, '..');
+  const rendered = renderDocs(repoRoot);
+
+  it('renders all three targets without throwing', () => {
+    expect(rendered.map((r) => r.out).sort()).toEqual([
+      'site/changelog/index.html',
+      'site/install-uk/index.html',
+      'site/install/index.html',
+    ]);
+  });
+
+  it('renders the real changelog with the changelog title and a version entry', () => {
+    const changelog = rendered.find((r) => r.out === 'site/changelog/index.html');
+    expect(changelog).toBeDefined();
+    expect(changelog!.html).toContain('<title>Warsaw Beer Overlay — Changelog</title>');
+    // The real CHANGELOG uses "## [x.y.z]" headings -> <h2>[x.y.z]</h2>.
+    expect(changelog!.html).toMatch(/<h2[^>]*>\[\d+\.\d+\.\d+\]/);
+    expect(changelog!.html).toContain('href="../"'); // ← Home
+    expect(changelog!.html.toLowerCase()).not.toContain('українською');
   });
 });

--- a/scripts/render-docs.ts
+++ b/scripts/render-docs.ts
@@ -62,31 +62,39 @@ export function renderPage(opts: RenderOptions): string {
 `;
 }
 
+const SETUP_TITLE = 'Warsaw Beer Overlay — Setup';
+
+// The pages rendered to site/ for GitHub Pages, relative to the repo root.
+const TARGETS: (Omit<RenderOptions, 'markdown'> & { src: string; out: string })[] = [
+  { src: 'docs/extension-install-en.md', out: 'site/install/index.html',
+    lang: 'en', title: SETUP_TITLE, altLang: 'uk', altHref: '../install-uk/', homeHref: '../' },
+  { src: 'docs/extension-install-uk.md', out: 'site/install-uk/index.html',
+    lang: 'uk', title: SETUP_TITLE, altLang: 'en', altHref: '../install/', homeHref: '../' },
+  { src: 'extension/CHANGELOG.md', out: 'site/changelog/index.html',
+    lang: 'en', title: 'Warsaw Beer Overlay — Changelog', homeHref: '../' },
+];
+
+// Reads each source under `root` and renders it to HTML. Pure w.r.t. the
+// filesystem output (no writes) so it can be exercised in tests against the
+// real repo files — a malformed source throws here rather than at deploy time.
+export function renderDocs(root: string): { src: string; out: string; html: string }[] {
+  return TARGETS.map((t) => {
+    const markdown = readFileSync(join(root, t.src), 'utf8');
+    return { src: t.src, out: t.out, html: renderPage({ ...t, markdown }) };
+  });
+}
+
 // CLI: npx tsx scripts/render-docs.ts
 // Renders the extension install guides (docs/extension-install-*.md) and the
 // changelog (extension/CHANGELOG.md) to static self-contained HTML pages under
 // site/ for GitHub Pages hosting.
 function main(): void {
   const root = join(__dirname, '..');
-  const setupTitle = 'Warsaw Beer Overlay — Setup';
-  const targets: (RenderOptions & { src: string; out: string })[] = [
-    { src: 'docs/extension-install-en.md', out: 'site/install/index.html',
-      lang: 'en', title: setupTitle, altLang: 'uk', altHref: '../install-uk/',
-      homeHref: '../', markdown: '' },
-    { src: 'docs/extension-install-uk.md', out: 'site/install-uk/index.html',
-      lang: 'uk', title: setupTitle, altLang: 'en', altHref: '../install/',
-      homeHref: '../', markdown: '' },
-    { src: 'extension/CHANGELOG.md', out: 'site/changelog/index.html',
-      lang: 'en', title: 'Warsaw Beer Overlay — Changelog', homeHref: '../',
-      markdown: '' },
-  ];
-  for (const t of targets) {
-    const markdown = readFileSync(join(root, t.src), 'utf8');
-    const html = renderPage({ ...t, markdown });
-    const outPath = join(root, t.out);
+  for (const { src, out, html } of renderDocs(root)) {
+    const outPath = join(root, out);
     mkdirSync(dirname(outPath), { recursive: true });
     writeFileSync(outPath, html);
-    console.log(`rendered ${t.src} -> ${t.out}`);
+    console.log(`rendered ${src} -> ${out}`);
   }
 }
 


### PR DESCRIPTION
Follow-up to #314. The `render-docs` unit tests cover the pure `renderPage()`, but the real file-reading path (`main()`) only executed at **Pages deploy time** — so a malformed changelog or install guide would fail the *deploy*, not the PR.

### Change
- Extract `renderDocs(root)` — reads the actual source files under `root` and returns rendered `{ src, out, html }[]` **without writing**. `main()` now just writes what it returns (and is thinner; the target list is single-sourced in `TARGETS`).
- Add smoke tests that run `renderDocs()` against the real repo files: all three targets render without throwing; the changelog has the right title, a `## [x.y.z]` version entry, the "← Home" link, and no language-switch.

### Verification
- 12/12 `render-docs` tests green, full typecheck clean.
- `npm run render-docs` still writes `site/install/`, `site/install-uk/`, `site/changelog/` end-to-end.

No behavior change to the generated pages; pure test/robustness hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)