### PR TITLE
feat(#286): retire resolved orphans (enrich_failures.retired_at + ops tool)

### DIFF
--- a/docs/superpowers/plans/2026-07/2026-07-19-retire-resolved-orphans.md
+++ b/docs/superpowers/plans/2026-07/2026-07-19-retire-resolved-orphans.md
@@ -1,0 +1,644 @@
+# Retire Resolved Orphans (#286) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A manual ops tool that moves *provably-resolved* classified `enrich_failures` rows to a terminal `retired` state, and stops those rows polluting the enrich pool, daily stats, and ops views.
+
+**Architecture:** Add a nullable `retired_at` timestamp column to `enrich_failures` (retirement keeps the original `review_class` for audit and appends the reason to `review_note`). A storage helper `retireEnrichFailure` performs the write. A CLI script `scripts/retire-resolved-orphans.ts` selects targets two ways — an **auto path** (re-run the current `isOntapNonBeerTap` predicate against the stored beer) and an **`--ids` escape hatch** (operator-supplied, requires `--reason`) — with dry-run default and `--apply`. Consumers (`listLookupCandidates`, `stats.orphansPending`) exclude retired rows.
+
+**Tech Stack:** Node.js, TypeScript, better-sqlite3, Vitest, `tsx` (ops scripts). Design doc: `docs/superpowers/specs/2026-07/2026-07-19-retire-resolved-orphans-design.md`.
+
+---
+
+## File Structure
+
+- `src/storage/schema.ts` — add migration 18 (`ALTER TABLE enrich_failures ADD COLUMN retired_at TEXT`).
+- `src/storage/enrich_failures.ts` — add `retireEnrichFailure(db, beerId, note, atIso)`.
+- `src/storage/enrich_failures.test.ts` — tests for `retireEnrichFailure`.
+- `src/storage/beers.ts` — `listLookupCandidates`: extend the `wontfix` exclusion to also skip `retired_at IS NOT NULL`.
+- `src/storage/beers.test.ts` — test: retired orphan drops out of the candidate pool.
+- `src/storage/stats.ts` — `orphansPending`: exclude retired orphans.
+- `src/storage/stats.test.ts` — test: retired orphan not counted.
+- `scripts/retire-resolved-orphans.ts` — CLI + `selectAutoRetireTargets`, `selectIdTargets`, `applyRetire`.
+- `scripts/retire-resolved-orphans.test.ts` — unit tests for the three exported functions.
+- `package.json` — add `"retire-resolved-orphans"` script alias.
+- `spec.md` — document the `retired_at` terminal state in the enrich_failures / orphan-triage section.
+
+**Note for the implementer (repo conventions):**
+- Ops scripts import from `../src/...`, call `loadOperatorEnv()` at module top, default to dry-run and write only on `--apply`. Follow `scripts/rearm-matcher-bug-orphans.ts`.
+- Tests use `openDb(':memory:')` + `migrate(db)`. Run a single test file with `npx vitest run <path>`.
+- `isOntapNonBeerTap` lives in `src/sources/ontap/non-beer.ts` and takes `{ style, brewery_ref, beer_ref }`.
+
+---
+
+## Task 1: Migration 18 — `retired_at` column
+
+**Files:**
+- Modify: `src/storage/schema.ts` (append to `MIGRATIONS`, after the `version: 17` object)
+- Test: `src/storage/schema.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/storage/schema.test.ts` (inside the top-level `describe`, or as a new `test`):
+
+```ts
+test('migration 18 adds nullable retired_at to enrich_failures', () => {
+  const db = openDb(':memory:');
+  migrate(db);
+  const cols = db.prepare(`PRAGMA table_info(enrich_failures)`).all() as { name: string; notnull: number }[];
+  const retired = cols.find((c) => c.name === 'retired_at');
+  expect(retired).toBeDefined();
+  expect(retired!.notnull).toBe(0); // nullable
+});
+```
+
+If `openDb`/`migrate` are not already imported in this test file, add:
+`import { openDb } from './db';` and `import { migrate } from './schema';` (check the existing imports first — reuse them if present).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/storage/schema.test.ts -t "retired_at"`
+Expected: FAIL (`retired` is `undefined`).
+
+- [ ] **Step 3: Add the migration**
+
+In `src/storage/schema.ts`, add a new object to the `MIGRATIONS` array immediately after the `version: 17` object (before the closing `];`):
+
+```ts
+  {
+    version: 18,
+    sql: `
+      ALTER TABLE enrich_failures ADD COLUMN retired_at TEXT;
+    `,
+  },
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/storage/schema.test.ts -t "retired_at"`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/storage/schema.ts src/storage/schema.test.ts
+git commit -m "feat(db): add enrich_failures.retired_at column (migration 18, #286)"
+```
+
+---
+
+## Task 2: `retireEnrichFailure` storage helper
+
+Sets `retired_at`, appends the reason to `review_note`, preserves `review_class`. Idempotent: only touches rows not already retired.
+
+**Files:**
+- Modify: `src/storage/enrich_failures.ts`
+- Test: `src/storage/enrich_failures.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `src/storage/enrich_failures.test.ts`. The file already has `freshDbWithBeer()`, `row()`, and imports from `./enrich_failures`. Add `retireEnrichFailure` to the import list, and add this `describe` block:
+
+```ts
+describe('retireEnrichFailure', () => {
+  test('sets retired_at, appends note, preserves review_class', () => {
+    const { db, id } = freshDbWithBeer();
+    recordEnrichFailure(db, row({ beer_id: id }));
+    setEnrichFailureReview(db, id, 'parser_bug', 'garbled name', '2026-07-01T00:00:00Z');
+
+    const changed = retireEnrichFailure(db, id, 'retired: current non-beer filter rejects', '2026-07-19T00:00:00Z');
+    expect(changed).toBe(true);
+
+    const got = db.prepare('SELECT * FROM enrich_failures WHERE beer_id = ?').get(id) as any;
+    expect(got.retired_at).toBe('2026-07-19T00:00:00Z');
+    expect(got.review_class).toBe('parser_bug'); // preserved
+    expect(got.review_note).toContain('garbled name');
+    expect(got.review_note).toContain('retired: current non-beer filter rejects');
+  });
+
+  test('is idempotent — a second call does not change or re-append', () => {
+    const { db, id } = freshDbWithBeer();
+    recordEnrichFailure(db, row({ beer_id: id }));
+    retireEnrichFailure(db, id, 'retired: x', '2026-07-19T00:00:00Z');
+
+    const changed = retireEnrichFailure(db, id, 'retired: x', '2026-07-20T00:00:00Z');
+    expect(changed).toBe(false);
+    const got = db.prepare('SELECT retired_at, review_note FROM enrich_failures WHERE beer_id = ?').get(id) as any;
+    expect(got.retired_at).toBe('2026-07-19T00:00:00Z'); // unchanged
+    expect((got.review_note.match(/retired: x/g) ?? []).length).toBe(1);
+  });
+
+  test('returns false when no row exists', () => {
+    const { db } = freshDbWithBeer();
+    expect(retireEnrichFailure(db, 999, 'retired: x', '2026-07-19T00:00:00Z')).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/storage/enrich_failures.test.ts -t "retireEnrichFailure"`
+Expected: FAIL (`retireEnrichFailure is not a function`).
+
+- [ ] **Step 3: Implement `retireEnrichFailure`**
+
+Add to `src/storage/enrich_failures.ts` (after `setEnrichFailureReview`):
+
+```ts
+// Terminal state for a classified failure whose underlying problem is resolved
+// (the responsible fix has shipped). Sets retired_at and appends `note` to
+// review_note, preserving the original review_class for audit. Idempotent: only
+// rows not already retired are touched (WHERE retired_at IS NULL), so re-runs
+// neither re-append the note nor overwrite the timestamp. Returns false when no
+// eligible row exists (missing, or already retired).
+export function retireEnrichFailure(
+  db: DB,
+  beerId: number,
+  note: string,
+  atIso: string,
+): boolean {
+  const info = db
+    .prepare(
+      `UPDATE enrich_failures
+         SET retired_at  = ?,
+             review_note = TRIM(COALESCE(review_note, '') || ' | ' || ?)
+       WHERE beer_id = ? AND retired_at IS NULL`,
+    )
+    .run(atIso, note, beerId);
+  return info.changes > 0;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/storage/enrich_failures.test.ts -t "retireEnrichFailure"`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/storage/enrich_failures.ts src/storage/enrich_failures.test.ts
+git commit -m "feat(storage): retireEnrichFailure terminal-state helper (#286)"
+```
+
+---
+
+## Task 3: Exclude retired orphans from the enrich candidate pool
+
+**Files:**
+- Modify: `src/storage/beers.ts` (`listLookupCandidates`, the `NOT EXISTS` sub-select ~lines 169-172)
+- Test: `src/storage/beers.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/storage/beers.test.ts`, inside the `describe('listLookupCandidates', ...)` block, add a test right after the existing `'excludes orphans triaged as wontfix'` test. Reuse that block's `seedBeerOnTap(db, { brewery, name })` helper and `recordEnrichFailure` + `setEnrichFailureReview` imports (already present). Retire by setting `retired_at` directly via UPDATE (there is no retire helper in this layer's imports; a raw UPDATE keeps the test self-contained):
+
+```ts
+test('excludes retired orphans (retired_at set)', () => {
+  const db = fresh();
+  const retired = seedBeerOnTap(db, { brewery: 'VINO KARPATIA', name: 'Bialy bez' });
+  const live = seedBeerOnTap(db, { brewery: 'Magic Road', name: 'Clementine' });
+  recordEnrichFailure(db, {
+    beer_id: retired, brewery: 'VINO KARPATIA', name: 'Bialy bez',
+    search_url: '', source_url: '', outcome: 'not_found',
+    candidates_count: 0, candidates_summary: '', at: '2026-05-26T11:00:00Z',
+  });
+  setEnrichFailureReview(db, retired, 'parser_bug', 'wine', '2026-05-26T11:30:00Z');
+  db.prepare('UPDATE enrich_failures SET retired_at = ? WHERE beer_id = ?')
+    .run('2026-05-26T11:45:00Z', retired);
+
+  const now = new Date('2026-05-26T12:00:00Z');
+  const out = listLookupCandidates(db, 10, now);
+  expect(out.map((c) => c.id)).toEqual([live]);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/storage/beers.test.ts -t "retired orphans"`
+Expected: FAIL (candidate still present — array not empty).
+
+- [ ] **Step 3: Widen the exclusion**
+
+In `src/storage/beers.ts`, `listLookupCandidates`, change the `NOT EXISTS` sub-select from:
+
+```sql
+         AND NOT EXISTS (
+           SELECT 1 FROM enrich_failures ef
+           WHERE ef.beer_id = b.id AND ef.review_class = 'wontfix'
+         )
+```
+
+to:
+
+```sql
+         AND NOT EXISTS (
+           SELECT 1 FROM enrich_failures ef
+           WHERE ef.beer_id = b.id
+             AND (ef.review_class = 'wontfix' OR ef.retired_at IS NOT NULL)
+         )
+```
+
+Also update the adjacent comment (currently mentions only `wontfix`) to note retired rows are excluded too.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/storage/beers.test.ts`
+Expected: PASS (new test + all existing `listLookupCandidates` tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/storage/beers.ts src/storage/beers.test.ts
+git commit -m "feat(storage): exclude retired orphans from enrich pool (#286)"
+```
+
+---
+
+## Task 4: Exclude retired orphans from daily stats
+
+**Files:**
+- Modify: `src/storage/stats.ts` (`orphansPending`, line ~64)
+- Test: `src/storage/stats.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+The exported stats function is `collectStatus(db, now)` (verified in `src/storage/stats.ts:30`); existing tests call it as `collectStatus(db, new Date(...))` and use a `fresh()` helper (`openDb(':memory:')` + `migrate`). Add this test to `src/storage/stats.test.ts`, reusing that file's `fresh()` helper and its `upsertBeer` import (the `'reports enrich health metrics'` test shows the raw-insert style):
+
+```ts
+it('orphansPending excludes retired orphans', () => {
+  const db = fresh();
+  // two orphan beers (untappd_id NULL)
+  const { lastInsertRowid: a } = db.prepare(
+    `INSERT INTO beers (untappd_id,name,brewery,normalized_name,normalized_brewery) VALUES (NULL,'Alpha','Brew A','alpha','brew a')`,
+  ).run();
+  db.prepare(
+    `INSERT INTO beers (untappd_id,name,brewery,normalized_name,normalized_brewery) VALUES (NULL,'Beta','Brew B','beta','brew b')`,
+  ).run();
+  // retire the first
+  db.prepare(
+    `INSERT INTO enrich_failures
+       (beer_id,brewery,name,search_url,outcome,candidates_count,candidates_summary,
+        fail_count,last_at,source_url,review_class,retired_at)
+     VALUES (?,'Brew A','Alpha','u','not_found',0,'',1,'2026-07-01T00:00:00Z','','parser_bug','2026-07-19T00:00:00Z')`,
+  ).run(a);
+
+  const m = collectStatus(db, new Date('2026-07-19T10:00:00Z'));
+  expect(m.orphansPending).toBe(1);
+});
+```
+
+> If `fresh()` is not defined in `stats.test.ts`, inline `const db = openDb(':memory:'); migrate(db);` (imports already present at the top of the file).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/storage/stats.test.ts -t "excludes retired"`
+Expected: FAIL (`orphansPending` is 2, not 1).
+
+- [ ] **Step 3: Update the query**
+
+In `src/storage/stats.ts`, change:
+
+```ts
+    orphansPending: count('SELECT COUNT(*) AS c FROM beers WHERE untappd_id IS NULL'),
+```
+
+to:
+
+```ts
+    orphansPending: count(
+      `SELECT COUNT(*) AS c FROM beers b
+        WHERE b.untappd_id IS NULL
+          AND NOT EXISTS (
+            SELECT 1 FROM enrich_failures ef
+            WHERE ef.beer_id = b.id AND ef.retired_at IS NOT NULL
+          )`,
+    ),
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/storage/stats.test.ts`
+Expected: PASS (new test + existing stats tests, including the original `orphansPending` assertion).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/storage/stats.ts src/storage/stats.test.ts
+git commit -m "feat(stats): exclude retired orphans from orphansPending (#286)"
+```
+
+---
+
+## Task 5: The `retire-resolved-orphans` ops tool
+
+Exports `selectAutoRetireTargets`, `selectIdTargets`, `applyRetire`; CLI with dry-run default, `--apply`, `--ids <csv>`, `--reason <text>`.
+
+**Files:**
+- Create: `scripts/retire-resolved-orphans.ts`
+- Create: `scripts/retire-resolved-orphans.test.ts`
+- Modify: `package.json` (scripts)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `scripts/retire-resolved-orphans.test.ts` (model the seeding on `scripts/rearm-matcher-bug-orphans.test.ts`):
+
+```ts
+import { describe, expect, it } from 'vitest';
+import type { DB } from '../src/storage/db';
+import { openDb } from '../src/storage/db';
+import { migrate } from '../src/storage/schema';
+import { normalizeBrewery, normalizeName } from '../src/domain/normalize';
+import { selectAutoRetireTargets, selectIdTargets, applyRetire } from './retire-resolved-orphans';
+
+interface Seed {
+  name: string;
+  brewery: string;
+  style?: string | null;
+  untappd_id?: number | null;
+  review_class?: 'parser_bug' | 'matcher_bug' | 'not_on_untappd' | 'wontfix' | null;
+  retired_at?: string | null;
+}
+
+function fresh(): DB {
+  const db = openDb(':memory:');
+  migrate(db);
+  return db;
+}
+
+function seed(db: DB, s: Seed): number {
+  const info = db.prepare(
+    `INSERT INTO beers (untappd_id, name, brewery, style, abv, rating_global, normalized_name, normalized_brewery)
+     VALUES (@untappd_id, @name, @brewery, @style, NULL, NULL, @nn, @nb)`,
+  ).run({
+    untappd_id: s.untappd_id ?? null, name: s.name, brewery: s.brewery, style: s.style ?? null,
+    nn: normalizeName(s.name), nb: normalizeBrewery(s.brewery),
+  });
+  const id = Number(info.lastInsertRowid);
+  db.prepare(
+    `INSERT INTO enrich_failures
+       (beer_id, brewery, name, search_url, outcome, candidates_count, candidates_summary,
+        fail_count, last_at, source_url, review_class, retired_at)
+     VALUES (?, ?, ?, 'u', 'not_found', 0, '', 1, '2026-07-01T00:00:00Z', '', ?, ?)`,
+  ).run(id, s.brewery, s.name, s.review_class ?? null, s.retired_at ?? null);
+  return id;
+}
+
+describe('selectAutoRetireTargets', () => {
+  it('selects classified orphans the current non-beer filter now rejects', () => {
+    const db = fresh();
+    const wine = seed(db, { name: 'Biały bez', brewery: 'VINO KARPATIA', review_class: 'parser_bug' });
+    seed(db, { name: 'Hazy IPA', brewery: 'Real Brewery', review_class: 'parser_bug' }); // real beer, kept
+    const ids = selectAutoRetireTargets(db).map((t) => t.beer_id);
+    expect(ids).toEqual([wine]);
+  });
+
+  it('excludes matched beers, untriaged rows, and already-retired rows', () => {
+    const db = fresh();
+    seed(db, { name: 'Wino A', brewery: 'VINO A', review_class: 'parser_bug', untappd_id: 555 }); // matched
+    seed(db, { name: 'Wino B', brewery: 'VINO B', review_class: null });                          // untriaged
+    seed(db, { name: 'Wino C', brewery: 'VINO C', review_class: 'wontfix', retired_at: '2026-07-01T00:00:00Z' }); // already retired
+    expect(selectAutoRetireTargets(db)).toEqual([]);
+  });
+});
+
+describe('selectIdTargets', () => {
+  it('returns only existing, orphan, not-yet-retired rows for the given ids', () => {
+    const db = fresh();
+    const a = seed(db, { name: 'Forest IPA', brewery: 'Forest IPA Brewery', review_class: 'parser_bug' });
+    const matched = seed(db, { name: 'M', brewery: 'M Brew', review_class: 'parser_bug', untappd_id: 9 });
+    const retired = seed(db, { name: 'R', brewery: 'R Brew', review_class: 'parser_bug', retired_at: '2026-07-01T00:00:00Z' });
+    const got = selectIdTargets(db, [a, matched, retired, 12345]).map((t) => t.beer_id);
+    expect(got).toEqual([a]);
+  });
+});
+
+describe('applyRetire', () => {
+  it('retires the targets and is idempotent', () => {
+    const db = fresh();
+    const a = seed(db, { name: 'Biały bez', brewery: 'VINO KARPATIA', review_class: 'parser_bug' });
+    const targets = selectAutoRetireTargets(db);
+    expect(applyRetire(db, targets, 'retired: current non-beer filter rejects')).toBe(1);
+    const got = db.prepare('SELECT retired_at, review_class FROM enrich_failures WHERE beer_id = ?').get(a) as any;
+    expect(got.retired_at).not.toBeNull();
+    expect(got.review_class).toBe('parser_bug');
+    // re-running selects nothing (already retired)
+    expect(selectAutoRetireTargets(db)).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run scripts/retire-resolved-orphans.test.ts`
+Expected: FAIL (cannot import from `./retire-resolved-orphans`).
+
+- [ ] **Step 3: Implement the tool**
+
+Create `scripts/retire-resolved-orphans.ts`:
+
+```ts
+import type { DB } from '../src/storage/db';
+import { openDb } from '../src/storage/db';
+import { loadEnv } from '../src/config/env';
+import { retireEnrichFailure } from '../src/storage/enrich_failures';
+import { isOntapNonBeerTap } from '../src/sources/ontap/non-beer';
+import { loadOperatorEnv } from './operator-env';
+
+loadOperatorEnv();
+
+const AUTO_NOTE = 'retired: current non-beer filter rejects';
+
+export interface RetireTarget {
+  beer_id: number;
+  brewery: string;
+  name: string;
+  style: string | null;
+  review_class: string | null;
+}
+
+// Classified orphan failures (review_class set, not yet retired) whose stored
+// beer the CURRENT non-beer filter would now reject — the proof of resolution.
+export function selectAutoRetireTargets(db: DB): RetireTarget[] {
+  const rows = db
+    .prepare(
+      `SELECT ef.beer_id, b.brewery, b.name, b.style, ef.review_class
+         FROM enrich_failures ef
+         JOIN beers b ON b.id = ef.beer_id
+        WHERE b.untappd_id IS NULL
+          AND ef.review_class IS NOT NULL
+          AND ef.retired_at IS NULL
+        ORDER BY ef.beer_id`,
+    )
+    .all() as RetireTarget[];
+  return rows.filter((r) =>
+    isOntapNonBeerTap({ style: r.style, brewery_ref: r.brewery, beer_ref: r.name }),
+  );
+}
+
+// Escape hatch: exactly the given beer_ids, restricted to existing orphan rows
+// not already retired. Unknown / matched / already-retired ids are silently
+// dropped here (the CLI warns about the difference).
+export function selectIdTargets(db: DB, ids: number[]): RetireTarget[] {
+  if (ids.length === 0) return [];
+  const placeholders = ids.map(() => '?').join(',');
+  return db
+    .prepare(
+      `SELECT ef.beer_id, b.brewery, b.name, b.style, ef.review_class
+         FROM enrich_failures ef
+         JOIN beers b ON b.id = ef.beer_id
+        WHERE b.untappd_id IS NULL
+          AND ef.retired_at IS NULL
+          AND ef.beer_id IN (${placeholders})
+        ORDER BY ef.beer_id`,
+    )
+    .all(...ids) as RetireTarget[];
+}
+
+// Retire all targets in one transaction. Returns the number actually written.
+export function applyRetire(db: DB, targets: RetireTarget[], note: string): number {
+  const txn = db.transaction((ts: RetireTarget[]) => {
+    let n = 0;
+    for (const t of ts) {
+      if (retireEnrichFailure(db, t.beer_id, note, new Date().toISOString())) n += 1;
+    }
+    return n;
+  });
+  return txn(targets);
+}
+
+function parseArgs(argv: string[]): { apply: boolean; ids: number[] | null; reason: string | null } {
+  const apply = argv.includes('--apply');
+  const idsIdx = argv.indexOf('--ids');
+  const reasonIdx = argv.indexOf('--reason');
+  const ids = idsIdx >= 0
+    ? (argv[idsIdx + 1] ?? '').split(',').map((s) => parseInt(s.trim(), 10)).filter((n) => Number.isInteger(n))
+    : null;
+  const reason = reasonIdx >= 0 ? (argv[reasonIdx + 1] ?? null) : null;
+  return { apply, ids, reason };
+}
+
+function main(argv: string[]): void {
+  const { apply, ids, reason } = parseArgs(argv);
+  const db = openDb(loadEnv().DATABASE_PATH);
+  try {
+    let targets: RetireTarget[];
+    let note: string;
+
+    if (ids !== null) {
+      if (!reason) {
+        console.error('Error: --ids requires --reason "<text>".');
+        process.exitCode = 1;
+        return;
+      }
+      note = `retired: ${reason}`;
+      targets = selectIdTargets(db, ids);
+      const found = new Set(targets.map((t) => t.beer_id));
+      const missing = ids.filter((id) => !found.has(id));
+      if (missing.length) {
+        console.warn(`Skipping ${missing.length} id(s) — unknown, already matched, or already retired: ${missing.join(', ')}`);
+      }
+    } else {
+      if (reason) {
+        console.error('Error: --reason is only valid with --ids (auto path uses a fixed note).');
+        process.exitCode = 1;
+        return;
+      }
+      note = AUTO_NOTE;
+      targets = selectAutoRetireTargets(db);
+    }
+
+    for (const t of targets) {
+      console.log(`#${t.beer_id} [${t.review_class}] ${t.brewery} / ${t.name}${t.style ? ` (style: ${t.style})` : ''}`);
+    }
+
+    if (apply) {
+      const n = applyRetire(db, targets, note);
+      console.log(`Retired ${n} orphan(s). Note: "${note}"`);
+    } else {
+      console.log(`${targets.length} orphan(s) would be retired (dry-run; pass --apply to write).`);
+    }
+  } finally {
+    db.close();
+  }
+}
+
+if (require.main === module) {
+  main(process.argv.slice(2));
+}
+```
+
+- [ ] **Step 4: Add the npm script**
+
+In `package.json`, in `"scripts"`, add after the `rearm-matcher-bug-orphans` line:
+
+```json
+    "retire-resolved-orphans": "tsx scripts/retire-resolved-orphans.ts",
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npx vitest run scripts/retire-resolved-orphans.test.ts`
+Expected: PASS (all describe blocks).
+
+- [ ] **Step 6: Smoke-test the CLI dry-run against a temp DB**
+
+Run:
+```bash
+npx tsx -e "const {openDb}=require('./src/storage/db');const {migrate}=require('./src/storage/schema');const db=openDb('/tmp/retire-smoke.db');migrate(db);db.prepare(\"INSERT INTO beers (untappd_id,name,brewery,style,normalized_name,normalized_brewery) VALUES (NULL,'Biały bez','VINO KARPATIA',NULL,'bialy bez','vino karpatia')\").run();db.prepare(\"INSERT INTO enrich_failures (beer_id,brewery,name,search_url,outcome,candidates_count,candidates_summary,fail_count,last_at,source_url,review_class) VALUES (1,'VINO KARPATIA','Biały bez','u','not_found',0,'',1,'2026-07-01T00:00:00Z','','parser_bug')\").run();db.close();"
+DOTENV_CONFIG_PATH=/dev/null DATABASE_PATH=/tmp/retire-smoke.db npx tsx scripts/retire-resolved-orphans.ts
+rm -f /tmp/retire-smoke.db
+```
+Expected: prints `#1 [parser_bug] VINO KARPATIA / Biały bez` then `1 orphan(s) would be retired (dry-run; ...)`.
+
+> If `loadEnv()` rejects a bare `DATABASE_PATH` env (it may require a full `.env`), instead point `DOTENV_CONFIG_PATH` at a throwaway `.env` file containing the required keys plus `DATABASE_PATH=/tmp/retire-smoke.db`. The goal is only to eyeball the dry-run output.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/retire-resolved-orphans.ts scripts/retire-resolved-orphans.test.ts package.json
+git commit -m "feat(ops): retire-resolved-orphans tool (auto + --ids escape hatch, #286)"
+```
+
+---
+
+## Task 6: Update `spec.md`
+
+**Files:**
+- Modify: `spec.md`
+
+- [ ] **Step 1: Locate the enrich_failures / orphan-triage section**
+
+Run: `grep -n "enrich_failures\|review_class\|wontfix\|orphan" spec.md | head -30`
+Read the surrounding section that documents `enrich_failures` columns / triage classes.
+
+- [ ] **Step 2: Document the terminal state**
+
+Add a sentence/bullet to that section describing the `retired_at` column and its semantics. Use wording consistent with the surrounding prose. Content to convey:
+
+> `retired_at` (nullable ISO timestamp): terminal state for a classified failure whose responsible parser/filter fix has shipped. Set by the `retire-resolved-orphans` ops tool. Retired rows keep their original `review_class` for audit; they are excluded from the enrich candidate pool (`listLookupCandidates`, alongside `wontfix`) and from the `orphansPending` daily-stats count. Selection is verification-based (auto: the current non-beer filter now rejects the row) or an explicit operator `--ids` escape hatch; never age- or class-based.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add spec.md
+git commit -m "docs(spec): document enrich_failures.retired_at terminal state (#286)"
+```
+
+---
+
+## Task 7: Full verification
+
+- [ ] **Step 1: Run the whole test suite**
+
+Run: `npx vitest run`
+Expected: all pass (no regressions in `beers`, `stats`, `enrich_failures`, `schema`, plus the new script tests).
+
+- [ ] **Step 2: Typecheck / lint (match repo conventions)**
+
+Run: `npm run typecheck` (or `npx tsc --noEmit` if that's the repo's check — verify in `package.json`).
+Expected: no errors.
+
+- [ ] **Step 3: Final review**
+
+Confirm: migration 18 present; `retireEnrichFailure` idempotent; both consumers exclude retired; tool has auto + `--ids` paths with dry-run default; `package.json` script added; `spec.md` updated. No `extension/**` change → no `docs/extension-install-uk.md` update required.

--- a/docs/superpowers/specs/2026-07/2026-07-19-retire-resolved-orphans-design.md
+++ b/docs/superpowers/specs/2026-07/2026-07-19-retire-resolved-orphans-design.md
@@ -1,0 +1,156 @@
+# Retire resolved orphans (#286)
+
+**Status:** design
+**Issue:** #286 — Ops: retire stale enrich failures after parser fixes
+**Date:** 2026-07-19
+
+## Problem
+
+Parser/filter fixes prevent *new* polluted rows, but the `enrich_failures` rows
+they were meant to resolve stay classified in production indefinitely. A row is
+only ever removed on a successful match (`clearEnrichFailure`); nothing else
+clears it. So resolved clusters (wine/spirit now filtered, Funkyshop #259,
+Menabrea/brewery=name #238) keep appearing "active" in ops views and inflate the
+orphan count.
+
+Prod reality (2026-07-19) that shapes the design:
+
+- Classified rows are mostly **on-tap and still live** — e.g. `parser_bug` is 90
+  on-tap / 7 off-tap. They are re-queried every enrich cycle and keep their class
+  because `recordEnrichFailure` preserves `review_class` across re-fails.
+- Sampling on-tap `parser_bug` rows, **most are still genuinely broken**
+  (`VINO KARPATIA / Biały bez`, `Forest IPA Brewery / Forest IPA`,
+  `Konrad Brewery 12° 12°`, …), not resolved fossils.
+
+**Consequence:** retirement cannot be driven by age or by `review_class` alone —
+that would nuke live, still-failing orphans. Each retirement needs a per-row
+*"is this actually resolved now"* signal.
+
+## Scope
+
+- **In:** a manual ops script that moves *provably-resolved* classified
+  `enrich_failures` rows to a terminal `retired` state, and stops those rows from
+  polluting the enrich pool, triage, ops views, and the daily digest count.
+- **Out:** `beers`/catalog cleanup, off-tap garbage collection, re-ingestion,
+  anything touching untriaged (`review_class IS NULL`) rows.
+
+Non-goal: automatically *detecting* resolution for fix categories that cannot be
+re-derived from stored data (see §Selection). Those go through an explicit
+operator-supplied escape hatch.
+
+## Selection — two verified paths
+
+The tool never selects by age or by `review_class` alone. Both paths print the
+affected rows for a dry-run eyeball before any write.
+
+### Auto path (default)
+
+Select orphan (`untappd_id IS NULL`) `enrich_failures` rows whose stored beer,
+mapped to `{ style, brewery_ref: brewery, beer_ref: name }`, makes the **current**
+`isOntapNonBeerTap` (`src/sources/ontap/non-beer.ts`) return `true`.
+
+That is the proof of resolution: the live pipeline would now reject this beer; it
+only survives because its `beers`/`match_links` rows predate the filter (the
+filter blocks new creation but does not retroactively remove existing rows). This
+is the only reusable verification predicate in the codebase, and it demonstrably
+catches real live rows (e.g. `VINO KARPATIA` → brewery contains `vino`).
+
+Output prints the tripping signal (token / sentinel) per row so the retirement is
+self-justifying.
+
+Auto path records a fixed note: `retired: current non-beer filter rejects`.
+
+### Escape hatch (`--ids`)
+
+`--ids 30289,32227,…` retires exactly those `beer_id`s. This covers parse-split
+fossils (brewery=name, degree/ABV noise) that have **no** reusable predicate — the
+`beers` row *is* the mis-parsed output, so there is nothing to re-derive; the
+operator supplies the judgment (gathered from the triage issue / a query).
+
+- Requires a mandatory `--reason "<text>"`, recorded in the note as
+  `retired: <reason>`.
+- Dry-run prints each row's `beer_id / brewery / name / review_class` for eyeball.
+- Skips ids that don't exist in `enrich_failures`, are already matched, or are
+  already retired (warns, does not touch).
+
+Auto and `--ids` are **mutually exclusive** modes; `--reason` is rejected in auto
+mode.
+
+## Terminal state — `retired_at` column
+
+Add `retired_at TEXT` (nullable ISO timestamp) to `enrich_failures` via a simple
+`ALTER TABLE ... ADD COLUMN` (schema migration 18 — no table rebuild, no CHECK
+change; contrast a new `review_class` enum value, which the migration-12 CHECK
+constraint would force a full table rebuild for).
+
+Retirement = set `retired_at = now` and append the reason to `review_note`. The
+row **keeps its original `review_class`**, so the audit trail reads *"this was a
+`parser_bug`, retired on DATE because X"* rather than overwriting history.
+
+`retired_at` is sticky — not auto-cleared on re-fail. Because retired rows are
+excluded from the enrich pool (below), `recordEnrichFailure` will not fire for
+them anyway; a genuine later match still deletes the whole row via
+`clearEnrichFailure`.
+
+### Behavior across consumers
+
+- **Untriaged triage** (`listUntriagedFailures`): already filters
+  `review_class IS NULL`; retired rows keep a class → already excluded. No change.
+- **Enrich re-attempts** (`listLookupCandidates`, `src/storage/beers.ts`): extend
+  the existing `wontfix` exclusion so orphans with `retired_at IS NOT NULL` are
+  also skipped — stop wasting Untappd calls on fossils, exactly like `wontfix`.
+- **Daily stats** (`src/storage/stats.ts`, `orphansPending`): exclude beers whose
+  failure is retired:
+  `... AND NOT EXISTS (SELECT 1 FROM enrich_failures ef WHERE ef.beer_id = beers.id AND ef.retired_at IS NOT NULL)`,
+  so the digest's "orphan'ів у черзі" number stops counting resolved fossils.
+- **Ops/reporting views** of active clusters filter `retired_at IS NULL`.
+
+## Tool UX
+
+Script `scripts/retire-resolved-orphans.ts`, npm alias
+`retire-resolved-orphans`, following the existing rearm-tool mold
+(`loadOperatorEnv`, dry-run default, `--apply`, run as the bot user against the
+prod `dist` build, sibling `.test.ts`).
+
+```
+npm run retire-resolved-orphans
+    → auto path, dry-run: lists orphan rows the current isOntapNonBeerTap now
+      rejects, each with tripping signal + beer_id / brewery / name / class.
+      Footer: "N would be retired (dry-run; pass --apply)."
+
+npm run retire-resolved-orphans -- --apply
+    → writes retired_at=now, appends note, prints "Retired N orphan(s)."
+
+npm run retire-resolved-orphans -- --ids 30289,32227 --reason "brewery=name, fixed by #238"
+    → escape hatch, dry-run: prints those rows for eyeball.
+      Add --apply to write.
+```
+
+Module exports (mirroring the rearm tools) for unit testing:
+`selectAutoRetireTargets(db)`, `selectIdTargets(db, ids)`, `applyRetire(db, targets, note)`.
+
+## Testing (Vitest)
+
+- `selectAutoRetireTargets`: wine/`vino` row selected; normal IPA not selected;
+  matched beer (`untappd_id` set) excluded; already-`retired_at` row excluded.
+- `applyRetire`: sets `retired_at` + appends note; idempotent; only touches
+  targets.
+- `--ids` path (`selectIdTargets`): retires listed ids; skips unknown / matched /
+  already-retired.
+- `listLookupCandidates`: a retired orphan drops out of the candidate pool.
+- `stats.orphansPending`: a retired orphan is not counted.
+- Schema migration 18: `retired_at` column present, defaults NULL, existing rows
+  unaffected.
+
+## Docs / spec
+
+- Update `spec.md` — the `enrich_failures` / orphan-triage section gains the
+  `retired_at` terminal state and its pool/stats/view semantics, in the same PR.
+- No `extension/**` change → no `docs/extension-install-uk.md` update needed.
+
+## Rollout
+
+Server-side only; ships via `deploy.sh` (migration 18 runs on startup). First real
+use: after this deploys, run the auto path dry-run to see the wine/non-beer
+cluster, then `--apply`; use `--ids` for the brewery=name / degree-noise clusters
+identified in triage.

--- a/docs/superpowers/specs/2026-07/2026-07-19-retire-resolved-orphans-design.md
+++ b/docs/superpowers/specs/2026-07/2026-07-19-retire-resolved-orphans-design.md
@@ -33,10 +33,16 @@ that would nuke live, still-failing orphans. Each retirement needs a per-row
   polluting the enrich pool, triage, ops views, and the daily digest count.
 - **Out:** `beers`/catalog cleanup, off-tap garbage collection, re-ingestion,
   anything touching untriaged (`review_class IS NULL`) rows.
+- **Out:** rows whose underlying parser bug is **still live** — e.g. the Konrad /
+  Krakonoš trailing-°Plato cluster (beer `12289`, tracked in #306). These are
+  not resolved; they must be *fixed*, not retired. Such a row becomes
+  retire-eligible (escape hatch) only after its fix ships and re-ingestion has
+  had a chance to produce a matched replacement.
 
 Non-goal: automatically *detecting* resolution for fix categories that cannot be
 re-derived from stored data (see §Selection). Those go through an explicit
-operator-supplied escape hatch.
+operator-supplied escape hatch, and only for clusters whose fix is already
+deployed.
 
 ## Selection — two verified paths
 
@@ -152,5 +158,6 @@ Module exports (mirroring the rearm tools) for unit testing:
 
 Server-side only; ships via `deploy.sh` (migration 18 runs on startup). First real
 use: after this deploys, run the auto path dry-run to see the wine/non-beer
-cluster, then `--apply`; use `--ids` for the brewery=name / degree-noise clusters
-identified in triage.
+cluster, then `--apply`; use `--ids` only for clusters whose parser fix has
+already shipped (e.g. brewery=name #238) — not for still-live bugs like the
+Konrad/Krakonoš trailing-°Plato cluster (#306).

--- a/docs/superpowers/specs/2026-07/2026-07-19-retire-resolved-orphans-design.md
+++ b/docs/superpowers/specs/2026-07/2026-07-19-retire-resolved-orphans-design.md
@@ -59,7 +59,18 @@ That is the proof of resolution: the live pipeline would now reject this beer; i
 only survives because its `beers`/`match_links` rows predate the filter (the
 filter blocks new creation but does not retroactively remove existing rows). This
 is the only reusable verification predicate in the codebase, and it demonstrably
-catches real live rows (e.g. `VINO KARPATIA` → brewery contains `vino`).
+catches real live rows: brewery-token rows (`WINO`, `Number wine`) and
+wine/spritz-styled rows (`Conegliano / Vino Bianco`, `Monte Santi / Aperol Spritz`)
+all trip the current filter.
+
+**Known gap (verified against prod):** `isOntapNonBeerTap`'s `BREWERY_TOKENS` list
+contains `wino`/`wine`/`vini` but **not** the Italian `vino`, and it only tests
+`style` when a style is present. So `VINO KARPATIA / Biały bez` (Italian `vino`
+spelling, empty style) does **not** auto-trip — verified: `isOntapNonBeerTap`
+returns `false` for it. Such rows go through the `--ids` escape hatch. Widening
+the shared filter (e.g. adding `vino` to `BREWERY_TOKENS`) is deliberately **out
+of #286 scope** — it changes live ontap ingestion behaviour and belongs with the
+parser-filter issues (#306/#238 family).
 
 Output prints the tripping signal (token / sentinel) per row so the retirement is
 self-justifying.
@@ -137,7 +148,8 @@ Module exports (mirroring the rearm tools) for unit testing:
 
 ## Testing (Vitest)
 
-- `selectAutoRetireTargets`: wine/`vino` row selected; normal IPA not selected;
+- `selectAutoRetireTargets`: wine row with a filter-tripping brewery (`WINO …`)
+  selected; normal IPA not selected;
   matched beer (`untappd_id` set) excluded; already-`retired_at` row excluded.
 - `applyRetire`: sets `retired_at` + appends note; idempotent; only touches
   targets.
@@ -158,6 +170,7 @@ Module exports (mirroring the rearm tools) for unit testing:
 
 Server-side only; ships via `deploy.sh` (migration 18 runs on startup). First real
 use: after this deploys, run the auto path dry-run to see the wine/non-beer
-cluster, then `--apply`; use `--ids` only for clusters whose parser fix has
-already shipped (e.g. brewery=name #238) — not for still-live bugs like the
-Konrad/Krakonoš trailing-°Plato cluster (#306).
+cluster the current filter trips, then `--apply`. Use `--ids` for (a) rows the
+filter misses (e.g. `VINO KARPATIA`, Italian `vino` + empty style) and (b)
+clusters whose parser fix has already shipped (e.g. brewery=name #238) — but not
+for still-live bugs like the Konrad/Krakonoš trailing-°Plato cluster (#306).

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "alias-key": "tsx scripts/brewery-alias-key.ts",
     "rearm-aliased-orphans": "tsx scripts/rearm-aliased-orphans.ts",
     "rearm-matcher-bug-orphans": "tsx scripts/rearm-matcher-bug-orphans.ts",
+    "retire-resolved-orphans": "tsx scripts/retire-resolved-orphans.ts",
     "render-docs": "tsx scripts/render-docs.ts"
   },
   "keywords": [],

--- a/scripts/retire-resolved-orphans.test.ts
+++ b/scripts/retire-resolved-orphans.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import type { DB } from '../src/storage/db';
+import { openDb } from '../src/storage/db';
+import { migrate } from '../src/storage/schema';
+import { normalizeBrewery, normalizeName } from '../src/domain/normalize';
+import { selectAutoRetireTargets, selectIdTargets, applyRetire } from './retire-resolved-orphans';
+
+interface Seed {
+  name: string;
+  brewery: string;
+  style?: string | null;
+  untappd_id?: number | null;
+  review_class?: 'parser_bug' | 'matcher_bug' | 'not_on_untappd' | 'wontfix' | null;
+  retired_at?: string | null;
+}
+
+function fresh(): DB {
+  const db = openDb(':memory:');
+  migrate(db);
+  return db;
+}
+
+function seed(db: DB, s: Seed): number {
+  const info = db.prepare(
+    `INSERT INTO beers (untappd_id, name, brewery, style, abv, rating_global, normalized_name, normalized_brewery)
+     VALUES (@untappd_id, @name, @brewery, @style, NULL, NULL, @nn, @nb)`,
+  ).run({
+    untappd_id: s.untappd_id ?? null, name: s.name, brewery: s.brewery, style: s.style ?? null,
+    nn: normalizeName(s.name), nb: normalizeBrewery(s.brewery),
+  });
+  const id = Number(info.lastInsertRowid);
+  db.prepare(
+    `INSERT INTO enrich_failures
+       (beer_id, brewery, name, search_url, outcome, candidates_count, candidates_summary,
+        fail_count, last_at, source_url, review_class, retired_at)
+     VALUES (?, ?, ?, 'u', 'not_found', 0, '', 1, '2026-07-01T00:00:00Z', '', ?, ?)`,
+  ).run(id, s.brewery, s.name, s.review_class ?? null, s.retired_at ?? null);
+  return id;
+}
+
+describe('selectAutoRetireTargets', () => {
+  it('selects classified orphans the current non-beer filter now rejects', () => {
+    const db = fresh();
+    const wine = seed(db, { name: 'Biały bez', brewery: 'WINO KARPATIA', review_class: 'parser_bug' });
+    seed(db, { name: 'Hazy IPA', brewery: 'Real Brewery', review_class: 'parser_bug' });
+    const ids = selectAutoRetireTargets(db).map((t) => t.beer_id);
+    expect(ids).toEqual([wine]);
+  });
+
+  it('excludes matched beers, untriaged rows, and already-retired rows', () => {
+    const db = fresh();
+    seed(db, { name: 'Wino A', brewery: 'WINO A', review_class: 'parser_bug', untappd_id: 555 });
+    seed(db, { name: 'Wino B', brewery: 'WINO B', review_class: null });
+    seed(db, { name: 'Wino C', brewery: 'WINO C', review_class: 'wontfix', retired_at: '2026-07-01T00:00:00Z' });
+    expect(selectAutoRetireTargets(db)).toEqual([]);
+  });
+});
+
+describe('selectIdTargets', () => {
+  it('returns only existing, orphan, not-yet-retired rows for the given ids', () => {
+    const db = fresh();
+    const a = seed(db, { name: 'Forest IPA', brewery: 'Forest IPA Brewery', review_class: 'parser_bug' });
+    const matched = seed(db, { name: 'M', brewery: 'M Brew', review_class: 'parser_bug', untappd_id: 9 });
+    const retired = seed(db, { name: 'R', brewery: 'R Brew', review_class: 'parser_bug', retired_at: '2026-07-01T00:00:00Z' });
+    const got = selectIdTargets(db, [a, matched, retired, 12345]).map((t) => t.beer_id);
+    expect(got).toEqual([a]);
+  });
+});
+
+describe('applyRetire', () => {
+  it('retires the targets and is idempotent', () => {
+    const db = fresh();
+    const a = seed(db, { name: 'Biały bez', brewery: 'WINO KARPATIA', review_class: 'parser_bug' });
+    const targets = selectAutoRetireTargets(db);
+    expect(applyRetire(db, targets, 'retired: current non-beer filter rejects')).toBe(1);
+    const got = db.prepare('SELECT retired_at, review_class FROM enrich_failures WHERE beer_id = ?').get(a) as any;
+    expect(got.retired_at).not.toBeNull();
+    expect(got.review_class).toBe('parser_bug');
+    expect(selectAutoRetireTargets(db)).toEqual([]);
+  });
+});

--- a/scripts/retire-resolved-orphans.ts
+++ b/scripts/retire-resolved-orphans.ts
@@ -1,0 +1,128 @@
+import type { DB } from '../src/storage/db';
+import { openDb } from '../src/storage/db';
+import { loadEnv } from '../src/config/env';
+import { retireEnrichFailure } from '../src/storage/enrich_failures';
+import { isOntapNonBeerTap } from '../src/sources/ontap/non-beer';
+import { loadOperatorEnv } from './operator-env';
+
+loadOperatorEnv();
+
+const AUTO_NOTE = 'retired: current non-beer filter rejects';
+
+export interface RetireTarget {
+  beer_id: number;
+  brewery: string;
+  name: string;
+  style: string | null;
+  review_class: string | null;
+}
+
+// Classified orphan failures (review_class set, not yet retired) whose stored
+// beer the CURRENT non-beer filter would now reject — the proof of resolution.
+export function selectAutoRetireTargets(db: DB): RetireTarget[] {
+  const rows = db
+    .prepare(
+      `SELECT ef.beer_id, b.brewery, b.name, b.style, ef.review_class
+         FROM enrich_failures ef
+         JOIN beers b ON b.id = ef.beer_id
+        WHERE b.untappd_id IS NULL
+          AND ef.review_class IS NOT NULL
+          AND ef.retired_at IS NULL
+        ORDER BY ef.beer_id`,
+    )
+    .all() as RetireTarget[];
+  return rows.filter((r) =>
+    isOntapNonBeerTap({ style: r.style, brewery_ref: r.brewery, beer_ref: r.name }),
+  );
+}
+
+// Escape hatch: exactly the given beer_ids, restricted to existing orphan rows
+// not already retired. Unknown / matched / already-retired ids are silently
+// dropped here (the CLI warns about the difference).
+export function selectIdTargets(db: DB, ids: number[]): RetireTarget[] {
+  if (ids.length === 0) return [];
+  const placeholders = ids.map(() => '?').join(',');
+  return db
+    .prepare(
+      `SELECT ef.beer_id, b.brewery, b.name, b.style, ef.review_class
+         FROM enrich_failures ef
+         JOIN beers b ON b.id = ef.beer_id
+        WHERE b.untappd_id IS NULL
+          AND ef.retired_at IS NULL
+          AND ef.beer_id IN (${placeholders})
+        ORDER BY ef.beer_id`,
+    )
+    .all(...ids) as RetireTarget[];
+}
+
+// Retire all targets in one transaction. Returns the number actually written.
+export function applyRetire(db: DB, targets: RetireTarget[], note: string): number {
+  const txn = db.transaction((ts: RetireTarget[]) => {
+    let n = 0;
+    for (const t of ts) {
+      if (retireEnrichFailure(db, t.beer_id, note, new Date().toISOString())) n += 1;
+    }
+    return n;
+  });
+  return txn(targets);
+}
+
+function parseArgs(argv: string[]): { apply: boolean; ids: number[] | null; reason: string | null } {
+  const apply = argv.includes('--apply');
+  const idsIdx = argv.indexOf('--ids');
+  const reasonIdx = argv.indexOf('--reason');
+  const ids = idsIdx >= 0
+    ? (argv[idsIdx + 1] ?? '').split(',').map((s) => parseInt(s.trim(), 10)).filter((n) => Number.isInteger(n))
+    : null;
+  const reason = reasonIdx >= 0 ? (argv[reasonIdx + 1] ?? null) : null;
+  return { apply, ids, reason };
+}
+
+function main(argv: string[]): void {
+  const { apply, ids, reason } = parseArgs(argv);
+  const db = openDb(loadEnv().DATABASE_PATH);
+  try {
+    let targets: RetireTarget[];
+    let note: string;
+
+    if (ids !== null) {
+      if (!reason) {
+        console.error('Error: --ids requires --reason "<text>".');
+        process.exitCode = 1;
+        return;
+      }
+      note = `retired: ${reason}`;
+      targets = selectIdTargets(db, ids);
+      const found = new Set(targets.map((t) => t.beer_id));
+      const missing = ids.filter((id) => !found.has(id));
+      if (missing.length) {
+        console.warn(`Skipping ${missing.length} id(s) — unknown, already matched, or already retired: ${missing.join(', ')}`);
+      }
+    } else {
+      if (reason) {
+        console.error('Error: --reason is only valid with --ids (auto path uses a fixed note).');
+        process.exitCode = 1;
+        return;
+      }
+      note = AUTO_NOTE;
+      targets = selectAutoRetireTargets(db);
+    }
+
+    for (const t of targets) {
+      console.log(`#${t.beer_id} [${t.review_class}] ${t.brewery} / ${t.name}${t.style ? ` (style: ${t.style})` : ''}`);
+    }
+
+    if (apply) {
+      const n = applyRetire(db, targets, note);
+      console.log(`Retired ${n} orphan(s). Note: "${note}"`);
+    } else {
+      console.log(`${targets.length} orphan(s) would be retired (dry-run; pass --apply to write).`);
+    }
+  } finally {
+    db.close();
+  }
+}
+
+if (require.main === module) {
+  main(process.argv.slice(2));
+}

--- a/spec.md
+++ b/spec.md
@@ -348,6 +348,9 @@ src/
 | `review_class` | TEXT | nullable CHECK IN (`parser_bug`,`matcher_bug`,`not_on_untappd`,`wontfix`) | клас тріажу після ручного розгляду; `NULL` = ще не розмічено; `parser_bug` — НАШ адаптер зіпсував інакше чистий рядок (криво розбита пивоварня/назва, обрізання, HTML-сміття, merch/скло/вино/їжа); зіпсований лістинг самої крамниці (типоси в її даних) — НЕ parser_bug; `matcher_bug` — пиво правдоподібно є на Untappd, але ми промахнулись: alias-геп, розбіжність назв, або шум у запиті, який треба лише нормалізувати перед пошуком; `not_on_untappd` — відсутнє на Untappd; `wontfix` — навмисно без матчингу |
 | `review_note` | TEXT | nullable | довільна нотатка тріажу (агент або адмін) |
 | `reviewed_at` | TEXT | nullable | час розмітки (ISO); виставляється ендпоінтом `POST /admin/enrich-failures/review` |
+| `retired_at` | TEXT | nullable (міграція 18) | термінальний стан для класифікованого провалу, чия причина вже усунена (відповідний фікс задеплоєно). Виставляється ops-тулою `retire-resolved-orphans`. Рядок **зберігає** початковий `review_class` (для аудиту); `review_note` доповнюється причиною |
+
+**Retirement (`retired_at`).** Класифіковані рядки провалів залишаються в БД назавжди (видаляються лише на `matched`), тож уже вирішені кластери (вино/спирт тепер фільтруються, brewery=name #238 тощо) продовжують виглядати «активними» й роздувати лічильник orphan'ів. `retire-resolved-orphans` (npm-скрипт, dry-run за замовчуванням, `--apply`) переводить **доказово вирішені** рядки в `retired_at`. Вибір — лише верифікований, ніколи за віком чи класом: **авто-шлях** бере класифікованих orphan'ів, яких поточний `isOntapNonBeerTap` тепер відкидає (доказ вирішення); **escape-hatch `--ids <csv> --reason "<text>"`** — явно задані оператором `beer_id` (для фіксів, яких предикат не ловить — напр. `VINO KARPATIA` italian-`vino`, або parse-split кластери після шипу фіксу). Retired-рядки виключені з enrich-пулу (`listLookupCandidates`, поряд із `wontfix`) та з лічильника `orphansPending` у щоденному дайджесті.
 
 **Хто що пише:** `applyLookupOutcome` (спільний для серверного крона і client-relay)
 upsert'ить рядок на `not_found`/`blocked` і **видаляє** його на `matched`. Один рядок на
@@ -431,6 +434,7 @@ pubs          *───* pubs             via pub_distances (a<b)
 | 15 | `job_state(key, value)` — дрібний крос-рестарт стан джоб (`daily_status_last_sent`, `untappd_circuit_open_until`, `untappd_profile_http_open_until`) |
 | 16 | `checkin_sync_state.profile_total` (INTEGER) — лік чекінів профілю Untappd для `/status` |
 | 17 | `api_usage` (денний облік запитів розширення) |
+| 18 | `enrich_failures.retired_at` (термінальний стан вирішених провалів; ops-тула `retire-resolved-orphans`) |
 
 ---
 

--- a/src/storage/beers.test.ts
+++ b/src/storage/beers.test.ts
@@ -319,6 +319,23 @@ describe('listLookupCandidates', () => {
     expect(out.map((c) => c.id)).toEqual([live]);
   });
 
+  test('excludes retired orphans (retired_at set)', () => {
+    const db = fresh();
+    const retired = seedBeerOnTap(db, { brewery: 'VINO KARPATIA', name: 'Bialy bez' });
+    const live = seedBeerOnTap(db, { brewery: 'Magic Road', name: 'Clementine' });
+    recordEnrichFailure(db, {
+      beer_id: retired, brewery: 'VINO KARPATIA', name: 'Bialy bez',
+      search_url: '', source_url: '', outcome: 'not_found',
+      candidates_count: 0, candidates_summary: '', at: '2026-05-26T11:00:00Z',
+    });
+    setEnrichFailureReview(db, retired, 'parser_bug', 'wine', '2026-05-26T11:30:00Z');
+    db.prepare('UPDATE enrich_failures SET retired_at = ? WHERE beer_id = ?')
+      .run('2026-05-26T11:45:00Z', retired);
+    const now = new Date('2026-05-26T12:00:00Z');
+    const out = listLookupCandidates(db, 10, now);
+    expect(out.map((c) => c.id)).toEqual([live]);
+  });
+
   test('keeps orphans triaged with a non-wontfix class (e.g. matcher_bug)', () => {
     const db = fresh();
     const matcherBug = seedBeerOnTap(db, { brewery: 'Magic Road', name: 'Clementine' });

--- a/src/storage/beers.ts
+++ b/src/storage/beers.ts
@@ -159,7 +159,8 @@ export function listLookupCandidates(
 ): LookupCandidate[] {
   // SQL pre-filter: orphan beers (untappd_id NULL) whose beer_id is on the
   // latest snapshot of at least one pub, excluding ones triaged as `wontfix`
-  // (intentionally never matched — re-querying them just wastes Untappd calls).
+  // (intentionally never matched — re-querying them just wastes Untappd calls)
+  // or retired (provably resolved by a shipped fix — re-querying is dead work).
   const rows = db
     .prepare(
       `SELECT b.id, b.brewery, b.name,
@@ -168,7 +169,8 @@ export function listLookupCandidates(
        WHERE b.untappd_id IS NULL
          AND NOT EXISTS (
            SELECT 1 FROM enrich_failures ef
-           WHERE ef.beer_id = b.id AND ef.review_class = 'wontfix'
+           WHERE ef.beer_id = b.id
+             AND (ef.review_class = 'wontfix' OR ef.retired_at IS NOT NULL)
          )
          AND EXISTS (
            SELECT 1 FROM match_links ml

--- a/src/storage/enrich_failures.test.ts
+++ b/src/storage/enrich_failures.test.ts
@@ -7,6 +7,7 @@ import {
   clearEnrichFailure,
   setEnrichFailureReview,
   listUntriagedFailures,
+  retireEnrichFailure,
   type EnrichFailureRow,
 } from './enrich_failures';
 
@@ -208,5 +209,34 @@ describe('enrich_failures', () => {
       brewery: 'B', name: 'b', search_url: 'u2', candidates_count: 2,
       candidates_summary: 'x|y', fail_count: 1, last_at: '2026-07-03T00:00:00Z',
     });
+  });
+});
+
+describe('retireEnrichFailure', () => {
+  test('sets retired_at, appends note, preserves review_class', () => {
+    const { db, id } = freshDbWithBeer();
+    recordEnrichFailure(db, row({ beer_id: id }));
+    setEnrichFailureReview(db, id, 'parser_bug', 'garbled name', '2026-07-01T00:00:00Z');
+    const changed = retireEnrichFailure(db, id, 'retired: current non-beer filter rejects', '2026-07-19T00:00:00Z');
+    expect(changed).toBe(true);
+    const got = db.prepare('SELECT * FROM enrich_failures WHERE beer_id = ?').get(id) as any;
+    expect(got.retired_at).toBe('2026-07-19T00:00:00Z');
+    expect(got.review_class).toBe('parser_bug');
+    expect(got.review_note).toContain('garbled name');
+    expect(got.review_note).toContain('retired: current non-beer filter rejects');
+  });
+  test('is idempotent — a second call does not change or re-append', () => {
+    const { db, id } = freshDbWithBeer();
+    recordEnrichFailure(db, row({ beer_id: id }));
+    retireEnrichFailure(db, id, 'retired: x', '2026-07-19T00:00:00Z');
+    const changed = retireEnrichFailure(db, id, 'retired: x', '2026-07-20T00:00:00Z');
+    expect(changed).toBe(false);
+    const got = db.prepare('SELECT retired_at, review_note FROM enrich_failures WHERE beer_id = ?').get(id) as any;
+    expect(got.retired_at).toBe('2026-07-19T00:00:00Z');
+    expect((got.review_note.match(/retired: x/g) ?? []).length).toBe(1);
+  });
+  test('returns false when no row exists', () => {
+    const { db } = freshDbWithBeer();
+    expect(retireEnrichFailure(db, 999, 'retired: x', '2026-07-19T00:00:00Z')).toBe(false);
   });
 });

--- a/src/storage/enrich_failures.test.ts
+++ b/src/storage/enrich_failures.test.ts
@@ -239,4 +239,11 @@ describe('retireEnrichFailure', () => {
     const { db } = freshDbWithBeer();
     expect(retireEnrichFailure(db, 999, 'retired: x', '2026-07-19T00:00:00Z')).toBe(false);
   });
+  test('note stands alone (no leading separator) when there was no prior note', () => {
+    const { db, id } = freshDbWithBeer();
+    recordEnrichFailure(db, row({ beer_id: id })); // review_note is NULL here
+    retireEnrichFailure(db, id, 'retired: current non-beer filter rejects', '2026-07-19T00:00:00Z');
+    const got = db.prepare('SELECT review_note FROM enrich_failures WHERE beer_id = ?').get(id) as any;
+    expect(got.review_note).toBe('retired: current non-beer filter rejects');
+  });
 });

--- a/src/storage/enrich_failures.ts
+++ b/src/storage/enrich_failures.ts
@@ -90,6 +90,29 @@ export function setEnrichFailureReview(
   return info.changes > 0;
 }
 
+// Terminal state for a classified failure whose underlying problem is resolved
+// (the responsible fix has shipped). Sets retired_at and appends `note` to
+// review_note, preserving the original review_class for audit. Idempotent: only
+// rows not already retired are touched (WHERE retired_at IS NULL), so re-runs
+// neither re-append the note nor overwrite the timestamp. Returns false when no
+// eligible row exists (missing, or already retired).
+export function retireEnrichFailure(
+  db: DB,
+  beerId: number,
+  note: string,
+  atIso: string,
+): boolean {
+  const info = db
+    .prepare(
+      `UPDATE enrich_failures
+         SET retired_at  = ?,
+             review_note = TRIM(COALESCE(review_note, '') || ' | ' || ?)
+       WHERE beer_id = ? AND retired_at IS NULL`,
+    )
+    .run(atIso, note, beerId);
+  return info.changes > 0;
+}
+
 export interface UntriagedFailure {
   beer_id: number;
   brewery: string;

--- a/src/storage/enrich_failures.ts
+++ b/src/storage/enrich_failures.ts
@@ -92,10 +92,11 @@ export function setEnrichFailureReview(
 
 // Terminal state for a classified failure whose underlying problem is resolved
 // (the responsible fix has shipped). Sets retired_at and appends `note` to
-// review_note, preserving the original review_class for audit. Idempotent: only
-// rows not already retired are touched (WHERE retired_at IS NULL), so re-runs
-// neither re-append the note nor overwrite the timestamp. Returns false when no
-// eligible row exists (missing, or already retired).
+// review_note, preserving the original review_class for audit. When there is no
+// prior note the note stands alone (no leading ` | ` separator). Idempotent:
+// only rows not already retired are touched (WHERE retired_at IS NULL), so
+// re-runs neither re-append the note nor overwrite the timestamp. Returns false
+// when no eligible row exists (missing, or already retired).
 export function retireEnrichFailure(
   db: DB,
   beerId: number,
@@ -106,10 +107,13 @@ export function retireEnrichFailure(
     .prepare(
       `UPDATE enrich_failures
          SET retired_at  = ?,
-             review_note = TRIM(COALESCE(review_note, '') || ' | ' || ?)
+             review_note = CASE
+               WHEN review_note IS NULL OR review_note = '' THEN ?
+               ELSE review_note || ' | ' || ?
+             END
        WHERE beer_id = ? AND retired_at IS NULL`,
     )
-    .run(atIso, note, beerId);
+    .run(atIso, note, note, beerId);
   return info.changes > 0;
 }
 

--- a/src/storage/schema.test.ts
+++ b/src/storage/schema.test.ts
@@ -247,4 +247,13 @@ describe('schema migrations', () => {
     const row = db.prepare("SELECT city FROM pubs WHERE slug = 'x'").get() as { city: string };
     expect(row.city).toBe('warszawa');
   });
+
+  test('migration 18 adds nullable retired_at to enrich_failures', () => {
+    const db = openDb(':memory:');
+    migrate(db);
+    const cols = db.prepare(`PRAGMA table_info(enrich_failures)`).all() as { name: string; notnull: number }[];
+    const retired = cols.find((c) => c.name === 'retired_at');
+    expect(retired).toBeDefined();
+    expect(retired!.notnull).toBe(0);
+  });
 });

--- a/src/storage/schema.ts
+++ b/src/storage/schema.ts
@@ -238,6 +238,12 @@ const MIGRATIONS: ReadonlyArray<{ version: number; sql: string }> = [
       );
     `,
   },
+  {
+    version: 18,
+    sql: `
+      ALTER TABLE enrich_failures ADD COLUMN retired_at TEXT;
+    `,
+  },
 ];
 
 export function migrate(db: DB): void {

--- a/src/storage/stats.test.ts
+++ b/src/storage/stats.test.ts
@@ -91,6 +91,24 @@ it('reports enrich health metrics', () => {
   expect(m.untappdSearchHealthy).toBe(true);
 });
 
+it('orphansPending excludes retired orphans', () => {
+  const db = fresh();
+  const { lastInsertRowid: a } = db.prepare(
+    `INSERT INTO beers (untappd_id,name,brewery,normalized_name,normalized_brewery) VALUES (NULL,'Alpha','Brew A','alpha','brew a')`,
+  ).run();
+  db.prepare(
+    `INSERT INTO beers (untappd_id,name,brewery,normalized_name,normalized_brewery) VALUES (NULL,'Beta','Brew B','beta','brew b')`,
+  ).run();
+  db.prepare(
+    `INSERT INTO enrich_failures
+       (beer_id,brewery,name,search_url,outcome,candidates_count,candidates_summary,
+        fail_count,last_at,source_url,review_class,retired_at)
+     VALUES (?,'Brew A','Alpha','u','not_found',0,'',1,'2026-07-01T00:00:00Z','','parser_bug','2026-07-19T00:00:00Z')`,
+  ).run(a);
+  const m = collectStatus(db, new Date('2026-07-19T10:00:00Z'));
+  expect(m.orphansPending).toBe(1);
+});
+
 test('collectStatus: extension /match metrics come from the previous Warsaw day', () => {
   const db = openDb(':memory:');
   migrate(db);

--- a/src/storage/stats.ts
+++ b/src/storage/stats.ts
@@ -61,7 +61,14 @@ export function collectStatus(db: DB, now: Date): StatusMetrics {
     pubsScraped24h: count('SELECT COUNT(DISTINCT pub_id) AS c FROM tap_snapshots WHERE snapshot_at >= ?', [cutoff24]),
     beersTotal: count('SELECT COUNT(*) AS c FROM beers'),
     beersMatched: count('SELECT COUNT(*) AS c FROM beers WHERE untappd_id IS NOT NULL'),
-    orphansPending: count('SELECT COUNT(*) AS c FROM beers WHERE untappd_id IS NULL'),
+    orphansPending: count(
+      `SELECT COUNT(*) AS c FROM beers b
+        WHERE b.untappd_id IS NULL
+          AND NOT EXISTS (
+            SELECT 1 FROM enrich_failures ef
+            WHERE ef.beer_id = b.id AND ef.retired_at IS NOT NULL
+          )`,
+    ),
     ratingsMissing: count('SELECT COUNT(*) AS c FROM beers WHERE untappd_id IS NOT NULL AND rating_global IS NULL'),
     snapshots: count('SELECT COUNT(*) AS c FROM tap_snapshots'),
     taps: count('SELECT COUNT(*) AS c FROM taps'),


### PR DESCRIPTION
## Summary

Closes #286. Historical classified `enrich_failures` rows (wine/spirit now filtered, parser fixes shipped) never clear — a row is only deleted on a successful match — so resolved clusters keep looking "active" and inflate the orphan count. This adds a **terminal `retired_at` state** and a **manual ops tool** to move *provably-resolved* rows into it, without deleting anything (audit-preserving).

- **Migration 18:** `enrich_failures.retired_at` (nullable ISO timestamp).
- **`retireEnrichFailure(db, beerId, note, atIso)`:** sets `retired_at`, appends the reason to `review_note`, **preserves the original `review_class`** for audit; idempotent (`WHERE retired_at IS NULL`).
- **Consumers exclude retired rows:** `listLookupCandidates` (enrich pool, alongside `wontfix`) and `stats.orphansPending` (daily digest count). Untriaged triage already excludes them (they keep a class).
- **`retire-resolved-orphans` CLI** (`npm run retire-resolved-orphans`, dry-run default + `--apply`):
  - **Auto path:** re-runs the current `isOntapNonBeerTap` against each stored beer; retires only rows the live filter now rejects (self-justifying).
  - **`--ids <csv> --reason "<text>"` escape hatch:** operator-supplied ids for fixes the predicate can't detect (e.g. parse-split clusters, or `VINO KARPATIA`).
  - Never selects by age or `review_class` alone.
- Docs: `spec.md` §3.13 + migration table, design + plan under `docs/superpowers/`.

## Notable finding (verified against prod)

The design initially claimed `VINO KARPATIA / Biały bez` would be auto-caught. Verified it is **not** — `isOntapNonBeerTap`'s `BREWERY_TOKENS` has `wino`/`wine`/`vini` but not the Italian `vino`, and it only tests `style` when present (this row has an empty style). It's legitimately an `--ids` escape-hatch case. Widening the shared live ontap filter is deliberately **out of scope** (it would change ingestion behaviour; belongs with the #306/#238 parser-filter work). Design doc corrected accordingly. Konrad/#306 live-parser rows are also explicitly scoped out (fix, don't retire).

## Test Plan

- [x] `npx vitest run` — 113 files, 1205 tests pass (+10)
- [x] `npm run typecheck` clean
- [x] CLI dry-run smoke-tested against a temp DB (prints the row + `N would be retired (dry-run …)`)
- [ ] After deploy: run auto-path dry-run to review the wine/non-beer cluster, then `--apply`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
