### PR TITLE
fix(matcher): 'family' brewery noise (#309) + strip 'Series:' query label (#303)

### DIFF
--- a/docs/superpowers/plans/2026-07/2026-07-19-matcher-family-noise-series-labels.md
+++ b/docs/superpowers/plans/2026-07/2026-07-19-matcher-family-noise-series-labels.md
@@ -1,0 +1,168 @@
+# `family` brewery noise + `Series:` query-label strip (#309 + #303) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Two small matcher-query normalisation fixes so `family`-suffixed breweries match and `Series:` collection labels stop zeroing the Untappd search.
+
+**Architecture:** Both live in `src/domain/normalize.ts`. #309 adds one token to the `BREWERY_NOISE` set (dropped from brewery tokens in both `normalizeBrewery` and the query builder). #303 adds one regex to `stripSearchNoise` (shared by query + match normalisation) that removes a leading label run ending in the word `series` + a separator.
+
+**Tech Stack:** TypeScript, Vitest. Design doc: `docs/superpowers/specs/2026-07/2026-07-19-matcher-family-noise-series-labels-design.md`.
+
+---
+
+## File Structure
+
+- `src/domain/normalize.ts` — `BREWERY_NOISE` set (add `'family'`); `stripSearchNoise` (add the `series`-label strip).
+- `src/domain/normalize.test.ts` — new tests for both.
+
+Both changes are additive and independent; each is its own task + commit.
+
+**Repo conventions:** run a single test file with `npx vitest run src/domain/normalize.test.ts`. Follow the existing test style in that file (bare `test(...)`/`expect` and `describe(...)` blocks). `stripSearchNoise`, `cleanSearchQuery`, `normalizeBrewery`, `BREWERY_NOISE` are all exported and already imported in the test file.
+
+---
+
+## Task 1: #309 — `family` as brewery noise
+
+**Files:**
+- Modify: `src/domain/normalize.ts` (the `BREWERY_NOISE` set, ends at the `'nanobrowar', 'nanobrowary', 'nanobryggeri',` line)
+- Test: `src/domain/normalize.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/domain/normalize.test.ts`:
+
+```ts
+describe("'family' brewery noise (#309)", () => {
+  test('family is dropped so X Family Brewery == X Brewery', () => {
+    expect(normalizeBrewery('HOPPY HOG FAMILY BREWERY')).toBe('hoppy hog');
+    expect(normalizeBrewery('Hoppy Hog Family Brewery')).toBe('hoppy hog');
+    expect(normalizeBrewery('HOPPY HOG BREWERY')).toBe('hoppy hog');
+  });
+  test('family is dropped from the search query brand tokens', () => {
+    expect(cleanSearchQuery('Hoppy Hog Family Brewery', 'Pale Ale')).toBe('Hoppy Hog Pale Ale');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/domain/normalize.test.ts -t "family"`
+Expected: FAIL — `normalizeBrewery('HOPPY HOG FAMILY BREWERY')` returns `'hoppy hog family'`, not `'hoppy hog'`.
+
+- [ ] **Step 3: Add `family` to `BREWERY_NOISE`**
+
+In `src/domain/normalize.ts`, change the last line of the `BREWERY_NOISE` set from:
+
+```ts
+  'nanobrowar', 'nanobrowary', 'nanobryggeri',
+]);
+```
+
+to:
+
+```ts
+  'nanobrowar', 'nanobrowary', 'nanobryggeri',
+  // Descriptor in "<brand> Family Brewery"; never the load-bearing brand token (#309).
+  'family',
+]);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/domain/normalize.test.ts -t "family"`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/domain/normalize.ts src/domain/normalize.test.ts
+git commit -m "fix(matcher): treat 'family' as brewery noise (#309)"
+```
+
+---
+
+## Task 2: #303 — strip a `Series` label prefix
+
+**Files:**
+- Modify: `src/domain/normalize.ts` (`stripSearchNoise`)
+- Test: `src/domain/normalize.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/domain/normalize.test.ts`:
+
+```ts
+describe("Series: label strip (#303)", () => {
+  test('strips a leading "<label> Series:" prefix, keeping the tail', () => {
+    expect(stripSearchNoise('Crazy Lines Series: Redwood')).toBe('Redwood');
+    expect(stripSearchNoise('Gold Series: Blast')).toBe('Blast');
+    expect(stripSearchNoise('WORLD CUP SERIES - 5 SPECIAL BEER')).toBe('5 SPECIAL BEER');
+  });
+  test('drops the Series label from the built search query', () => {
+    expect(cleanSearchQuery('Nepomucen', 'Crazy Lines Series: Redwood')).toBe('Nepomucen Redwood');
+  });
+  test('negative guard: leaves names without a series label untouched', () => {
+    expect(stripSearchNoise('Time Series IPA')).toBe('Time Series IPA'); // no separator after "series"
+    expect(stripSearchNoise('Double Dry Hopped Galaxy')).toBe('Double Dry Hopped Galaxy');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/domain/normalize.test.ts -t "Series"`
+Expected: FAIL — `stripSearchNoise('Crazy Lines Series: Redwood')` returns the full string (label not stripped).
+
+- [ ] **Step 3: Add the `series`-label strip to `stripSearchNoise`**
+
+In `src/domain/normalize.ts`, the `stripSearchNoise` function begins:
+
+```ts
+export function stripSearchNoise(s: string): string {
+  return s
+    .replace(/\[[^\]]*\]/g, ' ')                     // [adjunct, lists]
+```
+
+Insert the series-label strip as the **first** replacement in the chain, so it runs on the raw string:
+
+```ts
+export function stripSearchNoise(s: string): string {
+  return s
+    // Drop a leading "<label> Series:" collection prefix that otherwise ANDs the
+    // Algolia query to zero hits (#303). Anchored on the word "series" + a
+    // separator, so names without a labelled series ("Time Series IPA") are kept.
+    .replace(/^.*?\bseries\b\s*[:\-–—]\s*/iu, '')
+    .replace(/\[[^\]]*\]/g, ' ')                     // [adjunct, lists]
+```
+
+(Leave the rest of the function unchanged.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/domain/normalize.test.ts -t "Series"`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/domain/normalize.ts src/domain/normalize.test.ts
+git commit -m "fix(matcher): strip leading 'Series:' label from search query (#303)"
+```
+
+---
+
+## Task 3: Full verification
+
+- [ ] **Step 1: Run the whole normalize suite (no regression)**
+
+Run: `npx vitest run src/domain/normalize.test.ts`
+Expected: all pass (existing noise-strip, diacritics, nano-noise, multilingual tests + the 5 new tests).
+
+- [ ] **Step 2: Run the full suite + typecheck**
+
+Run: `npx vitest run` then `npm run typecheck`
+Expected: all tests pass; `tsc --noEmit` clean.
+
+- [ ] **Step 3: Final review**
+
+Confirm: `'family'` in `BREWERY_NOISE`; the `series`-strip is the first replacement in `stripSearchNoise`; no other files touched; no `spec.md`/`extension/**` changes needed (matcher-only, server-side).

--- a/docs/superpowers/specs/2026-07/2026-07-19-matcher-family-noise-series-labels-design.md
+++ b/docs/superpowers/specs/2026-07/2026-07-19-matcher-family-noise-series-labels-design.md
@@ -1,0 +1,58 @@
+# Matcher: `family` brewery noise + `Series:` query-label strip (#309 + #303)
+
+**Status:** design
+**Issues:** #309 (BREWERY_NOISE += `family`), #303 (strip `Series:` naming labels)
+**Date:** 2026-07-19
+
+Two small, independent matcher-query fixes in `src/domain/normalize.ts`, batched into one PR / one server deploy (both are tier-1 P0 wins from the 2026-07-19 matcher-bug review). Both are server-side and deploy independently of the extension.
+
+## Problem
+
+Reproduced against the current code (`cleanSearchQuery` / `normalizeBrewery`):
+
+- **#309:** `HOPPY HOG FAMILY BREWERY` normalises to `hoppy hog family`, but `HOPPY HOG BREWERY` → `hoppy hog`. The `family` token blocks the brewery-gate match (and pollutes the search query). Complements the shipped beerfreak parser fix #305.
+- **#303:** `Series:` collection labels survive into the search query and over-constrain Algolia (which ANDs terms) → zero candidates: `Crazy Lines Series: Redwood` → query `Nepomucen Crazy Lines Series: Redwood`; `Gold Series: Blast` unchanged. (Packaging parentheticals like `(puszka)` are **already** stripped by `stripSearchNoise` — verified `Ole! (puszka)` → `NEPO Ole` — so they are **out of scope**.)
+
+## §1 — #309: `family` as brewery noise
+
+Add `'family'` to the `BREWERY_NOISE` set in `src/domain/normalize.ts`. It is dropped by fold-comparison anywhere it appears in a brewery token list (used by both `normalizeBrewery` and `cleanSearchQuery`'s brand-token loop), so:
+
+- `HOPPY HOG FAMILY BREWERY` → `hoppy hog` == `HOPPY HOG BREWERY` → `hoppy hog`.
+
+**False-positive note:** `family` is effectively always a descriptor in brewery names (`X Family Brewery`), never the load-bearing brand token; dropping it is safe. Accepted, matching #309's call.
+
+## §2 — #303: strip a `Series` label prefix
+
+In `stripSearchNoise` (shared by query and match normalisation, so the strip helps both stages consistently), remove a leading label run that ends in the word **`series`** followed by a separator (`:`, `-`, en/em dash). Anchor regex on the `series` keyword:
+
+```
+/^.*?\bseries\b\s*[:\-–—]\s*/iu
+```
+
+Applied to the name, this yields:
+
+- `Crazy Lines Series: Redwood` → `Redwood`
+- `Gold Series: Blast` → `Blast`
+- `WORLD CUP SERIES - 5 SPECIAL BEER` → `5 SPECIAL BEER`
+
+**Scope (decided):** anchor on the `series` keyword only — **not** a generic `^<Label>:` strip. All known zero-candidate examples are `Series` labels; a blanket colon-prefix strip risks eating meaningful names (e.g. `Coup D'Etat`). The `\bseries\b` + separator guard leaves names without a series label untouched (`Time Series IPA` — no separator after `series` — is unchanged). Extend to other label words later only if prod data shows them.
+
+**Placement:** add the rule inside `stripSearchNoise`, before the trailing-punctuation / whitespace-collapse tail, so both the search query and the shared match normalisation drop the label. This keeps the query and the name-match keys consistent (structural noise removed from the query cannot be reintroduced downstream — the existing invariant of that helper).
+
+**Ordering caution:** place the `series` strip early enough that it runs on the raw name, but the regex is non-greedy and self-contained, so ordering among the other `stripSearchNoise` replacements does not matter for correctness.
+
+## What this does NOT do
+
+- Not the name-stage reconciliation for candidates that already come back (e.g. `Crazy Lines Series: White & Red` where Untappd keeps the series prefix) — that is #319.
+- Not packaging-token stripping — already handled.
+- No brewery-alias work (#318), no generic colon labels.
+
+## Testing (Vitest, `src/domain/normalize.test.ts`)
+
+- **#309:** `normalizeBrewery('HOPPY HOG FAMILY BREWERY') === normalizeBrewery('HOPPY HOG BREWERY')` (both `hoppy hog`); a `cleanSearchQuery` case confirming `family` is dropped from the brand tokens.
+- **#303:** `stripSearchNoise` / `cleanSearchQuery` cases: the three `Series` examples above strip to their tails; a **negative guard** — `Time Series IPA` (no separator) is unchanged; a name with an unrelated colon is unaffected by the `series`-anchored rule.
+- Full `normalize.test.ts` suite stays green (no regression to existing noise-strip cases).
+
+## Rollout
+
+Server-side only; ships via `deploy.sh`. After deploy, run `npm run rearm-matcher-bug-orphans` so backed-off matcher_bug orphans re-attempt against the improved normalisation. No `spec.md` schema change; no `extension/**` change → no extension-docs update.

--- a/src/domain/normalize.test.ts
+++ b/src/domain/normalize.test.ts
@@ -287,3 +287,18 @@ describe("'family' brewery noise (#309)", () => {
     expect(cleanSearchQuery('Hoppy Hog Family Brewery', 'Pale Ale')).toBe('Hoppy Hog Pale Ale');
   });
 });
+
+describe("Series: label strip (#303)", () => {
+  test('strips a leading "<label> Series:" prefix, keeping the tail', () => {
+    expect(stripSearchNoise('Crazy Lines Series: Redwood')).toBe('Redwood');
+    expect(stripSearchNoise('Gold Series: Blast')).toBe('Blast');
+    expect(stripSearchNoise('WORLD CUP SERIES - 5 SPECIAL BEER')).toBe('5 SPECIAL BEER');
+  });
+  test('drops the Series label from the built search query', () => {
+    expect(cleanSearchQuery('Nepomucen', 'Crazy Lines Series: Redwood')).toBe('Nepomucen Redwood');
+  });
+  test('negative guard: leaves names without a series label untouched', () => {
+    expect(stripSearchNoise('Time Series IPA')).toBe('Time Series IPA');
+    expect(stripSearchNoise('Double Dry Hopped Galaxy')).toBe('Double Dry Hopped Galaxy');
+  });
+});

--- a/src/domain/normalize.test.ts
+++ b/src/domain/normalize.test.ts
@@ -276,3 +276,14 @@ describe('stripSearchNoise', () => {
     expect(stripSearchNoise('Brewery (Special Edition) [adjuncts]')).toBe('Brewery');
   });
 });
+
+describe("'family' brewery noise (#309)", () => {
+  test('family is dropped so X Family Brewery == X Brewery', () => {
+    expect(normalizeBrewery('HOPPY HOG FAMILY BREWERY')).toBe('hoppy hog');
+    expect(normalizeBrewery('Hoppy Hog Family Brewery')).toBe('hoppy hog');
+    expect(normalizeBrewery('HOPPY HOG BREWERY')).toBe('hoppy hog');
+  });
+  test('family is dropped from the search query brand tokens', () => {
+    expect(cleanSearchQuery('Hoppy Hog Family Brewery', 'Pale Ale')).toBe('Hoppy Hog Pale Ale');
+  });
+});

--- a/src/domain/normalize.test.ts
+++ b/src/domain/normalize.test.ts
@@ -292,7 +292,11 @@ describe("Series: label strip (#303)", () => {
   test('strips a leading "<label> Series:" prefix, keeping the tail', () => {
     expect(stripSearchNoise('Crazy Lines Series: Redwood')).toBe('Redwood');
     expect(stripSearchNoise('Gold Series: Blast')).toBe('Blast');
-    expect(stripSearchNoise('WORLD CUP SERIES - 5 SPECIAL BEER')).toBe('5 SPECIAL BEER');
+    expect(stripSearchNoise('WORLD CUP SERIES - 5 SPECIAL BEER')).toBe('5 SPECIAL BEER'); // uppercase
+  });
+  test('tolerates casing and whitespace around the separator', () => {
+    expect(stripSearchNoise('gold series : blast')).toBe('blast'); // lowercase + space before colon
+    expect(stripSearchNoise('Gold SERIES:Blast')).toBe('Blast');   // no space after colon
   });
   test('drops the Series label from the built search query', () => {
     expect(cleanSearchQuery('Nepomucen', 'Crazy Lines Series: Redwood')).toBe('Nepomucen Redwood');

--- a/src/domain/normalize.ts
+++ b/src/domain/normalize.ts
@@ -129,6 +129,10 @@ function foldToken(tok: string): string {
 // from the search query cannot be reintroduced by downstream name matching.
 export function stripSearchNoise(s: string): string {
   return s
+    // Drop a leading "<label> Series:" collection prefix that otherwise ANDs the
+    // Algolia query to zero hits (#303). Anchored on the word "series" + a
+    // separator, so names without a labelled series ("Time Series IPA") are kept.
+    .replace(/^.*?\bseries\b\s*[:\-–—]\s*/iu, '')
     .replace(/\[[^\]]*\]/g, ' ')                     // [adjunct, lists]
     .replace(/\(([^)]*)\)/g, (_group, content: string) =>
       /^(?=[\p{L}\p{N}]*\d)[\p{L}\p{N}]+$/u.test(content) ? ` ${content} ` : ' ')

--- a/src/domain/normalize.ts
+++ b/src/domain/normalize.ts
@@ -17,6 +17,8 @@ export const BREWERY_NOISE = new Set([
   // is deliberately NOT noise — it's a separate word or brand fragment in
   // "Nano Cinco"/"Mandrill Nano Brewing", which stripping would corrupt (#228).
   'nanobrowar', 'nanobrowary', 'nanobryggeri',
+  // Descriptor in "<brand> Family Brewery"; never the load-bearing brand token (#309).
+  'family',
 ]);
 
 // Separator for collab/bilingual brewery names. Untappd uses:


### PR DESCRIPTION
## Summary

Two tier-1 matcher-query normalisation fixes (from the 2026-07-19 matcher-bug review), server-side, one deploy. Both in `src/domain/normalize.ts`.

- **#309** — add `family` to `BREWERY_NOISE`. `HOPPY HOG FAMILY BREWERY` normalised to `hoppy hog family` and so missed the brewery gate vs `HOPPY HOG BREWERY` → `hoppy hog`. `family` is always a descriptor, never the brand token. Complements the shipped beerfreak fix #305.
- **#303** — strip a leading `<label> Series:` collection prefix in `stripSearchNoise` (regex anchored on the word `series` + a separator). `Crazy Lines Series: Redwood` was searched verbatim and ANDed to zero Algolia hits; now searches `Redwood`. Scoped to `series` only (not generic colon labels); packaging parentheticals like `(puszka)` were already stripped and are untouched.

Verified against prod-observed inputs; negative guard keeps `Time Series IPA` (no separator) unchanged.

## Test Plan
- [x] `npx vitest run` — 113 files, 1211 tests (+5)
- [x] `npm run typecheck` clean
- [ ] After deploy: `npm run rearm-matcher-bug-orphans` so backed-off matcher_bug orphans re-attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)
