### PR TITLE
feat(matcher): #329 gate-miss brewery alias batch (4 pairs)

### DIFF
--- a/docs/superpowers/plans/2026-07/2026-07-20-brewery-alias-batch-329.md
+++ b/docs/superpowers/plans/2026-07/2026-07-20-brewery-alias-batch-329.md
@@ -1,0 +1,171 @@
+# Brewery Alias / Gate-Miss Batch #329 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add four verified curated brewery-alias pairs so the enrichment gate accepts the already-present Untappd candidate for ~7 orphans (4 Ziemia Obiecana beers + Bergquell/Erdbeer + Cieszyn Pilsner + TankBusters/Paranormal Activity).
+
+**Architecture:** Pure data change to `ALIAS_PAIRS` in `src/domain/brewery-aliases.ts`, mirroring the #318 batch. The existing `NEIGHBORS`/`aliasKeys` machinery and `breweryAliases` one-hop expansion pick the pairs up at module load — no logic change. Two test files lock the behaviour: `brewery-aliases.test.ts` (symmetry + no-hub) and `matcher.test.ts` (end-to-end `matchBeer` regression per pair).
+
+**Tech Stack:** TypeScript, Vitest. Design doc: `docs/superpowers/specs/2026-07/2026-07-20-brewery-alias-batch-329-design.md`.
+
+**The four pairs** (normalized forms, verified against `normalizeBrewery`):
+
+| shop brewery | Untappd brewery | pair |
+|---|---|---|
+| `ZIEMIA OBIACANA Brewery` | `Ziemia Obiecana` | `['ziemia obiacana', 'ziemia obiecana']` |
+| `BERGQELL Brewery` | `Bergquell Brauerei Löbau` | `['bergqell', 'bergquell lobau']` |
+| `Bracki Browar Zamkowy w Cieszynie Brewery` | `Arcyksiążęcy Browar Zamkowy Cieszyn` | `['bracki zamkowy w cieszynie', 'arcyksiazecy zamkowy cieszyn']` |
+| `Tank Busters Brewery` | `TankBusters.Co` | `['tank busters', 'tankbusters']` |
+
+---
+
+### Task 1: Add the four alias pairs (data + tests)
+
+**Files:**
+- Modify: `src/domain/brewery-aliases.ts` (append to `ALIAS_PAIRS`, currently ends at line ~40)
+- Modify: `src/domain/brewery-aliases.test.ts` (append a `#329` describe block after the `#318` block)
+- Modify: `src/domain/matcher.test.ts` (append a `#329` describe block at end of file)
+
+- [ ] **Step 1: Write the failing alias-map tests**
+
+Append to `src/domain/brewery-aliases.test.ts` (after the `describe('#318 gate-miss alias batch', …)` block):
+
+```typescript
+describe('#329 gate-miss alias batch', () => {
+  const PAIRS: ReadonlyArray<readonly [string, string]> = [
+    ['ziemia obiacana', 'ziemia obiecana'],
+    ['bergqell', 'bergquell lobau'],
+    ['bracki zamkowy w cieszynie', 'arcyksiazecy zamkowy cieszyn'],
+    ['tank busters', 'tankbusters'],
+  ];
+  test.each(PAIRS)('resolves %s <-> %s symmetrically', (shop, untappd) => {
+    expect(aliasNeighbors(shop)).toContain(untappd);
+    expect(aliasNeighbors(untappd)).toContain(shop);
+  });
+  // Each new form is a 1:1 equivalence — no shared form, so no new alias hub.
+  test.each(PAIRS.flat())('form %s has exactly one neighbour (no new hub)', (form) => {
+    expect(aliasNeighbors(form)).toHaveLength(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run the alias-map tests to verify they fail**
+
+Run: `npx vitest run src/domain/brewery-aliases.test.ts`
+Expected: FAIL — the `#329` `resolves … symmetrically` cases fail (`aliasNeighbors('ziemia obiacana')` returns `[]`, does not contain `'ziemia obiecana'`); the no-hub cases fail with length 0.
+
+- [ ] **Step 3: Write the failing matcher regression tests**
+
+Append to the end of `src/domain/matcher.test.ts`. The `c()` helper and `matchBeer`, `breweryAliases`, `breweryAliasesMatch` imports already exist at the top of the file.
+
+```typescript
+describe('#329 gate-miss alias batch — end to end', () => {
+  const passes = (shop: string, untappd: string) =>
+    breweryAliasesMatch(breweryAliases(shop), breweryAliases(untappd));
+
+  test('new pairs pass the brewery gate', () => {
+    expect(passes('ZIEMIA OBIACANA Brewery', 'Ziemia Obiecana')).toBe(true);
+    expect(passes('BERGQELL Brewery', 'Bergquell Brauerei Löbau')).toBe(true);
+    expect(passes('Bracki Browar Zamkowy w Cieszynie Brewery', 'Arcyksiążęcy Browar Zamkowy Cieszyn')).toBe(true);
+    expect(passes('Tank Busters Brewery', 'TankBusters.Co')).toBe(true);
+  });
+
+  // Catalog carries the authoritative Untappd brewery/name; input is the shop label.
+  const cat: CatalogBeer[] = [
+    c({ id: 101, brewery: 'Ziemia Obiecana', name: 'Bryła' }),
+    c({ id: 102, brewery: 'Ziemia Obiecana', name: 'Beach Hut' }),
+    c({ id: 103, brewery: 'Ziemia Obiecana', name: 'Padel Boys' }),
+    c({ id: 104, brewery: 'Ziemia Obiecana', name: 'Prole Juice' }),
+    c({ id: 105, brewery: 'Bergquell Brauerei Löbau', name: 'Erdbeer Porter' }),
+    c({ id: 106, brewery: 'Arcyksiążęcy Browar Zamkowy Cieszyn', name: 'Cieszyn Pilsner' }),
+    c({ id: 107, brewery: 'TankBusters.Co', name: 'Paranormal Activity' }),
+  ];
+
+  test.each([
+    ['ZIEMIA OBIACANA Brewery', 'BRYŁA', 101],
+    ['ZIEMIA OBIACANA Brewery', 'BEACH HUT', 102],
+    ['ZIEMIA OBIACANA Brewery', 'PADEL BOYS', 103],
+    ['ZIEMIA OBIACANA Brewery', 'Prole Juice', 104],
+    ['BERGQELL Brewery', 'Erdbeer', 105],
+    ['Bracki Browar Zamkowy w Cieszynie Brewery', 'CIESZYN PILSNER', 106],
+    ['Tank Busters Brewery', 'Paranormal Activity', 107],
+  ] as const)('%s / %s matches catalog id %i', (brewery, name, id) => {
+    expect(matchBeer({ brewery, name }, cat)).toEqual({ id, confidence: 1, source: 'exact' });
+  });
+});
+```
+
+- [ ] **Step 4: Run the matcher tests to verify they fail**
+
+Run: `npx vitest run src/domain/matcher.test.ts -t "#329"`
+Expected: FAIL — `passes(...)` returns `false` (gate rejects without the alias) and each `matchBeer` returns `null` instead of the expected `{ id, confidence: 1, source: 'exact' }`.
+
+- [ ] **Step 5: Add the four pairs to `ALIAS_PAIRS`**
+
+In `src/domain/brewery-aliases.ts`, insert immediately before the closing `];` of `ALIAS_PAIRS` (after the last `['drofa', 'дрофа'],` line):
+
+```typescript
+  // #329 batch (2026-07-20): gate-miss aliases, each verified against the orphan's
+  // enrich_failures.candidates_summary (authoritative Untappd brewery) and the real
+  // matcher name stage (only rows whose name already matches post-alias — see the
+  // #329 design doc). Name-divergent misses were routed to #319, not aliased here.
+  ['ziemia obiacana', 'ziemia obiecana'],      // brewery typo OBIACANA->OBIECANA; 4 beers
+  ['bergqell', 'bergquell lobau'],             // Erdbeer (Porter style-stripped)
+  ['bracki zamkowy w cieszynie', 'arcyksiazecy zamkowy cieszyn'], // Cieszyn Pilsner
+  ['tank busters', 'tankbusters'],             // Paranormal Activity
+```
+
+- [ ] **Step 6: Run both test files to verify they pass**
+
+Run: `npx vitest run src/domain/brewery-aliases.test.ts src/domain/matcher.test.ts`
+Expected: PASS — all `#329` symmetry, no-hub, gate, and match cases green; no pre-existing test regressed.
+
+- [ ] **Step 7: Full suite + typecheck**
+
+Run: `npm test && npm run typecheck`
+Expected: PASS — whole Vitest suite green, `tsc --noEmit` clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/domain/brewery-aliases.ts src/domain/brewery-aliases.test.ts src/domain/matcher.test.ts
+git commit -m "feat(matcher): #329 gate-miss brewery alias batch (4 pairs)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Deploy, re-arm, verify (ops — no code)
+
+**Files:** none (production operations).
+
+- [ ] **Step 1: Deploy to prod**
+
+Run: `bash deploy/deploy.sh` (rsyncs working tree to `/opt`, `npm ci && npm run build && npm prune --omit=dev`, restarts the service — activating the new `ALIAS_PAIRS` at module load).
+Expected: `journalctl` tail shows the service restarted cleanly.
+
+- [ ] **Step 2: Re-arm the backed-off orphans (dry-run first)**
+
+Run: `sudo -n -u warsaw-beer-bot bash -lc 'cd /opt/warsaw-beer-bot && npm run rearm-matcher-bug-orphans'`
+Expected: dry-run lists the affected orphans (incl. the Ziemia/Bergquell/Cieszyn/TankBusters rows) among the matcher_bug set; prints "N matcher-bug orphan(s) would be re-armed".
+
+- [ ] **Step 3: Apply the re-arm**
+
+Run: `sudo -n -u warsaw-beer-bot bash -lc 'cd /opt/warsaw-beer-bot && npm run rearm-matcher-bug-orphans -- --apply'`
+Expected: "Re-armed N matcher-bug orphan(s)." (resets `untappd_lookup_count=0`/`untappd_lookup_at=NULL` so the enrich cron retries them).
+
+- [ ] **Step 4: Verify after the next enrich cron**
+
+Run (after the cron has run, e.g. next :30):
+```bash
+sudo -n -u warsaw-beer-bot bash -lc 'sqlite3 /var/lib/warsaw-beer-bot/bot.db "SELECT id, brewery, name, untappd_id FROM beers WHERE id IN (32647,30934,31948,32312,11991,30141,32683)"'
+```
+Expected: the seven rows now have a non-null `untappd_id` and have dropped out of `enrich_failures` (self-clear on match, #127).
+
+---
+
+## Notes
+
+- Server-side only: no `extension/**` change → no `docs/extension-install-uk.md` update; no schema change → no `spec.md` change (per the design doc's "spec.md impact: none").
+- Open the PR after Task 1 and run the AI-review loop before deploying (Task 2), per the project workflow.

--- a/docs/superpowers/specs/2026-07/2026-07-20-brewery-alias-batch-329-design.md
+++ b/docs/superpowers/specs/2026-07/2026-07-20-brewery-alias-batch-329-design.md
@@ -1,0 +1,111 @@
+# Design: brewery alias / gate-miss batch #329
+
+**Date:** 2026-07-20
+**Issue:** #329 — *Matcher: brewery alias / gate-miss batch #2 (exact beer present, brewery label diverges)*
+**Precedent:** #318 (2026-07-19 alias batch), `docs/superpowers/specs/2026-07/2026-07-19-brewery-alias-gate-miss-batch-design.md`
+
+## Problem
+
+The 2026-07-20 orphan review surfaced a cluster of `matcher_bug` orphans where
+the *exact* beer is already on Untappd but the shop-side **brewery label
+diverges** from Untappd's, so the brewery hard-gate rejects a correct candidate.
+
+Not every such row is fixable with a curated alias, though. A brewery alias only
+helps when, once the brewery gate passes, the **name stage also accepts**. Probing
+the nine candidate rows against the real normalizers (`normalizeName`,
+`nameKeys`, `stripBreweryFromName`) showed only **four** rows match at the name
+stage post-alias; the rest diverge on the *name* (subset / reorder /
+brewery-echo) and cannot be rescued by an alias at all. Two proposed pairs
+(`dzik→cydrownia`, `panipani→trzech kumpli`) are in fact **already aliased since
+#318** and still fail — direct confirmation that name divergence, not the
+brewery gate, is what blocks them.
+
+## Scope (this cycle)
+
+Exactly the **four verified alias-fixable rows**. Everything else is routed
+elsewhere (see Out of Scope).
+
+### The four alias pairs
+
+Normalized forms below are the exact output of `normalizeBrewery()` (verified via
+the probe; re-confirm with `npm run alias-key "<shop>" "<untappd>"` during
+implementation):
+
+| beer_id(s) | shop `brewery / name` | Untappd brewery | name match post-alias | pair to add |
+|---|---|---|---|---|
+| 32647 (+30934/31948/32312 if present) | `ZIEMIA OBIACANA / BRYŁA` | Ziemia Obiecana | `bryla` = `bryla` (exact) | `['ziemia obiacana', 'ziemia obiecana']` |
+| 11991 | `BERGQELL / Erdbeer` | Bergquell Brauerei Löbau | `erdbeer` = `erdbeer` (Porter is a STYLE_WORD, stripped) | `['bergqell', 'bergquell lobau']` |
+| 30141 | `Bracki Browar Zamkowy w Cieszynie / CIESZYN PILSNER` | Arcyksiążęcy Browar Zamkowy Cieszyn | `cieszyn` = `cieszyn` (Pilsner stripped) | `['bracki zamkowy w cieszynie', 'arcyksiazecy zamkowy cieszyn']` |
+| 32683 | `Tank Busters / Paranormal Activity` | TankBusters.Co | key `activity paranormal` intersects | `['tank busters', 'tankbusters']` |
+
+**Ziemia Obiecana bonus rows.** The `ziemia obiacana ↔ ziemia obiecana` alias
+also covers the other three Ziemia Obiecana orphans — 30934 `BEACH HUT`, 31948
+`PADEL BOYS`, 32312 `Prole Juice` — *for free* **iff** those beers exist on
+Untappd under Ziemia Obiecana. Implementation verifies each via its
+`enrich_failures.candidates_summary`: any that resolve are rescued by the same
+alias; any that do not are left as-is (not this batch's concern).
+
+### Non-transitivity safety
+
+All four pairs are **fresh leaf↔leaf** pairs: none of the eight normalized forms
+already appears in `ALIAS_PAIRS`, so no alias hub is created and `breweryAliases`
+one-hop expansion stays sound. A test locks this (mirrors the #318
+"batch forms no alias hub" test): for each new form, `aliasNeighbors(form)` has
+length 1 and its partner is also a leaf.
+
+## Architecture
+
+Single-file data change plus a test, exactly like #318:
+
+- **`src/domain/brewery-aliases.ts`** — append the four pairs to `ALIAS_PAIRS`
+  under a `// #329 batch (2026-07-20)` comment. The existing `NEIGHBORS` /
+  `aliasKeys` machinery picks them up at module load; no logic change.
+- **`src/domain/brewery-aliases.test.ts`** — (a) assert each new pair resolves
+  (`aliasNeighbors` symmetric), (b) assert the batch forms no hub
+  (non-transitivity guard).
+- **`src/domain/matcher.test.ts`** — one `matchPrepared` test per pair: an input
+  beer `{ brewery: shopBrewery, name: shopName }` matches a prepared catalog row
+  `{ brewery: untappdBrewery, name: untappdName }`. `matchPrepared` runs the same
+  `breweryAliases` + name-stage gate the enrichment lookup uses, so this is the
+  faithful regression that the alias closes the real gate, not just the map.
+
+No change to `normalize.ts`, the gate, or the search-query builder.
+
+## Data flow / rollout
+
+1. Ship via `deploy.sh` (server-side only; no `extension/**`, no schema change).
+2. `ALIAS_PAIRS` is read at module load, so the deploy's service restart activates it.
+3. Re-arm the backed-off orphans so they re-attempt against the new aliases:
+   `sudo -n -u warsaw-beer-bot bash -lc 'cd /opt/warsaw-beer-bot && npm run rearm-matcher-bug-orphans -- --apply'`
+   (dry-run first without `-- --apply`).
+4. Verify: the four (up to seven) beer_ids gain `beers.untappd_id` and drop out
+   of `enrich_failures` on the next enrich cron.
+
+## Testing
+
+- `brewery-aliases.test.ts`: symmetry + no-hub (unit).
+- `matcher.test.ts`: one match assertion per pair, using the real shop→Untappd
+  strings from the table above (regression that the gate now passes).
+- Full `npm test` green; `npm run typecheck` clean.
+- Pre-deploy probe (throwaway): re-run the name-stage check to confirm the four
+  rows resolve and no unrelated catalog brewery collides with a new alias form.
+
+## Out of scope (explicitly)
+
+- **Name-stage divergence rows → #319** (subset / reorder / brewery-echo-in-name):
+  Chyliczki, Cydr Smykan, Jabłecznik Trzebnicki, Przetwórnia Chmielu, Cider Royal,
+  plus the already-aliased Dzik & PanIPAni. These need `nameKeys` /
+  `stripBreweryFromName` work, not an alias.
+- **`Carlsberg / okocim jasne` → #319 + source note.** `carlsberg ↔ okocim` is an
+  unsafe alias — Carlsberg is the multinational parent (Harnaś/Kasztelan/Książęce
+  are siblings); aliasing it to one brand is a false-positive hub. The real issue
+  is a **source mis-attribution** (parent company in the brewery field) compounded
+  by name subset (`okocim jasne` vs `Okocim Jasne Okocimskie`).
+- **`Cider` ↔ `Cidre` folding → #203 / with #319.** The probe shows it does not
+  complete any match on its own, so it is not a standalone `normalize.ts` change
+  now (YAGNI); it rides with the #319 name work.
+
+## `spec.md` impact
+
+None. `ALIAS_PAIRS` growth is data within the already-specified curated-alias
+layer (spec § on brewery gate / #202); no behavior or schema change to document.

--- a/src/domain/brewery-aliases.test.ts
+++ b/src/domain/brewery-aliases.test.ts
@@ -78,3 +78,20 @@ describe('#318 gate-miss alias batch', () => {
     expect(aliasNeighbors(form)).toHaveLength(1);
   });
 });
+
+describe('#329 gate-miss alias batch', () => {
+  const PAIRS: ReadonlyArray<readonly [string, string]> = [
+    ['ziemia obiacana', 'ziemia obiecana'],
+    ['bergqell', 'bergquell lobau'],
+    ['bracki zamkowy w cieszynie', 'arcyksiazecy zamkowy cieszyn'],
+    ['tank busters', 'tankbusters'],
+  ];
+  test.each(PAIRS)('resolves %s <-> %s symmetrically', (shop, untappd) => {
+    expect(aliasNeighbors(shop)).toContain(untappd);
+    expect(aliasNeighbors(untappd)).toContain(shop);
+  });
+  // Each new form is a 1:1 equivalence — no shared form, so no new alias hub.
+  test.each(PAIRS.flat())('form %s has exactly one neighbour (no new hub)', (form) => {
+    expect(aliasNeighbors(form)).toHaveLength(1);
+  });
+});

--- a/src/domain/brewery-aliases.ts
+++ b/src/domain/brewery-aliases.ts
@@ -37,6 +37,14 @@ const ALIAS_PAIRS: ReadonlyArray<readonly [string, string]> = [
   // shop (extension) sources:
   ['vibrant pour', 'vibrantpour'],
   ['drofa', 'дрофа'],
+  // #329 batch (2026-07-20): gate-miss aliases, each verified against the orphan's
+  // enrich_failures.candidates_summary (authoritative Untappd brewery) and the real
+  // matcher name stage (only rows whose name already matches post-alias — see the
+  // #329 design doc). Name-divergent misses were routed to #319, not aliased here.
+  ['ziemia obiacana', 'ziemia obiecana'],      // brewery typo OBIACANA->OBIECANA; 4 beers
+  ['bergqell', 'bergquell lobau'],             // Erdbeer (Porter style-stripped)
+  ['bracki zamkowy w cieszynie', 'arcyksiazecy zamkowy cieszyn'], // Cieszyn Pilsner
+  ['tank busters', 'tankbusters'],             // Paranormal Activity
 ];
 
 // normForm -> directly-paired forms. Built once at module load.

--- a/src/domain/matcher.test.ts
+++ b/src/domain/matcher.test.ts
@@ -92,8 +92,10 @@ describe('breweryAliases', () => {
 
   test('x-connector collab (lower case x) returns full + each side', () => {
     const out = breweryAliases('ZIEMIA OBIECANA x Weźże Krafta Brewery');
+    // The 'ziemia obiecana' side also expands one hop to its curated-alias
+    // partner 'ziemia obiacana' (the OBIACANA->OBIECANA typo pair, #329).
     expect(new Set(out)).toEqual(
-      new Set(['ziemia obiecana x wezze krafta', 'ziemia obiecana', 'wezze krafta']),
+      new Set(['ziemia obiecana x wezze krafta', 'ziemia obiecana', 'ziemia obiacana', 'wezze krafta']),
     );
   });
 
@@ -907,5 +909,40 @@ describe('makePreparedCatalog — add (#278)', () => {
     prepared.add(mk(5, 'Alpha / Beta', 'Shared Brew'));
     expect(prepared.candidatesByFirstToken('alpha').map((b) => b.id)).toEqual([5]);
     expect(prepared.candidatesByFirstToken('beta').map((b) => b.id)).toEqual([5]);
+  });
+});
+
+describe('#329 gate-miss alias batch — end to end', () => {
+  const passes = (shop: string, untappd: string) =>
+    breweryAliasesMatch(breweryAliases(shop), breweryAliases(untappd));
+
+  test('new pairs pass the brewery gate', () => {
+    expect(passes('ZIEMIA OBIACANA Brewery', 'Ziemia Obiecana')).toBe(true);
+    expect(passes('BERGQELL Brewery', 'Bergquell Brauerei Löbau')).toBe(true);
+    expect(passes('Bracki Browar Zamkowy w Cieszynie Brewery', 'Arcyksiążęcy Browar Zamkowy Cieszyn')).toBe(true);
+    expect(passes('Tank Busters Brewery', 'TankBusters.Co')).toBe(true);
+  });
+
+  // Catalog carries the authoritative Untappd brewery/name; input is the shop label.
+  const cat: CatalogBeer[] = [
+    c({ id: 101, brewery: 'Ziemia Obiecana', name: 'Bryła' }),
+    c({ id: 102, brewery: 'Ziemia Obiecana', name: 'Beach Hut' }),
+    c({ id: 103, brewery: 'Ziemia Obiecana', name: 'Padel Boys' }),
+    c({ id: 104, brewery: 'Ziemia Obiecana', name: 'Prole Juice' }),
+    c({ id: 105, brewery: 'Bergquell Brauerei Löbau', name: 'Erdbeer Porter' }),
+    c({ id: 106, brewery: 'Arcyksiążęcy Browar Zamkowy Cieszyn', name: 'Cieszyn Pilsner' }),
+    c({ id: 107, brewery: 'TankBusters.Co', name: 'Paranormal Activity' }),
+  ];
+
+  test.each([
+    ['ZIEMIA OBIACANA Brewery', 'BRYŁA', 101],
+    ['ZIEMIA OBIACANA Brewery', 'BEACH HUT', 102],
+    ['ZIEMIA OBIACANA Brewery', 'PADEL BOYS', 103],
+    ['ZIEMIA OBIACANA Brewery', 'Prole Juice', 104],
+    ['BERGQELL Brewery', 'Erdbeer', 105],
+    ['Bracki Browar Zamkowy w Cieszynie Brewery', 'CIESZYN PILSNER', 106],
+    ['Tank Busters Brewery', 'Paranormal Activity', 107],
+  ] as const)('%s / %s matches catalog id %i', (brewery, name, id) => {
+    expect(matchBeer({ brewery, name }, cat)).toEqual({ id, confidence: 1, source: 'exact' });
   });
 });


### PR DESCRIPTION
## What

Adds **4 curated brewery-alias pairs** (#329) so the enrichment brewery-gate accepts the already-present Untappd candidate for ~7 orphans:

| shop brewery | Untappd brewery | beers rescued |
|---|---|---|
| `ZIEMIA OBIACANA` | `Ziemia Obiecana` | Bryła, Beach Hut, Padel Boys, Prole Juice (typo `OBIACANA→OBIECANA`) |
| `BERGQELL` | `Bergquell Brauerei Löbau` | Erdbeer (Porter style-stripped) |
| `Bracki Browar Zamkowy w Cieszynie` | `Arcyksiążęcy Browar Zamkowy Cieszyn` | Cieszyn Pilsner |
| `Tank Busters` | `TankBusters.Co` | Paranormal Activity |

Pure data change to `ALIAS_PAIRS`, mirroring the #318 batch — no matcher logic touched.

## Why these four (and not the rest of #329)

Each row was verified against the **real** matcher name stage (`normalizeName`/`nameKeys`/`matchPrepared`): a brewery alias only rescues an orphan whose *name already matches post-alias*. These four do (exact / key-intersection). The name-divergent rows originally listed on #329 (subset / reorder / brewery-echo, incl. `Carlsberg/okocim` and the ciders) were **moved to #319** — an alias can't fix them. Two of them (`dzik`, `panipani`) were already aliased since #318 and still fail, confirming the split.

## Tests

- `brewery-aliases.test.ts`: `#329` block — pair symmetry + no-hub (non-transitivity) guard.
- `matcher.test.ts`: `#329` block — brewery-gate + end-to-end `matchBeer` regression for all 7 beers.
- Updated the pre-existing `ZIEMIA OBIECANA x Weźże Krafta` collab test: that brewery now correctly expands one hop to the `ziemia obiacana` typo partner.
- Full suite green (1266), `tsc --noEmit` clean.

## Rollout (after merge — not in this PR)

Server-side only (no `extension/**`, no schema/`spec.md` change). Deploy, then `rearm-matcher-bug-orphans --apply` so the backed-off orphans re-attempt against the new aliases.

Spec: `docs/superpowers/specs/2026-07/2026-07-20-brewery-alias-batch-329-design.md` · Plan: `docs/superpowers/plans/2026-07/2026-07-20-brewery-alias-batch-329.md`

Closes #329.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
