### PR TITLE
fix(matcher): #326 strip mid-dot ABV residue after degree spec

### DIFF
--- a/src/domain/normalize.test.ts
+++ b/src/domain/normalize.test.ts
@@ -287,6 +287,24 @@ describe('stripSearchNoise', () => {
   });
 });
 
+describe('degree/ABV mid-dot spec residue (#326)', () => {
+  // "<deg>°·<abv>" spec blocks: the "°" part was stripped but the "·<abv>"
+  // tail (mid-dot + ABV fragment) leaked into the search query, zeroing it.
+  test('strips a bare mid-dot ABV number with no % sign', () => {
+    expect(stripSearchNoise('Plum Plum Plum 12,5°·4')).toBe('Plum Plum Plum');
+  });
+  test('strips a mid-dot ABV percentage tail', () => {
+    expect(stripSearchNoise('Buzdygan Rozkoszy 24°·8,5%')).toBe('Buzdygan Rozkoszy');
+  });
+  test('strips a mid-dot <-prefixed ABV percentage tail', () => {
+    expect(stripSearchNoise('Freeky Mango Ale 7°·<0,5%')).toBe('Freeky Mango Ale');
+  });
+  test('cleanSearchQuery drops the residue instead of zeroing the query', () => {
+    expect(cleanSearchQuery('Inne Beczki', 'Plum Plum Plum 12,5°·4'))
+      .toBe('Inne Beczki Plum Plum Plum');
+  });
+});
+
 describe("'family' brewery noise (#309)", () => {
   test('family is dropped so X Family Brewery == X Brewery', () => {
     expect(normalizeBrewery('HOPPY HOG FAMILY BREWERY')).toBe('hoppy hog');

--- a/src/domain/normalize.ts
+++ b/src/domain/normalize.ts
@@ -142,8 +142,12 @@ export function stripSearchNoise(s: string): string {
       /^(?=[\p{L}\p{N}]*\d)[\p{L}\p{N}]+$/u.test(content) ? ` ${content} ` : ' ')
     // Keep compact digit-bearing identifiers such as (TAP04); drop (BBA), (collab …).
     .replace(/[[\](){}]/g, ' ')                      // stray/unbalanced brackets
+    // Degree/Plato spec, optionally followed by a mid-dot ABV tail: "24°",
+    // "12,5°·4", "24°·8,5%", "7°·<0,5%". The mid-dot (·/•/∙) fragment survived
+    // the bare "°" strip and leaked into the query, zeroing it (#326). Runs
+    // before the standalone "%" strip so the whole block is consumed at once.
+    .replace(/\d+(?:[.,]\d+)?\s*°(?:\s*[·•∙]\s*[<>]?\s*\d+(?:[.,]\d+)?\s*%?)?/gu, ' ')
     .replace(/[<>]?\s*\d+(?:[.,]\d+)?\s*%/g, ' ')    // <0,5%  4.5%  0,5 %
-    .replace(/\d+(?:[.,]\d+)?\s*°/g, ' ')            // 24°
     .replace(/\b(?:alc|abv|ibu)\b/gi, ' ')           // spec labels
     .replace(/["“”„]/g, ' ')                        // wrapping display/straight quotes
     .replace(/\s*[.!?,;:]+\s*$/, '')                  // trailing punctuation


### PR DESCRIPTION
Closes #326.

## Problem
Degree/Plato spec blocks of the form `<deg>°·<abv>` were only partially stripped from the Untappd search query. The `°` part was removed, but the mid-dot ABV tail survived and leaked into the Algolia query, which ANDs every term → zero candidates.

- `32760` Inne Beczki — `Plum Plum Plum 12,5°·4` → search query `Inne Beczki Plum Plum Plum ·4` (the `·4` fragment zeroed the match).

The failure is specific to an ABV tail with **no `%` sign** (`·4`): only the standalone `%` strip could catch a `·8,5%`/`·<0,5%` tail, and a bare `·N` slipped through.

## Fix
Extend the degree strip in `stripSearchNoise` to optionally consume a trailing mid-dot (`·`/`•`/`∙`) ABV fragment — with or without a `%` — and run it **before** the standalone `%` strip so the whole `<deg>°·<abv>` block is removed in one pass. Conservative: the mid-dot is only stripped when it directly follows a `<num>°` token, so decorative dots elsewhere in a name are untouched.

## Tests
Added `degree/ABV mid-dot spec residue (#326)` covering `12,5°·4`, `24°·8,5%`, `7°·<0,5%`, and the `cleanSearchQuery` end-to-end case. Full suite: 1294 passed, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)